### PR TITLE
docs(chatbot): support playbooks for read-only assistance

### DIFF
--- a/docs/chatbot/CHATBOT_SUPPORT_PLAYBOOKS.md
+++ b/docs/chatbot/CHATBOT_SUPPORT_PLAYBOOKS.md
@@ -1,0 +1,45 @@
+# Chatbot Support Playbooks
+
+Worker 4 — Q-024 Chatbot Support Playbooks — Report
+
+## Purpose
+Define how the chatbot handles support questions and guided navigation
+without mutating data.
+
+## Capabilities
+- Answer how-to questions
+- Execute read-only queries
+- Explain results
+- Deep-link to UI locations
+
+## Input Sources
+- User chat
+- Email-style requests
+- Admin prompts
+
+## Role Sensitivity
+- Member
+- Event Chair
+- Committee Lead
+- Tech Chair
+- Board
+
+## Response Structure
+1. Direct answer
+2. Context explanation
+3. Link to action page
+4. Escalation guidance (if needed)
+
+## Guardrails
+- Read-only
+- RBAC enforced
+- No assumptions
+- Cite data source
+
+## Non-Goals
+- No writes
+- No automation
+- No background jobs
+
+## Verdict
+READY FOR REVIEW


### PR DESCRIPTION
## Summary

- Defines how the chatbot handles support questions without mutating data
- **Capabilities**: answer how-to questions, execute read-only queries, explain results, deep-link to UI locations
- **Input sources**: user chat, email-style requests, admin prompts
- **Role sensitivity**: Member, Event Chair, Committee Lead, Tech Chair, Board
- **Response structure**: direct answer → context explanation → action link → escalation guidance
- **Guardrails**: read-only, RBAC enforced, no assumptions, cite data source

## Test plan

- [x] Document follows markdown format
- [x] No code changes (docs only)
- [x] Guardrails clearly defined
- [x] Role-sensitive response structure

**This PR contains docs/spec changes only. No runtime code changes.**

Worker 4 - Q-024 - Chatbot Support Playbooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nRelease classification: experimental\n