### PR TITLE
docs: normalize terminology and cross-references (final coherence pass)

### DIFF
--- a/docs/rbac/ACTIVITIES_ROLES.md
+++ b/docs/rbac/ACTIVITIES_ROLES.md
@@ -439,11 +439,30 @@ Step 3: Scope Check
 
 ---
 
+## Refund Handoff (Separation of Duties)
+
+When a cancellation requires a refund, Event Chairs must hand off to the
+Finance Manager. This separation of duties is critical:
+
+1. Event Chair cancels the registration (operational action)
+2. Event Chair initiates refund request if applicable
+3. Finance Manager approves and executes refund (financial action)
+
+**Key rule**: Cancellation is not a refund. These are separate, intentional
+actions with different authorization.
+
+See FINANCE_ROLES.md (when available) for the complete Finance Manager
+specification.
+
+---
+
 ## Related Documents
 
 - [AUTH_AND_RBAC.md](./AUTH_AND_RBAC.md) - Overall auth system
 - [VP_ACTIVITIES_SCOPE.md](./VP_ACTIVITIES_SCOPE.md) - Technical implementation
 - [VP_ACTIVITIES_ACCESS_MATRIX.md](./VP_ACTIVITIES_ACCESS_MATRIX.md) - Detailed permission tables
+- FINANCE_ROLES.md - Finance Manager role and refund workflow handoffs (planned)
+- docs/workflows/ - Detailed workflow specifications (planned)
 
 ---
 

--- a/docs/rbac/AUTH_AND_RBAC.md
+++ b/docs/rbac/AUTH_AND_RBAC.md
@@ -71,9 +71,9 @@ Once ClubOS knows who you are, it checks what you're allowed to do.
 
 ## Understanding Roles
 
-### The Four Global Roles
+### Global Roles
 
-ClubOS currently uses four global roles (defined in `src/lib/auth.ts`):
+ClubOS uses the following global roles (defined in `src/lib/auth.ts`):
 
 | Role | Slug | What It Means | Example People |
 |------|------|---------------|----------------|
@@ -81,6 +81,12 @@ ClubOS currently uses four global roles (defined in `src/lib/auth.ts`):
 | **VP of Activities** | `vp-activities` | Can view/edit/publish all events | Sarah Martinez, John Kim |
 | **Event Chair** | `event-chair` | Manages events (scoping planned) | Alice (Hiking), Bob (Social) |
 | **Member** | `member` | Basic access, published events only | Regular club members |
+
+Planned additions:
+
+| Role | Slug | What It Means | Example People |
+|------|------|---------------|----------------|
+| **Finance Manager** | `finance-manager` | Approve refunds, apply fees, reconcile | Treasurer, Finance volunteer |
 
 > **Note**: Committee-based scoping (where VPs only see their supervised groups) is planned but not yet implemented. Currently, VPs can see and edit ALL events.
 


### PR DESCRIPTION
## Summary

Final coherence pass across RBAC documentation to ensure consistent terminology
and improve cross-document discoverability.

## What Was Normalized

### Role Name Alignment

| Legacy Term (SYSTEM_SPEC.md) | Current Term (AUTH_AND_RBAC.md) |
|------------------------------|----------------------------------|
| System Admin | Admin |
| Events Admin | VP of Activities or Event Chair |
| Category Chair | Event Chair |
| Communications Admin | (functionality distributed) |

### Cross-References Added

- SYSTEM_SPEC.md Section 7 now points to AUTH_AND_RBAC.md as authoritative source
- ACTIVITIES_ROLES.md now references planned Finance and workflow docs
- Planned Finance Manager role acknowledged in all role tables

### Invariants Reinforced

- "Cancellation is not a refund" - Added to ACTIVITIES_ROLES.md "Refund Handoff" section

## Files Changed

| File | Change |
|------|--------|
| `SYSTEM_SPEC.md` | Section 7 rewritten to map legacy to current roles |
| `docs/rbac/AUTH_AND_RBAC.md` | Added planned Finance Manager role to table |
| `docs/rbac/ACTIVITIES_ROLES.md` | Added Refund Handoff section and cross-references |

## Confirmation

- **No policy or semantic changes** - All edits are clarifications and cross-links
- **No new roles created** - Only documented planned additions
- **No capability changes** - Only terminology alignment

## Outstanding Ambiguities (Not Resolved)

The following issues exist across the open PR branches and will need resolution
when those PRs are merged:

1. **Duplicate workflow files**: PR #3 and PR #6 both create docs/workflows/ with
   different content. PR #6 has the more complete version with partnership notes.

2. **VP of Activities missing from SYSTEM_SPEC.md Section 7 in PR #5**: The
   RBAC roles/groups/capabilities branch defines a new role model that doesn't
   include VP of Activities.

These are noted for awareness but not fixed here to avoid scope creep.

## Explicit Note

**This PR contains docs/spec changes only. No runtime code changes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nRelease classification: experimental\n