### PR TITLE
docs(rbac): activities chair delegation UI spec

### DIFF
--- a/docs/data/QUERY_TEMPLATES_REGISTRY.md
+++ b/docs/data/QUERY_TEMPLATES_REGISTRY.md
@@ -1,0 +1,40 @@
+# Query Templates Registry (v1)
+
+## Purpose
+Define allowlisted, named query templates used by list widgets, dashboards, and the read-only chatbot. Templates are the ONLY way UI and chatbot request filtered/sorted lists.
+
+## Key Rule
+No arbitrary filters/sorts from UI/chatbot. Only templates + small safe parameters (cursor, page_size, optional date window).
+
+## Template Shape (Concept)
+- template_id (stable string)
+- entity (members|events|registrations|payments)
+- visibility (role/scopes required)
+- allowlisted_filters (fixed)
+- allowlisted_sorts (fixed)
+- default_page_size
+- response_projection (safe fields only)
+
+## v1 Templates (initial)
+
+### Events
+- EVT_UPCOMING_PUBLIC
+- EVT_UPCOMING_MEMBER
+- EVT_MY_EVENTS_CHAIR
+- EVT_WAITLISTED (chair)
+
+### Registrations
+- REG_MY_UPCOMING
+- REG_EVENT_ROSTER_CHAIR
+
+### Members
+- MEM_DIRECTORY_PUBLIC (very limited, optional)
+- MEM_DIRECTORY_MEMBER (role-gated, limited fields)
+- MEM_NEW_MEMBERS_30D (admin)
+
+### Payments (deferred)
+- PAY_APPROVAL_QUEUE_FINANCE (contract only; no runtime yet)
+
+## Notes
+- Templates are referenced by widgets via template_id.
+- Server resolves template_id + ViewerContext -> executes safely.

--- a/docs/rbac/ACTIVITIES_CHAIR_DELEGATION_UI_SPEC.md
+++ b/docs/rbac/ACTIVITIES_CHAIR_DELEGATION_UI_SPEC.md
@@ -1,0 +1,31 @@
+# Activities -> Chair Delegation UI Spec (v1)
+
+## Goal
+Allow VP Activities to manage Event Chair assignments safely, with audit logging and strict scope rules.
+
+## Roles
+- VP_ACTIVITIES: can assign/remove Event Chair for events (scoped to Activities)
+- EVENT_CHAIR: can manage their own events/registrants; cannot grant roles
+- SYSTEM_ADMIN: break-glass, full visibility
+
+## UI Surfaces
+1) Chair Assignment Panel (Admin-only)
+- Search events
+- View current chair(s)
+- Assign chair (by member_id)
+- Remove chair
+- Reason required for every change
+
+2) Committee Roster Manager (optional v2)
+- Maintain committee membership list used for suggestions (no implicit authority)
+
+## Guardrails
+- No grant outside Activities domain
+- No cross-org delegation
+- Time-bounded grants optional (v2)
+- All changes append-only audited (actor, target, before/after, timestamp, reason)
+- Deny-path behavior visible (clear errors)
+
+## Success Criteria
+- VP Activities can staff events without needing President for routine changes
+- Chairs can do event operations without role-management capabilities


### PR DESCRIPTION
## Summary

Defines UI and guardrails for VP Activities to manage Event Chair assignments.

### Roles
- **VP_ACTIVITIES**: assign/remove Event Chair (scoped to Activities)
- **EVENT_CHAIR**: manage own events/registrants (no role grants)
- **SYSTEM_ADMIN**: break-glass, full visibility

### UI Surfaces
1. Chair Assignment Panel: search events, view/assign/remove chairs, reason required
2. Committee Roster Manager (v2): suggestion list, no implicit authority

### Guardrails
- No grant outside Activities domain
- No cross-org delegation
- Append-only audit (actor, target, before/after, timestamp, reason)
- Clear deny-path errors

**This PR contains docs/spec changes only. No runtime code changes.**

Worker 4 - Activities Chair Delegation UI Spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nRelease classification: experimental\n