### PR TITLE
docs: specify agreements, releases, and partnership delegation gates

### DIFF
--- a/SYSTEM_SPEC.md
+++ b/SYSTEM_SPEC.md
@@ -265,6 +265,38 @@ Placeholder modules for future expansion:
 - Carpooling
 - Photo and media management
 - Volunteer management
+- Bill.com reimbursement workflow visibility (see docs/external/BILLCOM_REIMBURSEMENT_BACKLOG.md)
+
+----------------------------------------------------------------------
+
+12. External Systems and SSO
+
+ClubOS integrates with external systems for specialized functions while
+maintaining its role as the identity and authorization system of record.
+
+12.1 Requirements
+
+- ClubOS must support SSO for external system access where feasible.
+- External system access must be mapped to ClubOS roles and groups.
+- No core workflow may depend on a single departing volunteer.
+- Credentials for external systems must be owned by roles, not individuals.
+- Term transitions must include access review and credential rotation.
+
+12.2 Integration Patterns
+
+- OIDC/OAuth SSO (preferred for user access)
+- Webhook/API integration (for data sync)
+- Service accounts (break-glass only, documented and rotated)
+
+12.3 Current Integrations
+
+- JotForm: Event request form UI (transitioning to native ClubOS UI)
+- Bill.com: Reimbursement processing (QuickBooks remains accounting SOR)
+- QuickBooks: Accounting system of record
+
+See docs/external/EXTERNAL_SYSTEMS_AND_SSO_SPEC.md for the complete specification
+including JotForm migration plan, Bill.com integration flow, and term transition
+procedures.
 
 ----------------------------------------------------------------------
 
@@ -754,4 +786,51 @@ Event registration delegation (partner signups)
 - Third party email provider integration beyond a single outbound channel.
 
 These items may be added in future phases once the core public site and mail system are stable.
+
+----------------------------------------------------------------------
+
+## Agreements and Releases
+
+ClubOS enforces certain agreements as hard gates. Actions are blocked until the
+required agreements are satisfied.
+
+### Agreement Types
+
+- **Membership Agreement**: Required for all members. Cannot register for events without it.
+- **Media Rights Agreement**: Required for all members. Opt-out allowed but must be explicit.
+- **Partnership Delegation Agreement**: Bilateral. Partner A cannot act for Partner B unless B signed.
+- **Guest Release**: Event-scoped. Guest must sign directly; cannot be delegated.
+
+### Hard Gates
+
+Hard gates block actions when requirements are not met:
+
+1. **Event Registration Gate**: Members cannot register unless Membership Agreement AND Media Rights Agreement are signed.
+2. **Partnership Delegation Gate**: Partner A cannot register/cancel for Partner B unless B has granted delegation rights via signed agreement.
+3. **Guest Participation Gate**: Guests cannot participate in events requiring releases unless they have signed directly.
+
+### What Happens When Unmet
+
+- User sees clear message identifying which agreement is missing
+- Action is blocked (not just warned)
+- User is directed to signing flow
+- Admin override available for exceptional cases (logged)
+
+### Admin Views
+
+- Dashboard showing members missing required agreements
+- List of guests registered for release-required events who have not yet signed
+- Agreement signature history and audit trail
+- Export capability for compliance review
+
+### Key Rules
+
+- Delegation CANNOT override hard gates (Partner A cannot sign for Partner B)
+- Guest release is NON-DELEGABLE (member cannot sign for their guest)
+- Revocation of delegation is effective immediately
+- Agreement gates do not grant permissions; they only gate actions
+
+See docs/agreements/AGREEMENTS_SYSTEM_SPEC.md for full specification.
+
+----------------------------------------------------------------------
 

