### PR TITLE
docs: specify partnerships delegation for registration payment cancellation

### DIFF
--- a/docs/rbac/AUTH_AND_RBAC.md
+++ b/docs/rbac/AUTH_AND_RBAC.md
@@ -137,6 +137,72 @@ ClubOS currently uses four global roles (defined in `src/lib/auth.ts`):
 
 ---
 
+## Delegation Layer: Partnerships
+
+Partnerships are object-level delegated permissions applied after authentication.
+They enable one member to act on behalf of another for specific actions without
+granting global role privileges.
+
+### How Partnerships Fit into Authorization
+
+```
+User Request: "Register my partner for this event"
+                    |
+                    v
+         +-------------------+
+         |   RBAC Check      |
+         |   Can user access |
+         |   registration?   |
+         +-------------------+
+                    |
+                    v
+         +-------------------+
+         |   Partnership     |
+         |   Delegation      |
+         |   Check           |
+         +-------------------+
+                    |
+        +-----------+-----------+
+        |                       |
+        v                       v
+    NO delegation           Delegation exists
+    (can only act           (can act for partner
+     for self)               based on mode)
+```
+
+### Key Principles
+
+- Delegation does not grant global privileges. A member with a partnership
+  cannot access admin features or see other members' data just because they
+  have delegation rights.
+
+- Delegation only expands who may act on behalf of whom for specific actions:
+  - Event registration
+  - Event cancellation
+  - Payment method selection
+
+- Delegation must be logged and visible in audit trails. Every action taken
+  under delegation records both the acting member and the affected member.
+
+### Suggested Capability Hooks
+
+For implementation, the following capabilities may be checked:
+
+- events.registration.create_on_behalf: Can register another member for events
+- events.registration.cancel_on_behalf: Can cancel another member's registration
+- finance.payment.use_partner_method: Can use partner's payment method
+
+These capabilities are granted by active Partnership or Delegation records,
+not by global roles.
+
+### Reference
+
+See SYSTEM_SPEC.md section "Partnerships: Register, Pay, and Cancel on Behalf
+of a Partner" for the full specification including delegation modes, audit
+requirements, and guardrails.
+
+---
+
 ## How RBAC Differs from Data Ownership
 
 This is an important distinction:

