### PR TITLE
docs: add workflow library stubs for key roles

### DIFF
--- a/SYSTEM_SPEC.md
+++ b/SYSTEM_SPEC.md
@@ -755,3 +755,18 @@ Event registration delegation (partner signups)
 
 These items may be added in future phases once the core public site and mail system are stable.
 
+----------------------------------------------------------------------
+
+## Workflow Library
+
+Role-specific workflow documentation for operational procedures:
+
+- [Event Chair Workflow](docs/workflows/EVENT_CHAIR.md) - Cancellations, waitlist substitution, finance handoff
+- [Finance Manager Workflow](docs/workflows/FINANCE_MANAGER.md) - Refund lifecycle, cancellation fees, reconciliation
+- [Membership Manager Workflow](docs/workflows/MEMBERSHIP_MANAGER.md) - Status changes, approvals, communications
+
+These workflows define the operational procedures that ClubOS must support. Each document specifies the role, preconditions, steps, inputs, outputs, audit requirements, and failure modes for key business processes.
+
+----------------------------------------------------------------------
+
+END OF SYSTEM SPEC

--- a/docs/workflows/EVENT_CHAIR.md
+++ b/docs/workflows/EVENT_CHAIR.md
@@ -1,0 +1,66 @@
+# Event Chair Workflow
+
+## Purpose
+
+Enable Event Chairs to manage event cancellations and waitlist substitutions with clear handoffs to Finance Manager for any refund processing.
+
+## Who uses this
+
+- Event Chairs
+- VPs of Activities
+- Category Chairs with event management responsibilities
+
+## Preconditions
+
+- User has Event Chair role or equivalent permissions
+- Event exists and has registrations
+- Cancellation request has been received from a registered member
+
+## Primary steps
+
+1. Receive and verify cancellation request from member
+2. Confirm member identity and registration status
+3. Execute cancellation (change registration status to CANCELLED)
+4. Check waitlist for eligible replacement
+5. If replacement exists, promote next waitlist member to REGISTERED
+6. Notify affected members (cancelled member and promoted member if applicable)
+7. If refund is needed, initiate refund request (handoff to Finance Manager)
+8. Record reason code and any notes
+
+## Inputs
+
+- Member cancellation request (verbal, email, or system)
+- Member identity verification
+- Event and registration details
+- Waitlist state
+
+## Outputs
+
+- Updated registration status (CANCELLED)
+- Waitlist promotion (if applicable)
+- Member notifications sent
+- Refund request created (if applicable, forwarded to Finance Manager)
+
+## Audit trail
+
+- Who requested the cancellation (member)
+- Who executed the cancellation (Event Chair)
+- Timestamp of cancellation
+- Replacement member ID (if any)
+- Timestamp of waitlist promotion
+- Reason code (voluntary, emergency, no-show, etc.)
+- Notes field for exceptional circumstances
+
+## Failure modes and guardrails
+
+- **Cancellation without notification**: System requires confirmation before status change
+- **Waitlist promotion skipped**: System auto-identifies next eligible member
+- **Refund executed by Event Chair**: System blocks direct refund; must go through Finance Manager
+- **Out-of-order waitlist promotion**: System enforces timestamp priority
+- **Household limit violation**: System checks compliance before promotion
+
+## Open questions
+
+- Should Event Chairs be able to batch-cancel multiple registrations?
+- Should there be a deadline after which Event Chairs cannot cancel without VP approval?
+- How should guest registrations (non-members) be handled differently?

--- a/docs/workflows/FINANCE_MANAGER.md
+++ b/docs/workflows/FINANCE_MANAGER.md
@@ -1,0 +1,74 @@
+# Finance Manager Workflow
+
+## Purpose
+
+Process refund requests through a controlled lifecycle, apply cancellation fee policies, and ensure all financial transactions are reconciled with QuickBooks as the system of record.
+
+## Who uses this
+
+- Finance Manager
+- Treasurer
+- Authorized financial approvers
+
+## Preconditions
+
+- User has Finance Manager role
+- Refund request exists (created by Event Chair or system)
+- Payment processor credentials are configured
+- QuickBooks integration is active
+
+## Primary steps
+
+1. Review incoming refund request (member, event, amount, reason)
+2. Check policy compliance (timing, replacement status, prior history)
+3. Approve or deny request with documented reason
+4. If approved, calculate final refund amount (apply cancellation fee if required)
+5. Execute refund through payment processor
+6. Wait for processor confirmation
+7. Record execution result in ClubOS
+8. Sync transaction to QuickBooks
+9. Verify reconciliation (processor, ClubOS, QuickBooks alignment)
+
+## Inputs
+
+- Refund request record (from Event Chair)
+- Member payment history
+- Event cancellation policy
+- Replacement status (from Event Chair workflow)
+
+## Outputs
+
+- Approved or denied refund decision
+- Executed refund transaction
+- Updated ClubOS financial record
+- QuickBooks journal entry
+- Reconciliation confirmation
+
+## Audit trail
+
+- Who requested (member or Event Chair)
+- Who approved (Finance Manager)
+- Who executed (Finance Manager or automated system)
+- Original amount requested
+- Final amount refunded
+- Fee amount retained
+- Timestamp for each state transition (Requested, Approved, Executed, Recorded, Synced)
+- Reason code
+- Processor transaction ID
+- QuickBooks reference ID
+
+## Failure modes and guardrails
+
+- **Ghost credits**: Refund recorded in ClubOS but not executed in processor or not synced to QuickBooks. Prevention: atomic transactions and daily reconciliation.
+- **Unauthorized refund**: Refund executed without Finance Manager approval. Prevention: role-based access control blocks Event Chair from direct execution.
+- **Fee policy bypass**: Cancellation fee not applied when required. Prevention: system enforces policy rules before approval can proceed.
+- **Reconciliation drift**: Processor and QuickBooks totals diverge. Prevention: daily automated comparison with alerts on discrepancy.
+- **Duplicate refund**: Same refund executed twice. Prevention: idempotency keys and state machine enforcement.
+
+QuickBooks is the system of record for all financial data. ClubOS tracks workflow context and approvals but does not replace QuickBooks as the accounting authority.
+
+## Open questions
+
+- What is the escalation path when reconciliation fails?
+- Should there be a refund amount threshold requiring additional approval?
+- How should credit card disputes interact with this workflow?

