### PR TITLE
code(chatbot): Query routing stub (template-based, read-only)

### DIFF
--- a/docs/rbac/ACTIVITIES_CHAIR_DELEGATION_UI_SPEC.md
+++ b/docs/rbac/ACTIVITIES_CHAIR_DELEGATION_UI_SPEC.md
@@ -1,0 +1,31 @@
+# Activities -> Chair Delegation UI Spec (v1)
+
+## Goal
+Allow VP Activities to manage Event Chair assignments safely, with audit logging and strict scope rules.
+
+## Roles
+- VP_ACTIVITIES: can assign/remove Event Chair for events (scoped to Activities)
+- EVENT_CHAIR: can manage their own events/registrants; cannot grant roles
+- SYSTEM_ADMIN: break-glass, full visibility
+
+## UI Surfaces
+1) Chair Assignment Panel (Admin-only)
+- Search events
+- View current chair(s)
+- Assign chair (by member_id)
+- Remove chair
+- Reason required for every change
+
+2) Committee Roster Manager (optional v2)
+- Maintain committee membership list used for suggestions (no implicit authority)
+
+## Guardrails
+- No grant outside Activities domain
+- No cross-org delegation
+- Time-bounded grants optional (v2)
+- All changes append-only audited (actor, target, before/after, timestamp, reason)
+- Deny-path behavior visible (clear errors)
+
+## Success Criteria
+- VP Activities can staff events without needing President for routine changes
+- Chairs can do event operations without role-management capabilities

--- a/src/lib/chatbot/queryRouting.ts
+++ b/src/lib/chatbot/queryRouting.ts
@@ -1,4 +1,8 @@
-import { type QueryTemplateId } from "@/lib/query/templates";
+// Query template IDs (stub - will be replaced by actual template registry)
+export type QueryTemplateId =
+  | "EVT_UPCOMING_MEMBER"
+  | "REG_MY_UPCOMING"
+  | "MEM_DIRECTORY_MEMBER";
 
 export type ChatIntent =
   | { type: "HOW_TO"; topic: string }
@@ -22,7 +26,7 @@ export function routeChatMessage(message: string): ChatIntent {
 
 export function renderIntent(intent: ChatIntent): ChatResponse {
   if (intent.type === "HOW_TO") {
-    return { kind: "TEXT", text: `I can help with that. What are you trying to accomplish in the app?` };
+    return { kind: "TEXT", text: "I can help with that. What are you trying to accomplish in the app?" };
   }
   if (intent.type === "QUERY") {
     return { kind: "LIST", templateId: intent.templateId, title: "Here is what I found" };


### PR DESCRIPTION
Adds minimal chatbot routing that maps a few phrases to allowlisted query templates; read-only skeleton only.\n\nRelease classification: experimental\n