--- a/docs/workflows/EVENT_CHAIR_WORKFLOW.md
+++ b/docs/workflows/EVENT_CHAIR_WORKFLOW.md
@@ -1,0 +1,127 @@
+# Event Chair Workflow: Cancellations and Waitlist Substitution
+
+**Audience**: Event Chairs, VPs of Activities
+**Purpose**: Define the operational workflow for handling cancellations and waitlist substitutions
+
+---
+
+## Overview
+
+This workflow describes how Event Chairs handle member cancellations and waitlist
+substitutions. The goal is predictable, auditable operations with clear handoff
+to Finance Manager when refunds are involved.
+
+---
+
+## Cancellation Flow
+
+```
+Member or partner requests cancellation
+            |
+            v
+   +------------------+
+   | Event Chair      |
+   | confirms request |
+   +------------------+
+            |
+            v
+   +------------------+
+   | Cancel the       |
+   | registration     |
+   | (status change)  |
+   +------------------+
+            |
+            v
+   +------------------+
+   | Waitlist check:  |
+   | Is there a       |
+   | replacement?     |
+   +------------------+
+            |
+       +----+----+
+       |         |
+       v         v
+     YES        NO
+       |         |
+       v         |
+   +------------+|
+   | Promote    ||
+   | next from  ||
+   | waitlist   ||
+   +------------+|
+       |         |
+       v         v
+   +------------------+
+   | Notify affected  |
+   | members          |
+   +------------------+
+            |
+            v
+   +------------------+
+   | Refund needed?   |
+   | (handoff to FM)  |
+   +------------------+
+```
+
+---
+
+## Waitlist Substitution Rules
+
+When a spot opens up, the waitlist is processed in this order:
+
+1. Timestamp priority: Earliest waitlist entry first
+2. Same registration type: Match original capacity slot type if applicable
+3. Household rule: If event has per-household limits, check compliance
+
+The system identifies the next eligible waitlist member. The Event Chair
+confirms and triggers the promotion.
+
+---
+
+## Partnership Delegation Notes
+
+Cancellations and registrations may be initiated by a partner under partnership
+delegation. The following rules apply:
+
+- A partner with delegation rights may cancel a registration on behalf of their
+  partner. The system must verify the delegation is active before allowing the
+  action.
+
+- Waitlist substitution logic is independent of who initiated the cancellation.
+  The next eligible member is promoted regardless of whether the cancellation
+  was initiated by the registrant, their partner, or the Event Chair.
+
+- The audit trail must show the acting partner vs the affected registrant. Every
+  cancellation record must include:
+  - actingMemberId: Who clicked cancel
+  - affectedMemberId: Whose registration was cancelled
+  - timestamp
+  - eventId
+  - registrationId
+
+This distinction is critical for support requests and dispute resolution.
+
+---
+
+## Refund Handoff
+
+When a cancellation may require a refund:
+
+1. Event Chair (or member/partner) initiates the cancellation
+2. System creates a Pending Refund Request if applicable
+3. Finance Manager reviews eligibility and amount
+4. Finance Manager approves/denies and executes refund
+
+**Key rule**: Cancellation is not a refund. These are separate actions.
+
+---
+
+## Related Documents
+
+- [FINANCE_MANAGER_WORKFLOW.md](./FINANCE_MANAGER_WORKFLOW.md)
+- [AUTH_AND_RBAC.md](../rbac/AUTH_AND_RBAC.md) - Delegation Layer section
+- SYSTEM_SPEC.md - Partnerships section
+
+---
+
+*Document maintained by ClubOS development team. Last updated: December 2024*