--- a/docs/workflows/MEMBERSHIP_MANAGER.md
+++ b/docs/workflows/MEMBERSHIP_MANAGER.md
@@ -1,0 +1,70 @@
+# Membership Manager Workflow
+
+## Purpose
+
+Manage membership status changes, approvals, and member communications while maintaining audit trails for changes that affect billing or eligibility.
+
+## Who uses this
+
+- Membership Manager
+- Membership Committee members
+- Board-designated membership approvers
+
+## Preconditions
+
+- User has Membership Manager role or equivalent permissions
+- Contact record exists for the member
+- Membership change request has been received or identified
+
+## Primary steps
+
+1. Receive membership status change request (application, renewal, lapse, reinstatement)
+2. Verify contact information and eligibility criteria
+3. Review supporting documentation if required
+4. Approve or deny the status change
+5. Update membership record with new status and effective dates
+6. Trigger appropriate member communications
+7. If billing impact, ensure Finance Manager is notified
+8. Record decision and rationale
+
+## Inputs
+
+- Membership application or change request
+- Contact profile data
+- Current membership status and history
+- Eligibility criteria (membership type requirements)
+- Supporting documentation (if applicable)
+
+## Outputs
+
+- Updated membership status (ACTIVE, LAPSED, ALUMNI, PROSPECT)
+- Updated membership level (NEWBIE, NEWCOMER, EXTENDED, BOARD, ALUMNI_LEVEL, OTHER)
+- Member notification sent (welcome, renewal confirmation, lapse notice)
+- Finance notification (if billing affected)
+- Audit record of change
+
+## Audit trail
+
+- Who requested the change (member or staff)
+- Who approved the change (Membership Manager)
+- Previous status and level
+- New status and level
+- Effective date of change
+- Reason code (new application, renewal, voluntary lapse, administrative, etc.)
+- Billing impact flag (yes/no)
+- Supporting document references
+
+## Failure modes and guardrails
+
+- **Eligibility bypass**: Membership granted without meeting criteria. Prevention: system validates eligibility rules before approval.
+- **Communication gap**: Member not notified of status change. Prevention: mandatory notification trigger on status transitions.
+- **Billing disconnect**: Membership status changed without finance awareness. Prevention: automatic notification to Finance Manager when billing-affecting changes occur.
+- **History loss**: Prior membership records overwritten. Prevention: append-only membership history (new rows, not updates).
+- **Unauthorized change**: Status modified by non-approved user. Prevention: role-based access control with Membership Manager permission required.
+
+## Open questions
+
+- What is the grace period for lapsed members before losing member benefits?
+- Should membership renewals be auto-approved or require manual review?
+- How should household membership status changes propagate to associated contacts?
+- What documentation is required for reinstatement after lapse?


### PR DESCRIPTION
## Summary

- Creates `docs/workflows/` folder with three role-specific workflow stub files
- Adds Workflow Library section with links in SYSTEM_SPEC.md
- Uses consistent template format across all three workflows

## Files changed

- `docs/workflows/EVENT_CHAIR.md` - Cancellations, waitlist substitution, finance handoff
- `docs/workflows/FINANCE_MANAGER.md` - Refund lifecycle, cancellation fees, reconciliation
- `docs/workflows/MEMBERSHIP_MANAGER.md` - Status changes, approvals, communications
- `SYSTEM_SPEC.md` - Added Workflow Library section with links

## Note

**docs/spec only; no runtime changes**

No functional code changes. Does not modify:
- `src/**`
- `tests/**`
- `eslint.config.*`
- `package.json`, lockfiles, CI config, or DB/schema files

🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nRelease classification: experimental\n