### PR TITLE
docs: define agreement tracking and eligibility gates

### DIFF
--- a/SYSTEM_SPEC.md
+++ b/SYSTEM_SPEC.md
@@ -268,6 +268,72 @@ Placeholder modules for future expansion:
 
 ----------------------------------------------------------------------
 
+12. Agreement-Based Eligibility Gates
+
+Certain actions require signed agreements regardless of role, scope, or delegation
+status. These gates are checked after all other authorization checks and cannot be
+bypassed.
+
+For the canonical agreement type definitions, versioning rules, and data model,
+see docs/agreements/AGREEMENTS_AND_CONSENT_MODEL.md.
+
+12.1 Gate Types
+
+Membership Agreement
+- Required for: Any event registration (self, partner, or admin-assisted)
+- Version requirement: Current version (effectiveDate <= now AND not deprecated)
+- If missing or outdated: Block registration with clear error message
+
+Media Rights Agreement
+- Required for: Registration to events flagged as media-covered (requiresMediaRights = true)
+- Version requirement: Current version
+- If missing or outdated: Block registration with clear error message
+- Note: Members who opt out of media rights cannot register for media-covered events
+
+Guest Release
+- Required for: Guest registration at events requiring guest release
+- Non-delegable: A member cannot accept this on behalf of a guest
+- The guest must accept directly (in-person or via guest registration flow)
+- If missing: Block guest registration
+
+Partnership Delegation Consent
+- Required for: One member to register on behalf of another (partner flows)
+- Bilateral: Both partners must have signed the current partnership consent
+- If either consent is missing or revoked: Delegation is inactive
+- Effect: Partner registration buttons/actions are disabled until both consent
+
+12.2 Gate Evaluation Order
+
+Agreement gates are evaluated AFTER all other authorization checks:
+
+1. Authenticate user (401 if failed)
+2. Resolve roles and capabilities
+3. Apply scope rules (committee assignment)
+4. Apply delegation layer (if acting on behalf)
+5. Apply agreement gates (this section)
+
+A user may pass steps 1-4 but still be blocked at step 5 if an agreement is
+missing, outdated, or revoked.
+
+12.3 Applicability
+
+These gates apply uniformly to:
+- Self actions (member registering themselves)
+- Partner on-behalf actions (partner registering for member via delegation)
+- Admin-assisted actions (admin registering a member)
+
+Admin role does not exempt a registrant from agreement requirements. An admin
+registering a member must ensure the member has the required agreements on file.
+
+12.4 Error Response
+
+When an agreement gate blocks an action, the response must include:
+- Which agreement is missing or outdated
+- What version is required
+- How to obtain or update the agreement
+
+----------------------------------------------------------------------
+
 END OF SYSTEM SPEC
 
 --------------------------------------------------