--- a/docs/agreements/AGREEMENTS_SYSTEM_SPEC.md
+++ b/docs/agreements/AGREEMENTS_SYSTEM_SPEC.md
@@ -1,0 +1,320 @@
+# Agreements System Specification
+
+**Purpose**: Define agreement types, versioning, storage, and enforcement in ClubOS
+**Audience**: Tech Chair, Development Team, Board
+**Status**: Specification (docs-only)
+
+---
+
+## Overview
+
+ClubOS enforces certain agreements as hard gates. Users cannot proceed with specific
+actions until the required agreements are satisfied. This document specifies the
+agreement types, their requirements, and how they integrate with the authorization
+evaluation order.
+
+### Evaluation Order
+
+Agreements are evaluated as part of the ClubOS authorization chain:
+
+```
+Auth -> Roles -> Scope -> Delegation -> Hard Gates (Agreements)
+```
+
+Agreements are checked LAST, after all other authorization checks pass. A user may
+have the correct role and delegation rights, but still be blocked if an agreement
+hard gate is not satisfied.
+
+---
+
+## Agreement Types
+
+### 1. Membership Agreement
+
+**Purpose**: Establishes the member's relationship with the club
+**Required for**: All active members
+**Scope**: Club-wide
+
+Enforcement:
+- New members cannot register for any event until signed
+- Existing members whose agreement expires must re-sign before registering
+- Admin can override in exceptional cases (logged)
+
+Content includes:
+- Code of conduct
+- Liability acknowledgment
+- Communication consent
+- Dues and fee policies
+
+### 2. Media Rights Agreement
+
+**Purpose**: Grants permission for the club to use member photos/media
+**Required for**: All active members
+**Scope**: Club-wide
+
+Enforcement:
+- New members cannot register for any event until signed
+- Members may opt out (decline media rights) but must explicitly do so
+- Opt-out does not block registration; it sets a flag for event photographers
+
+Content includes:
+- Photo/video permission grant
+- Social media usage consent
+- Opt-out option with acknowledgment
+
+### 3. Partnership Delegation Agreement
+
+**Purpose**: Establishes delegation rights between partners
+**Required for**: Partnership delegation functionality
+**Scope**: Bilateral (between two specific contacts)
+
+Enforcement:
+- Partner A cannot act on behalf of Partner B unless B has signed
+- Partner B cannot act on behalf of Partner A unless A has signed
+- Both parties must sign for MUTUAL delegation mode
+- Revocation is effective immediately
+
+Content includes:
+- Grant of registration rights (register for partner)
+- Grant of cancellation rights (cancel partner's registration)
+- Grant of payment method usage (use partner's card on file)
+- Revocation clause
+- Bilateral consent acknowledgment
+
+### 4. Guest Release Agreement
+
+**Purpose**: Liability release for non-member guests at specific events
+**Required for**: Guests attending events that require releases
+**Scope**: Event-specific
+
+Enforcement:
+- Guest cannot participate in event without signing
+- Check-in system blocks participation if release not signed
+- CANNOT be delegated (guest must sign directly)
+- Member bringing guest cannot sign on guest's behalf
+
+Content includes:
+- Liability waiver
+- Emergency contact information
+- Acknowledgment of event-specific risks (e.g., hiking, boating)
+
+---
+
+## Versioning Model
+
+### Version Identification
+
+Each agreement has:
+- `agreement_type`: enum (MEMBERSHIP, MEDIA_RIGHTS, PARTNERSHIP_DELEGATION, GUEST_RELEASE)
+- `version_id`: unique identifier (UUID or incremental)
+- `content_hash`: SHA-256 hash of agreement content
+- `effective_date`: when this version became active
+- `supersedes_version_id`: previous version (nullable for first version)
+
+### Version Tracking Requirements
+
+1. When agreement content changes, a new version must be created
+2. The system must track which version each user signed
+3. If a new version is published:
+   - Existing signatures remain valid unless explicitly invalidated
+   - Admin can mark a version as "re-signature required"
+   - Users with re-signature required are blocked until they sign the new version
+
+### Content Hash
+
+The content_hash serves as a tamper-evident seal:
+- Hash is computed from the exact agreement text
+- If hash does not match stored content, signature is invalid
+- Enables audit verification that signed content was not altered
+
+---
+
+## Storage Requirements
+
+### Signature Record
+
+Each signed agreement must store:
+
+```
+agreement_signature:
+  id: UUID
+  contact_id: who signed
+  agreement_type: MEMBERSHIP | MEDIA_RIGHTS | PARTNERSHIP_DELEGATION | GUEST_RELEASE
+  version_id: which version was signed
+  signed_at: timestamp (UTC)
+  actor_id: who performed the action (may differ from contact_id for admin overrides)
+  method: WEB_UI | ADMIN_OVERRIDE | API | PAPER_UPLOAD
+  ip_address: (optional) for web signatures
+  event_id: (nullable) for event-scoped agreements like guest releases
+  partner_contact_id: (nullable) for partnership delegation (the other party)
+  revoked_at: (nullable) timestamp if revoked
+  revoked_by: (nullable) who revoked
+```
+
+### Retrieval Requirements
+
+The system must support:
+- Show exact version signed by a specific user
+- Show full audit trail of signatures and revocations
+- Show all users who have NOT signed a required agreement
+- Show all users whose signatures are for an outdated version (if re-sign required)
+- Export agreement signature history for compliance/legal review
+
+---
+
+## Enforcement Points
+
+### Hard Gate: Event Registration
+
+```
+User attempts to register for event
+        |
+        v
+   Auth -> Roles -> Scope -> Delegation checks pass?
+        |
+        NO --> 401/403 error
+        |
+       YES
+        |
+        v
+   Is user a member?
+        |
+       YES --> Check: Membership Agreement signed?
+        |              |
+        |         NO --> BLOCKED: "Please sign Membership Agreement"
+        |              |
+        |         YES --> Check: Media Rights Agreement signed?
+        |                      |
+        |                 NO --> BLOCKED: "Please sign Media Rights Agreement"
+        |                      |
+        |                 YES --> Proceed to registration
+        |
+       NO (guest) --> Different flow (guest release at check-in)
+```
+
+### Hard Gate: Partnership Delegation
+
+```
+Partner A attempts to register Partner B for event
+        |
+        v
+   Auth -> Roles -> Scope checks pass?
+        |
+       YES
+        |
+        v
+   Does Partner B have active Partnership Delegation Agreement
+   granting rights to Partner A?
+        |
+       NO --> BLOCKED: "Partner has not granted delegation rights"
+        |
+       YES
+        |
+        v
+   Has Partner B signed Membership Agreement?
+        |
+       NO --> BLOCKED: "Partner must sign Membership Agreement"
+        |
+       YES
+        |
+        v
+   Has Partner B signed Media Rights Agreement?
+        |
+       NO --> BLOCKED: "Partner must sign Media Rights Agreement"
+        |
+       YES
+        |
+        v
+   Proceed with registration for Partner B
+```
+
+### Hard Gate: Guest Participation
+
+```
+Guest arrives at event check-in
+        |
+        v
+   Does event require Guest Release?
+        |
+       NO --> Check in guest normally
+        |
+       YES
+        |
+        v
+   Has this specific guest signed Guest Release for this event?
+        |
+       NO --> BLOCKED: "Guest must sign release before participating"
+        |              (Provide signing mechanism at check-in)
+        |
+       YES --> Check in guest
+```
+
+---
+
+## Admin Views Required
+
+### Missing Agreements Dashboard
+
+Admins must be able to view:
+- List of members missing Membership Agreement
+- List of members missing Media Rights Agreement
+- List of members with outdated agreement versions (if re-sign required)
+- List of guests registered for events requiring releases who have not yet signed
+
+### Partnership Status View
+
+Admins must be able to view:
+- All active partnerships
+- Delegation status (who has granted rights to whom)
+- Revocation history
+
+### Agreement Audit View
+
+Admins must be able to view:
+- Full signature history for any contact
+- Exact agreement version text that was signed
+- Who signed, when, and by what method
+- Export capability for compliance
+
+---
+
+## Key Rules
+
+### Delegation Cannot Override Hard Gates
+
+Even if Partner A has been granted full delegation rights by Partner B:
+- Partner A cannot register Partner B if Partner B has not signed required agreements
+- Partner A cannot sign agreements on behalf of Partner B
+- Each member must sign their own Membership and Media Rights agreements
+
+### Guest Release is Non-Delegable
+
+- The member who brings a guest CANNOT sign the guest release on their behalf
+- The guest must sign directly (at check-in if not done in advance)
+- System must track which guest signed, not which member brought them
+
+### Revocation is Immediate
+
+- When Partner B revokes delegation rights from Partner A:
+  - Revocation takes effect immediately
+  - Partner A's in-progress actions may complete
+  - Partner A cannot initiate new actions on behalf of Partner B
+  - No grace period; no notification requirement before revocation
+
+### Agreement Gates Do Not Grant Permissions
+
+- Signing an agreement only satisfies a gate; it does not grant role permissions
+- A member who signs all agreements still cannot access admin features unless they have an admin role
+- Agreements and RBAC are separate concerns evaluated in sequence
+
+---
+
+## Related Documents
+
+- docs/rbac/AUTH_AND_RBAC.md - Delegation layer and role-based access
+- SYSTEM_SPEC.md - Agreements and Releases section
+- docs/project/AGREEMENTS_AND_PARTNERSHIP_ACCEPTANCE_CRITERIA.md - Build-ready acceptance criteria
+
+---
+
+*Document maintained by ClubOS development team. Last updated: December 2024*

--- a/docs/project/AGREEMENTS_AND_PARTNERSHIP_ACCEPTANCE_CRITERIA.md
+++ b/docs/project/AGREEMENTS_AND_PARTNERSHIP_ACCEPTANCE_CRITERIA.md
@@ -1,0 +1,218 @@
+# Agreements and Partnership Acceptance Criteria
+
+**Purpose**: Build-ready acceptance criteria for agreements and partnership delegation
+**Audience**: Engineering team, QA
+**Status**: Specification (docs-only, no implementation)
+
+---
+
+## Agreement Hard Gates
+
+### Membership Agreement
+
+**AC-AG-001**: Given a new member who has NOT signed the Membership Agreement, when
+they attempt to register for any event, then the system must block registration with
+message "Please sign your Membership Agreement to continue."
+
+**AC-AG-002**: Given a member whose Membership Agreement has expired (if version
+requires re-signing), when they attempt to register for any event, then the system
+must block registration until they sign the current version.
+
+**AC-AG-003**: Given a member who HAS signed the Membership Agreement, when they
+attempt to register for an event, then this gate passes (other gates may still apply).
+
+### Media Rights Agreement
+
+**AC-AG-004**: Given a new member who has NOT signed the Media Rights Agreement, when
+they attempt to register for any event, then the system must block registration with
+message "Please sign your Media Rights Agreement to continue."
+
+**AC-AG-005**: Given a member who has signed the Media Rights Agreement with OPT-OUT,
+when they attempt to register for an event, then registration is allowed (opt-out is
+recorded as a flag, not a blocker).
+
+**AC-AG-006**: Given a member who has signed both Membership and Media Rights
+agreements, when they attempt to register for an event, then agreement gates pass.
+
+### Agreement Versioning
+
+**AC-AG-007**: Given an agreement with a new version published AND marked as
+re-signature required, when a member who signed the old version attempts to register,
+then the system must block registration until they sign the new version.
+
+**AC-AG-008**: Given an agreement signature record, when an admin requests audit
+details, then the system must display the exact version text that was signed, the
+timestamp, and the signing method.
+
+---
+
+## Partnership Delegation
+
+### Bilateral Consent
+
+**AC-PA-001**: Given Partner A and Partner B with NO partnership delegation agreement
+signed by B, when Partner A attempts to register Partner B for an event, then the
+system must block the action with message "Partner has not granted delegation rights."
+
+**AC-PA-002**: Given Partner B has signed a Partnership Delegation Agreement granting
+rights to Partner A, when Partner A attempts to register Partner B for an event, then
+the delegation gate passes (other gates may still apply).
+
+**AC-PA-003**: Given Partnership in MUTUAL mode where only Partner A has signed
+(Partner B has not), when Partner B attempts to register Partner A for an event, then
+the system must block the action (B has not been granted rights by A).
+
+### Delegation Modes
+
+**AC-PA-004**: Given Partnership in PRIMARY_A mode, when Partner A attempts to
+register Partner B, then the action is allowed (A can act for both).
+
+**AC-PA-005**: Given Partnership in PRIMARY_A mode, when Partner B attempts to
+register Partner A, then the system must block the action (B can only act for self).
+
+**AC-PA-006**: Given Partnership in NONE or INDEPENDENT mode, when either partner
+attempts to act for the other, then the system must block the action.
+
+### Revocation
+
+**AC-PA-007**: Given Partner B has granted delegation rights to Partner A, when
+Partner B revokes those rights, then the revocation takes effect immediately.
+
+**AC-PA-008**: Given Partner A is in the middle of browsing events for Partner B when
+Partner B revokes, when Partner A attempts to complete a registration, then the
+system must block the action (revocation already effective).
+
+**AC-PA-009**: Given a revocation event, when the system logs it, then the log must
+include: who revoked, when, and the partnership affected.
+
+### Delegation Cannot Override Hard Gates
+
+**AC-PA-010**: Given Partner A has delegation rights from Partner B, but Partner B has
+NOT signed the Membership Agreement, when Partner A attempts to register Partner B,
+then the system must block with message about Partner B's missing agreement.
+
+**AC-PA-011**: Given Partner A has delegation rights from Partner B, when Partner A
+attempts to sign the Membership Agreement on behalf of Partner B, then the system
+must block the action (agreements are non-delegable).
+
+**AC-PA-012**: Given any delegation scenario, when the action would bypass a hard
+gate, then the system must block the action. Delegation cannot override gates.
+
+### Payment Method Delegation
+
+**AC-PA-013**: Given Partner A has delegation rights including payment method usage,
+when Partner A registers for an event, then Partner A may select Partner B's payment
+method on file.
+
+**AC-PA-014**: Given Partner A does NOT have payment method delegation from Partner B,
+when Partner A attempts to use Partner B's card, then the system must block the
+selection.
+
+---
+
+## Guest Release
+
+### Non-Delegable Signing
+
+**AC-GR-001**: Given an event that requires a Guest Release, when a member attempts
+to sign the release on behalf of their guest, then the system must block the action
+with message "Guest must sign release directly."
+
+**AC-GR-002**: Given a guest who has NOT signed the Guest Release for an event, when
+check-in staff attempts to check in the guest, then the system must block check-in
+with message "Guest must sign release before participating."
+
+**AC-GR-003**: Given a guest who HAS signed the Guest Release for the specific event,
+when check-in staff attempts to check in the guest, then check-in is allowed.
+
+### Event-Scoped
+
+**AC-GR-004**: Given a guest who signed a Guest Release for Event A, when the same
+guest attends Event B (which also requires a release), then the guest must sign a
+new release for Event B.
+
+**AC-GR-005**: Given an event that does NOT require a Guest Release, when a guest
+arrives at check-in, then no release check is performed.
+
+### Check-In View
+
+**AC-GR-006**: Given check-in staff viewing the attendance list for an event
+requiring guest releases, when viewing a guest entry, then the system must display
+release status (signed/not signed) prominently.
+
+**AC-GR-007**: Given check-in staff viewing the attendance list, when the release
+status is "not signed," then the system must provide a way for the guest to sign
+on-site (e.g., tablet signing flow).
+
+---
+
+## Admin Functions
+
+### Missing Agreements Dashboard
+
+**AC-AD-001**: Given an admin viewing the missing agreements dashboard, when the page
+loads, then the system must display a list of all members missing the Membership
+Agreement.
+
+**AC-AD-002**: Given an admin viewing the missing agreements dashboard, when the page
+loads, then the system must display a list of all members missing the Media Rights
+Agreement.
+
+**AC-AD-003**: Given events requiring guest releases, when an admin views the
+dashboard, then the system must display a list of registered guests who have not yet
+signed their release.
+
+### Admin Override
+
+**AC-AD-004**: Given a member blocked by an agreement hard gate, when an admin
+performs an override, then the override must be logged with: admin ID, member ID,
+which gate was overridden, reason provided, timestamp.
+
+**AC-AD-005**: Given an admin override was performed, when viewing the member's
+registration, then the system must indicate the registration was allowed via
+override.
+
+### Partnership Management
+
+**AC-AD-006**: Given an admin viewing partnerships, when viewing a specific
+partnership, then the system must display: both partners, delegation mode, which
+agreements are signed, revocation history.
+
+---
+
+## Audit and Retrieval
+
+**AC-AU-001**: Given a signed agreement, when an admin requests retrieval, then the
+system must display: exact agreement text signed, version ID, content hash, signed_at
+timestamp, method (web/admin/paper).
+
+**AC-AU-002**: Given a member's agreement history, when an admin requests export,
+then the system must produce a downloadable record suitable for compliance review.
+
+**AC-AU-003**: Given any delegated action, when logged, then the log must include:
+acting_member_id, affected_member_id, action_type, delegation_id, timestamp.
+
+---
+
+## Summary of Hard Gates
+
+| Gate | Blocks | Can Delegate? | Override? |
+|------|--------|---------------|-----------|
+| Membership Agreement | Event registration | NO | Admin only (logged) |
+| Media Rights Agreement | Event registration | NO | Admin only (logged) |
+| Partnership Delegation | Acting for partner | N/A (bilateral consent) | N/A |
+| Guest Release | Guest participation | NO | Admin only (logged) |
+
+**Key Rule**: Delegation CANNOT override hard gates.
+
+---
+
+## Related Documents
+
+- docs/agreements/AGREEMENTS_SYSTEM_SPEC.md - Full specification
+- docs/rbac/AUTH_AND_RBAC.md - Delegation layer and gate evaluation
+- SYSTEM_SPEC.md - Agreements and Releases section
+
+---
+
+*Document maintained by ClubOS development team. Last updated: December 2024*


### PR DESCRIPTION
## Summary

Adds comprehensive specification for agreement hard gates and partnership delegation
in ClubOS authorization chain.

### Authorization Evaluation Order
```
Auth -> Roles -> Scope -> Delegation -> Hard Gates (Agreements)
```

### Hard Gates Defined

| Gate | Blocks | Can Delegate? |
|------|--------|---------------|
| **Membership Agreement** | Event registration | NO |
| **Media Rights Agreement** | Event registration | NO |
| **Partnership Delegation** | Acting for partner | N/A (bilateral consent) |
| **Guest Release** | Guest participation | NO |

### Key Rule

**Delegation CANNOT override hard gates.**

- Partner A cannot register Partner B if B has not signed required agreements
- Partner A cannot sign agreements on behalf of Partner B
- Guest releases must be signed by the guest directly (non-delegable)
- Revocation of delegation rights is effective immediately

### Files Changed

**New files:**
- `docs/agreements/AGREEMENTS_SYSTEM_SPEC.md` - Full agreement system specification
- `docs/project/AGREEMENTS_AND_PARTNERSHIP_ACCEPTANCE_CRITERIA.md` - Build-ready acceptance criteria

**Modified files:**
- `SYSTEM_SPEC.md` - Added "Agreements and Releases" section
- `docs/rbac/AUTH_AND_RBAC.md` - Added Partnership Delegation Layer and Hard Gates sections

### Acceptance Criteria Count

- Agreement gates: AC-AG-001 through AC-AG-008
- Partnership delegation: AC-PA-001 through AC-PA-014
- Guest releases: AC-GR-001 through AC-GR-007
- Admin functions: AC-AD-001 through AC-AD-006

**This PR contains docs/spec changes only. No runtime code changes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nRelease classification: experimental\n