### PR TITLE
docs(widgets): photo gallery widget contract

### DIFF
--- a/docs/widgets/PHOTO_GALLERY_WIDGET_CONTRACT.md
+++ b/docs/widgets/PHOTO_GALLERY_WIDGET_CONTRACT.md
@@ -1,0 +1,28 @@
+# Photo Gallery Widget Contract
+
+Worker 4 — Widget Contract — Report
+
+## Allowed Responsibilities
+- Render photos
+- Request metadata
+- Invoke declared actions
+
+## Forbidden Responsibilities
+- Authentication
+- Authorization
+- Privacy enforcement
+- Face recognition decisions
+
+## Allowed Events
+- photo:view
+- photo:download
+- face:tag:add
+- face:tag:remove
+
+## Security Invariants
+- Widget never decides access
+- Widget never stores secrets
+- Widget treats storage URLs as opaque
+
+## Verdict
+READY FOR REVIEW


### PR DESCRIPTION
## Summary

- Defines strict contract for photo gallery widget:
  - **Widget is renderer-only, not authority**
  - Allowed responsibilities: render photos, request metadata, invoke declared actions
  - Forbidden responsibilities: authentication, authorization, privacy enforcement, face recognition decisions
- Allowed events: photo:view, photo:download, face:tag:add, face:tag:remove
- Security invariants:
  - Widget never decides access
  - Widget never stores secrets
  - Widget treats storage URLs as opaque

## Test plan

- [x] Document follows markdown format
- [x] No code changes (docs only)
- [x] Security invariants defined
- [x] Allowed/forbidden responsibilities clear

**This PR contains docs/spec changes only. No runtime code changes.**

Worker 4 - Widget Contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nRelease classification: experimental\n