--- a/docs/agreements/AGREEMENTS_AND_CONSENT_MODEL.md
+++ b/docs/agreements/AGREEMENTS_AND_CONSENT_MODEL.md
@@ -1,0 +1,256 @@
+# Agreements and Consent Model
+
+**Audience**: Tech Chair, Board, Administrators
+**Purpose**: Define how ClubOS tracks member and guest agreements, consents, and releases
+
+---
+
+## Overview
+
+ClubOS requires certain agreements and releases before members or guests can take specific actions. This document is the canonical reference for agreement types, versioning, acceptance tracking, revocation rules, and audit requirements.
+
+Other documents (SYSTEM_SPEC.md, AUTH_AND_RBAC.md, workflow docs) reference this document rather than duplicating these definitions.
+
+---
+
+## Agreement Types
+
+ClubOS tracks the following agreement types:
+
+| Type | Slug | Who Signs | Purpose |
+|------|------|-----------|---------|
+| Membership Agreement | `membership_agreement` | Member | Required for any event registration |
+| Media Rights Agreement | `media_rights` | Member | Required for events with photography or video |
+| Partnership Delegation Consent | `partnership_consent` | Both partners | Enables one partner to act on behalf of another |
+| Guest Release | `guest_release` | Guest (non-delegable) | Required for events that allow guests |
+
+### Membership Agreement
+
+The Membership Agreement captures the member's acceptance of club rules, liability waivers, and code of conduct. Every active member must have accepted the current version.
+
+- **Gate**: No event registration (self, partner, or admin-assisted) without current version accepted
+- **Triggered by**: Initial membership signup, annual renewal, or version change
+- **Version tracking**: Required
+
+### Media Rights Agreement
+
+The Media Rights Agreement authorizes the club to use photos and videos that include the member.
+
+- **Gate**: No registration for events flagged as media-covered without current version accepted
+- **Triggered by**: First media-covered event registration, or version change
+- **Version tracking**: Required
+- **Note**: Members may opt out of media rights; opting out blocks registration for media-covered events
+
+### Partnership Delegation Consent
+
+Partnership delegation allows one member to register or cancel on behalf of another (typically a spouse or partner). Both parties must explicitly consent.
+
+- **Gate**: Delegation is inactive until both partners have signed
+- **Triggered by**: Either partner initiating a partnership request
+- **Revocation**: Either partner may revoke at any time; effective immediately
+- **Bilateral**: Both grantorContactId and delegateContactId must have signed
+
+### Guest Release
+
+For events that allow guests, the guest must sign a release accepting liability and club rules.
+
+- **Gate**: No guest registration without guest-signed release
+- **Non-delegable**: A member cannot accept this on behalf of a guest
+- **Scope**: Per-event or per-event-type depending on policy
+- **Version tracking**: Required
+
+---
+
+## Versioning Requirements
+
+All agreement types MUST be versioned to support:
+
+- Tracking which version a member accepted
+- Requiring re-acceptance when agreement text changes
+- Audit trail showing what the member agreed to
+
+### Version Record Fields
+
+Each agreement version includes:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id | UUID | Unique identifier for this version |
+| agreementType | enum | One of: membership_agreement, media_rights, partnership_consent, guest_release |
+| versionId | string | Human-readable version (e.g., "2024-01", "v2.1") |
+| contentHash | string | SHA-256 hash of agreement text for tamper detection |
+| effectiveDate | datetime | When this version becomes active |
+| deprecatedDate | datetime (nullable) | When this version was replaced (null if current) |
+| createdAt | datetime | Record creation timestamp |
+
+### Current Version Rule
+
+For gating purposes, "current version" means:
+
+- The version where effectiveDate <= now AND deprecatedDate IS NULL
+- If no current version exists, the gate cannot be passed (system configuration error)
+
+---
+
+## Acceptance Record Fields
+
+When a member or guest accepts an agreement, the system records:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id | UUID | Unique identifier for this acceptance |
+| agreementVersionId | UUID | Foreign key to the agreement version |
+| contactId | UUID | The Contact who accepted (member or guest) |
+| acceptedAt | datetime | Timestamp of acceptance |
+| acceptanceMethod | enum | How accepted: web_form, in_person, admin_assisted |
+| ipAddress | string (nullable) | IP address at time of acceptance (optional) |
+| userAgent | string (nullable) | Browser user-agent (optional) |
+| revokedAt | datetime (nullable) | If revoked, when (null if still active) |
+| revokedReason | string (nullable) | Reason for revocation if applicable |
+
+### Acceptance Method Values
+
+| Value | Description |
+|-------|-------------|
+| web_form | Member accepted via web interface |
+| in_person | Member accepted in person (e.g., at event check-in) |
+| admin_assisted | Admin recorded acceptance on member's behalf (with member present) |
+
+---
+
+## Revocation Rules
+
+Different agreement types have different revocation rules:
+
+| Agreement Type | Revocable | Effect of Revocation |
+|----------------|-----------|----------------------|
+| Membership Agreement | No (except by lapsing membership) | N/A |
+| Media Rights Agreement | Yes | Member blocked from future media-covered events |
+| Partnership Consent | Yes (either partner) | Delegation immediately inactive |
+| Guest Release | No (per-event, not ongoing) | N/A |
+
+### Revocation Process
+
+For revocable agreements:
+
+1. Member requests revocation via web interface or admin assistance
+2. System sets revokedAt timestamp on acceptance record
+3. Gates immediately treat this agreement as not accepted
+4. No retroactive effect (past registrations remain valid)
+
+### Partnership Consent Revocation
+
+When either partner revokes partnership consent:
+
+- Delegation is immediately inactive for both directions
+- The other partner is notified
+- No pending delegated actions are affected (only future actions blocked)
+- Partnership can be re-established if both partners consent again
+
+---
+
+## Audit Requirements
+
+The system MUST maintain a complete audit trail for agreements:
+
+### What Must Be Logged
+
+| Event | Required Fields |
+|-------|-----------------|
+| Agreement version created | agreementType, versionId, effectiveDate, createdBy |
+| Agreement accepted | contactId, agreementVersionId, acceptanceMethod, acceptedAt |
+| Agreement revoked | contactId, agreementVersionId, revokedAt, revokedReason, revokedBy |
+| Gate check failed | contactId, agreementType, reason, attemptedAction |
+
+### Retention
+
+- Acceptance records: Retained for the lifetime of the Contact record plus 7 years
+- Agreement versions: Retained indefinitely (never deleted, only deprecated)
+- Audit logs: Retained for 7 years minimum
+
+---
+
+## Visibility by Role
+
+Different roles have different visibility into agreement data:
+
+| Role | Can View | Can Modify |
+|------|----------|------------|
+| Member | Own acceptance history | Accept agreements, revoke permitted consents |
+| Event Chair | Registrant agreement status for own events | None |
+| Finance Manager | Agreement status for dispute resolution | None |
+| VP of Activities | Registrant agreement status for supervised events | None |
+| Admin | All agreement data | Create versions, record admin-assisted acceptances |
+
+### Member Self-Service
+
+Members can view:
+
+- Which agreements they have accepted
+- Which version of each agreement they accepted
+- When they accepted each agreement
+- Current status (active, revoked, outdated)
+
+Members cannot view:
+
+- Other members' agreement status
+- Agreement acceptance audit logs
+
+---
+
+## Integration with Eligibility Gates
+
+This document defines the agreement types and tracking model. The eligibility gates that enforce these agreements are specified in:
+
+- **SYSTEM_SPEC.md**: Section "Agreement-Based Eligibility Gates" defines which gates apply to which actions
+- **AUTH_AND_RBAC.md**: Section "Hard Gates: Agreements and Releases" defines evaluation order
+
+The gate logic follows this pattern:
+
+```
+1. Identify required agreements for the action
+2. For each required agreement:
+   a. Find current version (effectiveDate <= now AND deprecatedDate IS NULL)
+   b. Check if Contact has acceptance for that version
+   c. Check if acceptance is not revoked
+3. If any required agreement is missing, outdated, or revoked: BLOCK
+4. Otherwise: ALLOW
+```
+
+---
+
+## Data Model Summary
+
+```
+AgreementVersion
+  - id (UUID)
+  - agreementType (enum)
+  - versionId (string)
+  - contentHash (string)
+  - effectiveDate (datetime)
+  - deprecatedDate (datetime nullable)
+  - createdAt (datetime)
+
+AgreementAcceptance
+  - id (UUID)
+  - agreementVersionId (UUID FK)
+  - contactId (UUID FK)
+  - acceptedAt (datetime)
+  - acceptanceMethod (enum)
+  - ipAddress (string nullable)
+  - userAgent (string nullable)
+  - revokedAt (datetime nullable)
+  - revokedReason (string nullable)
+```
+
+---
+
+## Related Documents
+
+- [SYSTEM_SPEC.md](../../SYSTEM_SPEC.md) - Agreement-Based Eligibility Gates
+- [AUTH_AND_RBAC.md](../rbac/AUTH_AND_RBAC.md) - Hard Gates evaluation order
+- [FINANCE_ROLES.md](../rbac/FINANCE_ROLES.md) - Finance Manager visibility into agreements
+
+---
+
+*Document maintained by ClubOS development team. Last updated: December 2024*