--- a/docs/workflows/FINANCE_MANAGER_WORKFLOW.md
+++ b/docs/workflows/FINANCE_MANAGER_WORKFLOW.md
@@ -1,0 +1,126 @@
+# Finance Manager Workflow: Refunds, Fees, and Reconciliation
+
+**Audience**: Treasurer, Finance Manager, Tech Chair
+**Purpose**: Define the financial workflow for refunds, cancellation fees, and reconciliation
+
+---
+
+## Overview
+
+This workflow describes how the Finance Manager handles refunds, applies
+cancellation fees, and ensures proper reconciliation. The goal is to maintain
+accurate financial records and prevent inconsistencies between ClubOS and
+external accounting systems.
+
+---
+
+## Refund Lifecycle
+
+Every refund follows this lifecycle:
+
+```
++------------+     +------------+     +------------+
+| REQUESTED  | --> | APPROVED   | --> | EXECUTED   |
++------------+     +------------+     +------------+
+                                            |
+                                            v
+                   +------------+     +------------+
+                   |   SYNCED   | <-- | RECORDED   |
+                   +------------+     +------------+
+```
+
+### State Definitions
+
+| State | Description |
+|-------|-------------|
+| REQUESTED | Refund request created (by member, partner, or Event Chair) |
+| APPROVED | Finance Manager reviewed and authorized |
+| EXECUTED | Payment processor has processed the refund |
+| RECORDED | ClubOS internal records updated |
+| SYNCED | Transaction synced to external accounting system |
+
+A refund is not complete until it reaches SYNCED state.
+
+---
+
+## Partnership Delegation Notes
+
+Refund eligibility and approval is independent from who clicked cancel. The
+Finance Manager must evaluate the refund based on policy, not on whether the
+cancellation was initiated by the registrant or their partner.
+
+### Required Visibility
+
+When reviewing a refund request, the Finance Manager must see:
+
+- Acting member: Who initiated the cancellation
+- Payer identity: Who paid for the original registration (may be registrant
+  or their partner)
+- Registrant identity: Whose registration was cancelled
+- Payment method used: Which card or payment method was charged
+
+This three-way distinction (actor, payer, registrant) is critical when
+partnerships are involved.
+
+### Refund Destination Rules
+
+1. Default: Refund returns to the original payment method used for the
+   transaction, even if a partner paid on behalf of the registrant.
+
+2. Exceptions: Refunding to a different payment method requires:
+   - Finance Manager approval
+   - Logged reason code
+   - Documentation in the refund record
+
+3. No ghost credits: The refund amount must be recorded consistently in
+   ClubOS and synced to external accounting. Internal credits without
+   corresponding accounting entries are prohibited.
+
+### Reconciliation Requirements
+
+Daily reconciliation must compare:
+
+- Processor refund totals
+- ClubOS refund records
+- External accounting entries
+
+Any discrepancy triggers Finance Manager review before additional refunds
+can be processed.
+
+---
+
+## Cancellation Fee Policy
+
+| Scenario | Policy Example |
+|----------|----------------|
+| Cancel > 7 days before | Full refund |
+| Cancel 3-7 days before | 75% refund, 25% fee |
+| Cancel < 3 days before | 50% refund, 50% fee |
+| No-show | No refund |
+
+Finance Manager may override policy in documented exceptional cases.
+
+---
+
+## Key Guardrails
+
+1. Cancellation is not a refund. A cancelled registration may or may not
+   result in a refund depending on policy and Finance Manager approval.
+
+2. Separation of duties. Event Chairs and members can initiate cancellations,
+   but only the Finance Manager can approve and execute refunds.
+
+3. Audit everything. Every refund request, approval, and execution must be
+   logged with timestamps, actor IDs, and reason codes.
+
+---
+
+## Related Documents
+
+- [EVENT_CHAIR_WORKFLOW.md](./EVENT_CHAIR_WORKFLOW.md)
+- [AUTH_AND_RBAC.md](../rbac/AUTH_AND_RBAC.md) - Delegation Layer section
+- SYSTEM_SPEC.md - Partnerships section
+
+---
+
+*Document maintained by ClubOS development team. Last updated: December 2024*


### PR DESCRIPTION
## Summary

- Adds **Partnerships** as a first-class concept enabling one member to act on behalf of another
- Defines **four delegation modes**: None, Mutual, Primary-only, Independent
- Specifies **three delegated actions**: register on behalf, cancel on behalf, pay using partner method
- Adds **audit requirements** distinguishing actor vs payer vs registrant
- Integrates with **Event Chair** and **Finance Manager** workflows
- Preserves **"cancellation is not a refund"** separation of duties

## Files Changed

**Modified files:**
- `SYSTEM_SPEC.md` - Full Partnerships specification (replaces earlier delegation sketch)
- `docs/rbac/AUTH_AND_RBAC.md` - New "Delegation Layer: Partnerships" section

**New files:**
- `docs/workflows/EVENT_CHAIR_WORKFLOW.md` - Cancellation workflow with partnership notes
- `docs/workflows/FINANCE_MANAGER_WORKFLOW.md` - Refund workflow with partnership-aware requirements

## Key Design Decisions

1. **Partnership delegation does not grant global privileges** - Only expands who can act for whom
2. **Cancellation is not a refund** - Separation of duties preserved regardless of who initiated
3. **Three-way audit trail** - Acting member, payer identity, and registrant identity all logged
4. **Refund returns to original payment method** - Even if partner paid; exceptions require FM approval
5. **Split tender is future** - Single payment method per transaction for now

## Capability Hooks (for implementation)

- `events.registration.create_on_behalf`
- `events.registration.cancel_on_behalf`
- `finance.payment.use_partner_method`

## Explicit Note

**This PR contains docs/spec changes only. No runtime code changes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nRelease classification: experimental\n