### PR TITLE
docs+code: Query template registry (skeleton)

### DIFF
--- a/docs/data/QUERY_TEMPLATES_REGISTRY.md
+++ b/docs/data/QUERY_TEMPLATES_REGISTRY.md
@@ -1,0 +1,40 @@
+# Query Templates Registry (v1)
+
+## Purpose
+Define allowlisted, named query templates used by list widgets, dashboards, and the read-only chatbot. Templates are the ONLY way UI and chatbot request filtered/sorted lists.
+
+## Key Rule
+No arbitrary filters/sorts from UI/chatbot. Only templates + small safe parameters (cursor, page_size, optional date window).
+
+## Template Shape (Concept)
+- template_id (stable string)
+- entity (members|events|registrations|payments)
+- visibility (role/scopes required)
+- allowlisted_filters (fixed)
+- allowlisted_sorts (fixed)
+- default_page_size
+- response_projection (safe fields only)
+
+## v1 Templates (initial)
+
+### Events
+- EVT_UPCOMING_PUBLIC
+- EVT_UPCOMING_MEMBER
+- EVT_MY_EVENTS_CHAIR
+- EVT_WAITLISTED (chair)
+
+### Registrations
+- REG_MY_UPCOMING
+- REG_EVENT_ROSTER_CHAIR
+
+### Members
+- MEM_DIRECTORY_PUBLIC (very limited, optional)
+- MEM_DIRECTORY_MEMBER (role-gated, limited fields)
+- MEM_NEW_MEMBERS_30D (admin)
+
+### Payments (deferred)
+- PAY_APPROVAL_QUEUE_FINANCE (contract only; no runtime yet)
+
+## Notes
+- Templates are referenced by widgets via template_id.
+- Server resolves template_id + ViewerContext -> executes safely.

--- a/src/lib/query/templates.ts
+++ b/src/lib/query/templates.ts
@@ -1,0 +1,113 @@
+export type QueryEntity = "members" | "events" | "registrations" | "payments";
+
+export type RoleKey =
+  | "PUBLIC"
+  | "MEMBER"
+  | "EVENT_CHAIR"
+  | "VP_ACTIVITIES"
+  | "FINANCE_MANAGER"
+  | "VP_FINANCE"
+  | "PRESIDENT"
+  | "BOARD"
+  | "SYSTEM_ADMIN";
+
+export type QueryTemplateId =
+  | "EVT_UPCOMING_PUBLIC"
+  | "EVT_UPCOMING_MEMBER"
+  | "EVT_MY_EVENTS_CHAIR"
+  | "EVT_WAITLISTED"
+  | "REG_MY_UPCOMING"
+  | "REG_EVENT_ROSTER_CHAIR"
+  | "MEM_DIRECTORY_MEMBER"
+  | "MEM_NEW_MEMBERS_30D"
+  | "PAY_APPROVAL_QUEUE_FINANCE";
+
+export type QueryTemplate = {
+  id: QueryTemplateId;
+  entity: QueryEntity;
+  minRole: RoleKey;
+  description: string;
+  defaultPageSize: 10 | 25 | 50;
+  allowedParams: readonly string[];
+};
+
+export const QUERY_TEMPLATES: readonly QueryTemplate[] = [
+  {
+    id: "EVT_UPCOMING_PUBLIC",
+    entity: "events",
+    minRole: "PUBLIC",
+    description: "Upcoming public events (safe fields only).",
+    defaultPageSize: 25,
+    allowedParams: ["cursor", "page_size"],
+  },
+  {
+    id: "EVT_UPCOMING_MEMBER",
+    entity: "events",
+    minRole: "MEMBER",
+    description: "Upcoming events visible to logged-in members.",
+    defaultPageSize: 25,
+    allowedParams: ["cursor", "page_size"],
+  },
+  {
+    id: "EVT_MY_EVENTS_CHAIR",
+    entity: "events",
+    minRole: "EVENT_CHAIR",
+    description: "Events where viewer is the chair (scope-filtered).",
+    defaultPageSize: 25,
+    allowedParams: ["cursor", "page_size"],
+  },
+  {
+    id: "EVT_WAITLISTED",
+    entity: "events",
+    minRole: "EVENT_CHAIR",
+    description: "Events with waitlist activity for chair view (scope-filtered).",
+    defaultPageSize: 25,
+    allowedParams: ["cursor", "page_size"],
+  },
+  {
+    id: "REG_MY_UPCOMING",
+    entity: "registrations",
+    minRole: "MEMBER",
+    description: "Viewer's upcoming registrations (self-scoped).",
+    defaultPageSize: 25,
+    allowedParams: ["cursor", "page_size"],
+  },
+  {
+    id: "REG_EVENT_ROSTER_CHAIR",
+    entity: "registrations",
+    minRole: "EVENT_CHAIR",
+    description: "Event roster for chair (event-scoped).",
+    defaultPageSize: 50,
+    allowedParams: ["cursor", "page_size"],
+  },
+  {
+    id: "MEM_DIRECTORY_MEMBER",
+    entity: "members",
+    minRole: "MEMBER",
+    description: "Member directory (limited fields; role-gated).",
+    defaultPageSize: 25,
+    allowedParams: ["cursor", "page_size"],
+  },
+  {
+    id: "MEM_NEW_MEMBERS_30D",
+    entity: "members",
+    minRole: "SYSTEM_ADMIN",
+    description: "New members in last 30 days (admin).",
+    defaultPageSize: 25,
+    allowedParams: ["cursor", "page_size"],
+  },
+  {
+    id: "PAY_APPROVAL_QUEUE_FINANCE",
+    entity: "payments",
+    minRole: "FINANCE_MANAGER",
+    description: "Finance approval queue (contract only; runtime deferred).",
+    defaultPageSize: 25,
+    allowedParams: ["cursor", "page_size"],
+  },
+] as const;
+
+export function getQueryTemplate(id: QueryTemplateId): QueryTemplate {
+  const t = QUERY_TEMPLATES.find((x) => x.id === id);
+  if (!t) throw new Error(`Unknown QueryTemplateId: ${id}`);
+  return t;
+}


### PR DESCRIPTION
Adds allowlisted query template registry docs and a TypeScript registry stub for future list widgets/chatbot.\n\nRelease classification: experimental\n