--- a/docs/rbac/AUTH_AND_RBAC.md
+++ b/docs/rbac/AUTH_AND_RBAC.md
@@ -184,6 +184,84 @@ User Request: "Show me the events"
 
 ---
 
+## Evaluation Order
+
+When processing any request, ClubOS evaluates access in this order:
+
+```
+1. Authenticate user -----> 401 if failed
+        |
+        v
+2. Resolve roles and capabilities
+        |
+        v
+3. Apply scope rules (committee assignment)
+        |
+        v
+4. Apply delegation layer (if acting on behalf)
+        |
+        v
+5. Apply hard gates (agreements and releases)
+        |
+        v
+   ALLOW or DENY
+```
+
+Hard gates (step 5) are checked LAST and override all previous checks. A user may
+pass authentication, role, scope, and delegation checks but still be blocked by a
+missing or outdated agreement.
+
+---
+
+## Hard Gates: Agreements and Releases
+
+Certain actions require signed agreements regardless of role, scope, or delegation
+status. These are non-negotiable gates that cannot be bypassed by any role,
+including Admin.
+
+| Gate | Requirement | Applies To |
+|------|-------------|------------|
+| Membership Agreement | Current version required | Any event registration |
+| Media Rights Agreement | Current version required | Media-covered events only |
+| Guest Release | Guest-signed (non-delegable) | Events requiring guest release |
+| Partnership Consent | Both partners signed | Delegation/on-behalf actions |
+
+### Key Rules
+
+1. **Membership Agreement**: No event registration (self, partner, or admin-assisted)
+   without the current version of the Membership Agreement on file.
+
+2. **Media Rights Agreement**: No registration for events flagged as media-covered
+   without the current version of the Media Rights Agreement on file.
+
+3. **Guest Release**: For events requiring guest releases, the guest must sign
+   directly. A member cannot accept a guest release on behalf of a guest.
+   This is non-delegable.
+
+4. **Partnership Delegation Consent**: Partnership delegation is inactive until
+   BOTH partners have signed the partnership consent agreement. Either partner
+   may revoke at any time, immediately deactivating delegation.
+
+### Admin Does Not Bypass
+
+Admin role does not exempt a registrant from agreement requirements. When an Admin
+registers a member for an event, the system still checks that the member has the
+required agreements on file. Admin can record an admin-assisted acceptance but
+cannot skip the requirement.
+
+### Canonical Reference
+
+For agreement type definitions, versioning rules, acceptance tracking, and the
+data model, see the canonical document:
+
+- [Agreements and Consent Model](../agreements/AGREEMENTS_AND_CONSENT_MODEL.md)
+
+For gate enforcement rules in the context of event registration, see:
+
+- SYSTEM_SPEC.md - Agreement-Based Eligibility Gates section
+
+---
+
 ## Error Messages You Might See
 
 ### 401 Unauthorized


