### PR TITLE
code(chatbot): query execution API skeleton (v1)

### DIFF
--- a/docs/chatbot/CHATBOT_QUERY_EXECUTION_API_V1.md
+++ b/docs/chatbot/CHATBOT_QUERY_EXECUTION_API_V1.md
@@ -1,0 +1,24 @@
+# Chatbot Query Execution API v1
+
+Purpose
+- Allow chatbot to execute read-only queries via allowlisted templates.
+- Enforce RBAC on every request.
+- Return results plus deep-link suggestions.
+
+Request
+- intent: "QUERY"
+- template_id: string
+- params: object (template allowlist)
+- response_style: "SUMMARY" | "TABLE" | "DETAIL"
+
+Response
+- answer: string
+- data: object (optional, redacted)
+- deep_links: array of { href, label }
+- policy: { read_only: true }
+
+Hard gates
+- No mutations
+- No arbitrary filters/sorts
+- Template-only queries
+- Server RBAC + redactions always

--- a/src/app/api/chatbot/query/route.ts
+++ b/src/app/api/chatbot/query/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  void body;
+
+  return NextResponse.json(
+    {
+      answer: "TODO: implement chatbot query execution (template-only, read-only)",
+      data: null,
+      deep_links: [],
+      policy: { read_only: true },
+    },
+    { status: 501 },
+  );
+}


### PR DESCRIPTION
Adds v1 skeleton for chatbot template-only query execution API. Read-only; RBAC enforcement to be implemented next.\n\nRelease classification: experimental\n