### PR TITLE
docs: clarify RBAC scope delegation and agreement gates

### DIFF
--- a/SYSTEM_SPEC.md
+++ b/SYSTEM_SPEC.md
@@ -202,6 +202,13 @@ Each role grants explicit rights to:
 - Access analytics
 - Access system settings
 
+7.4 Detailed RBAC Documentation
+See docs/rbac/AUTH_AND_RBAC.md for:
+- Evaluation order (Auth -> Roles -> Scope -> Delegation -> Hard Gates)
+- Scope rules for committee-scoped Event Chair access
+- Delegation layer (Partnerships) rules and bilateral consent
+- Hard gates (Membership Agreement, Media Rights, Guest Release)
+
 ----------------------------------------------------------------------
 
 8. Notifications Framework


### PR DESCRIPTION
## Summary

Add missing RBAC requirements surfaced by persona fit assessment and
partnership delegation model.

## Added Sections (docs/rbac/AUTH_AND_RBAC.md)

### Evaluation Order
Clarifies the processing sequence:
1. Authenticate user
2. Resolve roles and capabilities
3. Apply scope rules (committee/event assignment)
4. Apply delegation layer (Partnerships)
5. Apply hard gates (agreements/releases)

### Scope Rules: Committee-Scoped Event Chair Access
Defines when Event Chair capabilities apply:
- User is assigned as chair/co-chair for the event, OR
- Event's committee_id matches user's committee memberships
- If neither is true, actions are denied even if role is present

### Delegation Layer: Partnerships
Clarifies partnership delegation rules:
- Does not grant global privileges
- Requires explicit bilateral consent
- Revocable by either partner
- Cannot override agreement gates

### Hard Gates: Agreements and Releases
Non-negotiable gates that apply regardless of role/scope/delegation:
- Membership Agreement (required version) for any registration
- Media Rights Agreement (required version) for media-covered events
- Guest Release (guest-signed) for events requiring it
- **Guest release is non-delegable** (guest must accept directly)

## Updated Files

| File | Change |
|------|--------|
| `docs/rbac/AUTH_AND_RBAC.md` | Added 4 new sections (77 lines) |
| `SYSTEM_SPEC.md` | Added Section 7.4 reference to RBAC docs (7 lines) |

## Confirmation

- **Docs/spec only** - No runtime code changes
- **ASCII only** - No smart quotes or Unicode dashes
- **Minimal edits** - Only clarifying rules, no new concepts beyond work order scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nRelease classification: experimental\n