### PR TITLE
docs: add event policy gates (venue, guests, drop-ins, insurance)

### DIFF
--- a/SYSTEM_SPEC.md
+++ b/SYSTEM_SPEC.md
@@ -755,3 +755,65 @@ Event registration delegation (partner signups)
 
 These items may be added in future phases once the core public site and mail system are stable.
 
+----------------------------------------------------------------------
+
+## Event Policy Gates
+
+Event Policy Gates are system-enforced rules that prevent invalid events or invalid
+attendance scenarios. These gates must be checked before an event can be published
+or before a registration can be accepted.
+
+For detailed examples and implementation notes, see docs/policies/EVENT_POLICY_GATES.md.
+
+### Venue Type Gate
+
+- venue_type: PRIVATE_HOME | PUBLIC_VENUE
+- Events at PRIVATE_HOME require House Registrar approval before publishing
+- System must block publishing until approval is recorded
+- Approval includes: liability acknowledgment, capacity confirmation, parking notes
+
+### Non-Member Policy Gate
+
+Private home events:
+- Alumni and guests are NOT permitted (insurance restriction)
+- System must block non-member registrations for private_home events
+
+Public venue events:
+- Alumni and guests are permitted ONLY if the event explicitly enables them
+- Member priority window: non-members may register only after a configured delay
+  (e.g., members-only for first 48 hours)
+- Non-member fee must be >= member fee (system must enforce)
+
+### Registration Required Gate
+
+- If registration_required = true:
+  - Drop-ins are not permitted
+  - Check-in process must verify registration status
+  - Walk-ups must be turned away or registered on-site if capacity allows
+- If registration_required = false:
+  - Event is open; no registration tracking required
+
+### Host and Hostess Rules
+
+- Event may designate host(s) with special privileges
+- Host registration is automatic and does not count against capacity
+- Host may have a limited number of personal guest slots (configured per event)
+- Host guests must still comply with venue type rules (no guests at private homes)
+
+### Special Event Types
+
+Boating events:
+- venue_type = boating requires pre-review with VP Activities before publishing
+- Insurance and liability documentation must be attached to event record
+- System should flag boating events for manual review
+
+### Alcohol Policy Gate
+
+- Events serving alcohol must:
+  - Display alcohol policy acknowledgment to registrants
+  - Designate a responsible party role (not necessarily bartender)
+  - Track that the responsible party assignment was made
+- System should prevent publishing alcohol events without responsible party assigned
+
+----------------------------------------------------------------------
+