### PR DESCRIPTION
## Summary

Adds canonical documentation for agreement-based eligibility gates that control member and guest access to events.

## Files Changed

**New file:**
- `docs/agreements/AGREEMENTS_AND_CONSENT_MODEL.md` - Canonical reference for agreement types, versioning, and acceptance tracking

**Modified files:**
- `SYSTEM_SPEC.md` - Added section 12 "Agreement-Based Eligibility Gates"
- `docs/rbac/AUTH_AND_RBAC.md` - Added "Evaluation Order" and "Hard Gates" sections

## Agreement Types Defined

| Type | Slug | Who Signs | Purpose |
|------|------|-----------|---------|
| Membership Agreement | `membership_agreement` | Member | Required for any event registration |
| Media Rights Agreement | `media_rights` | Member | Required for media-covered events |
| Partnership Delegation Consent | `partnership_consent` | Both partners | Enables partner-on-behalf flows |
| Guest Release | `guest_release` | Guest (non-delegable) | Required for events allowing guests |

## Gates Defined

1. **Membership Agreement Gate** - Blocks registration without current version
2. **Media Rights Gate** - Blocks registration to media-covered events
3. **Guest Release Gate** - Non-delegable; guest must sign directly
4. **Partnership Consent Gate** - Bilateral; both partners must consent

## Key Design Decisions

- Hard gates are checked LAST (after auth, roles, scope, delegation)
- Admin role does NOT bypass agreement requirements
- Guest Release is explicitly non-delegable
- Partnership delegation requires bilateral consent and is immediately revocable

## Confirmation

- This PR contains documentation changes only
- No runtime code changes
- Cross-references established between canonical doc and consuming docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nRelease classification: experimental\n