--- a/docs/policies/EVENT_POLICY_GATES.md
+++ b/docs/policies/EVENT_POLICY_GATES.md
@@ -1,0 +1,252 @@
+# Event Policy Gates
+
+**Purpose**: Define system-enforced rules that prevent invalid events or attendance scenarios
+**Audience**: Event Chairs, VPs of Activities, Tech Chair
+
+---
+
+## Overview
+
+Policy gates are validation rules that ClubOS enforces before an event can be published
+or before a registration can be accepted. These rules derive from club insurance
+requirements, operational policies, and governance decisions.
+
+Gates are checked at two points:
+1. Event publishing (can this event go live?)
+2. Registration acceptance (can this person register?)
+
+---
+
+## Gate 1: Venue Type
+
+### Rule
+
+Every event must specify a venue_type:
+- PRIVATE_HOME
+- PUBLIC_VENUE
+- BOATING (special case; see Gate 5)
+
+### Enforcement
+
+**PRIVATE_HOME events**:
+- Require House Registrar approval before publishing
+- Approval record must include:
+  - Homeowner liability acknowledgment
+  - Maximum capacity
+  - Parking instructions (if applicable)
+- System blocks "Publish" action until approval is attached
+
+**PUBLIC_VENUE events**:
+- No special approval required
+- Venue contract or reservation confirmation recommended but not gated
+
+### Example
+
+```
+Event: "Wine Tasting at the Smiths"
+venue_type: PRIVATE_HOME
+house_registrar_approved: false
+--> PUBLISH BLOCKED: "Requires House Registrar approval"
+
+Event: "Lunch at Eladio's"
+venue_type: PUBLIC_VENUE
+--> PUBLISH ALLOWED
+```
+
+---
+
+## Gate 2: Non-Member Policy
+
+### Rule
+
+Non-members (alumni, guests, prospects) have restricted access based on venue type.
+
+### Enforcement
+
+**PRIVATE_HOME events**:
+- Non-members are NOT permitted (insurance restriction)
+- System must reject registration attempts from non-member contacts
+- Error: "This event is for active members only (private venue insurance policy)"
+
+**PUBLIC_VENUE events**:
+- Non-members permitted ONLY if event.allow_nonmembers = true
+- Member priority window: if event.member_priority_hours > 0, non-members
+  cannot register until that window expires
+- Non-member fee >= member fee (system enforces; cannot save event otherwise)
+
+### Example
+
+```
+Event: "Garden Party" (PRIVATE_HOME)
+Registrant: Alumni member
+--> REGISTRATION BLOCKED: "Private home events are for active members only"
+
+Event: "Museum Tour" (PUBLIC_VENUE, allow_nonmembers=true, member_priority_hours=48)
+Registrant: Guest (attempting at hour 24)
+--> REGISTRATION BLOCKED: "Registration opens for non-members in 24 hours"
+
+Registrant: Guest (attempting at hour 50)
+--> REGISTRATION ALLOWED
+```
+
+---
+
+## Gate 3: Registration Required
+
+### Rule
+
+Events may require advance registration (registration_required = true) or allow drop-ins.
+
+### Enforcement
+
+**registration_required = true**:
+- Drop-ins are not permitted
+- Check-in system must verify registration before admitting attendee
+- Walk-ups can be registered on-site ONLY if capacity allows
+- Event chair must be able to add late registrations
+
+**registration_required = false**:
+- No registration tracking; attendance is open
+- Headcount may still be tracked for planning purposes
+
+### Example
+
+```
+Event: "Hiking Trip" (registration_required=true, capacity=20, registered=20)
+Walk-up arrives at trailhead
+--> CHECK-IN BLOCKED: "Not on registration list; event at capacity"
+
+Event: "Coffee Chat" (registration_required=false)
+Walk-up arrives
+--> ALLOWED (no gate)
+```
+
+---
+
+## Gate 4: Host and Hostess Rules
+
+### Rule
+
+Events may designate one or more hosts with special privileges.
+
+### Enforcement
+
+- Host registration is automatic; does not consume a capacity slot
+- Host may bring personal guests up to event.host_guest_limit (default: 0)
+- Host guests still subject to venue type rules:
+  - At PRIVATE_HOME: host guests NOT allowed (insurance)
+  - At PUBLIC_VENUE: host guests allowed if event.allow_nonmembers = true
+- Host is responsible for their guests' conduct and fees
+
+### Example
+
+```
+Event: "Potluck Dinner" (PRIVATE_HOME, host=Jane Doe, host_guest_limit=2)
+Jane attempts to register 1 guest
+--> BLOCKED: "Guests not permitted at private home events"
+
+Event: "Restaurant Night" (PUBLIC_VENUE, host=Jane Doe, host_guest_limit=2)
+Jane registers with 2 guests
+--> ALLOWED
+```
+
+---
+
+## Gate 5: Special Event Types (Boating)
+
+### Rule
+
+Boating events carry elevated insurance and liability requirements.
+
+### Enforcement
+
+- Events with venue_type = BOATING require VP Activities pre-review
+- Insurance documentation must be attached before publishing
+- System flags boating events for manual review queue
+- Cannot publish without vp_activities_approved = true
+
+### Example
+
+```
+Event: "Sailing Day on the Harbor"
+venue_type: BOATING
+vp_activities_approved: false
+--> PUBLISH BLOCKED: "Boating events require VP Activities approval"
+```
+
+---
+
+## Gate 6: Alcohol Policy
+
+### Rule
+
+Events serving alcohol must comply with club alcohol policy.
+
+### Enforcement
+
+- If event.serves_alcohol = true:
+  - Must designate a responsible_party_contact_id
+  - Registrants must acknowledge alcohol policy (checkbox or equivalent)
+  - System blocks publishing if responsible_party not assigned
+- Responsible party is accountable for compliance; specific tactics (bartender,
+  wristbands, etc.) are operational decisions not enforced by system
+
+### Example
+
+```
+Event: "Wine Tasting Evening"
+serves_alcohol: true
+responsible_party_contact_id: null
+--> PUBLISH BLOCKED: "Alcohol events require a designated responsible party"
+
+serves_alcohol: true
+responsible_party_contact_id: 12345 (John Smith)
+--> PUBLISH ALLOWED
+```
+
+---
+
+## Event Chair Checklist: Policy Gates to Confirm Before Posting
+
+Before requesting event publication, verify:
+
+- [ ] Venue type selected (PRIVATE_HOME, PUBLIC_VENUE, or BOATING)
+- [ ] If PRIVATE_HOME: House Registrar approval attached
+- [ ] If BOATING: VP Activities approval attached
+- [ ] Non-member policy configured correctly for venue type
+- [ ] Member priority window set (if allowing non-members)
+- [ ] Non-member fee >= member fee (if applicable)
+- [ ] Registration required setting matches event intent
+- [ ] Host(s) designated if applicable
+- [ ] If serving alcohol: responsible party assigned
+- [ ] Capacity set appropriately for venue
+
+---
+
+## Policy Clarifications Needed
+
+The following items require clarification from club leadership:
+
+1. **Host guest count at public venues**: Chair Guidelines mention host may have
+   "a guest or two" but exact limit is not specified. TBD: Default host_guest_limit?
+
+2. **Member priority window duration**: No standard duration specified. TBD: Should
+   default be 24h, 48h, or configurable per event?
+
+3. **Vaccination policy (legacy)**: 2021 Chair Guidelines reference vaccination
+   requirements. Legacy reference; not enforced in current system unless policy
+   is reaffirmed by board.
+
+4. **Budget threshold for VP review**: Some events may require VP review based on
+   budget amount, not just venue type. TBD: Is there a dollar threshold?
+
+---
+
+## Related Documents
+
+- SYSTEM_SPEC.md - Event Policy Gates section
+- docs/rbac/AUTH_AND_RBAC.md - Role permissions for event publishing
+
+---
+
+*Document maintained by ClubOS development team. Last updated: December 2024*

--- a/docs/workflows/EVENT_CHAIR_WORKFLOW.md
+++ b/docs/workflows/EVENT_CHAIR_WORKFLOW.md
@@ -1,0 +1,94 @@
+# Event Chair Workflow
+
+**Audience**: Event Chairs, VPs of Activities
+**Purpose**: Define operational workflows for Event Chairs
+
+---
+
+## Overview
+
+This document describes the key workflows Event Chairs follow when creating,
+managing, and closing events in ClubOS.
+
+---
+
+## Event Creation Workflow
+
+1. Create event draft with required fields
+2. Configure registration settings (capacity, fees, deadlines)
+3. Review and confirm policy gates (see checklist below)
+4. Request publication from VP of Activities
+5. VP reviews and publishes (or requests changes)
+
+---
+
+## Policy Gates to Confirm Before Posting
+
+Before requesting event publication, verify each gate:
+
+### Venue Gate
+- [ ] Venue type selected: PRIVATE_HOME, PUBLIC_VENUE, or BOATING
+- [ ] If PRIVATE_HOME: House Registrar approval attached
+- [ ] If BOATING: VP Activities approval attached and insurance documented
+
+### Non-Member Gate
+- [ ] Non-member policy configured correctly for venue type
+- [ ] If PRIVATE_HOME: Confirm no non-members can register
+- [ ] If PUBLIC_VENUE with non-members: Member priority window set
+- [ ] Non-member fee >= member fee (if applicable)
+
+### Registration Gate
+- [ ] Registration required setting matches event intent
+- [ ] Capacity set appropriately for venue
+
+### Host Gate
+- [ ] Host(s) designated if applicable
+- [ ] Host guest limits configured (remember: no guests at private homes)
+
+### Alcohol Gate
+- [ ] If serving alcohol: responsible party assigned
+- [ ] Alcohol policy acknowledgment enabled for registrants
+
+For detailed gate definitions and examples, see:
+[EVENT_POLICY_GATES.md](../policies/EVENT_POLICY_GATES.md)
+
+---
+
+## Cancellation and Substitution Workflow
+
+When handling cancellations:
+
+1. Receive cancellation request from member (or partner acting on their behalf)
+2. Confirm request and execute cancellation in system
+3. Check waitlist for eligible replacement
+4. If replacement found: promote and notify
+5. If refund needed: initiate refund request (handoff to Finance Manager)
+
+Key rules:
+- Cancellation is not a refund (separate actions)
+- Waitlist priority: earliest timestamp first
+- Audit trail must record who acted and who was affected
+
+---
+
+## Refund Handoff
+
+When a cancellation requires a refund:
+
+1. Event Chair initiates refund request in system
+2. System creates Pending Refund Request
+3. Finance Manager reviews eligibility and policy
+4. Finance Manager approves/denies and executes
+
+Event Chair does NOT execute refunds directly.
+
+---
+
+## Related Documents
+
+- [EVENT_POLICY_GATES.md](../policies/EVENT_POLICY_GATES.md) - Detailed policy gate definitions
+- [AUTH_AND_RBAC.md](../rbac/AUTH_AND_RBAC.md) - Role permissions
+
+---
+
+*Document maintained by ClubOS development team. Last updated: December 2024*


### PR DESCRIPTION
## Summary

Adds system-enforced policy gates for events to prevent invalid events and attendance scenarios.

## Gates Added

- **Venue Type Gate**: PRIVATE_HOME requires House Registrar approval; PUBLIC_VENUE has no special gate
- **Non-Member Policy Gate**: No alumni/guests at private homes (insurance); public venues require explicit opt-in and member priority window
- **Registration Required Gate**: If enabled, no drop-ins; check-in must verify registration
- **Host/Hostess Rules**: Automatic registration, configurable guest limits, venue compliance
- **Special Event Types**: Boating events require VP Activities pre-review
- **Alcohol Policy Gate**: Must designate responsible party before publishing

## Files Changed

- `SYSTEM_SPEC.md` - Added Event Policy Gates section with link to detailed doc
- `docs/policies/EVENT_POLICY_GATES.md` - Detailed gate definitions with examples
- `docs/workflows/EVENT_CHAIR_WORKFLOW.md` - Added policy gates checklist for Event Chairs

## TBD Clarifications

- Host guest count default (guidelines say "a guest or two")
- Member priority window default duration (24h, 48h, or configurable?)
- Vaccination policy status (2021 reference marked as legacy)
- Budget threshold for VP review (if any)

## Note

**docs/spec only; no runtime changes**

🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nRelease classification: experimental\n