### PR TITLE
code(widgets): list gadget runtime skeleton (v1)

### DIFF
--- a/docs/widgets/LIST_GADGET_RUNTIME_V1.md
+++ b/docs/widgets/LIST_GADGET_RUNTIME_V1.md
@@ -1,0 +1,41 @@
+# List Gadget Runtime v1
+
+Purpose
+- Provide a safe, RBAC-scoped list-rendering runtime for homepage and admin dashboards.
+- Browser provides template_id + template_params only. Server enforces RBAC and allowlists.
+
+Non-goals
+- No arbitrary filtering/sorting from the browser.
+- No server-side mutations.
+
+Request shape
+- template_id: string
+- params: object (template-specific allowlist)
+- cursor: opaque string (optional)
+- page_size: integer (server clamps)
+
+Server responsibilities
+- Validate template_id exists in registry
+- Validate params against per-template allowlist schema
+- Compute ViewerContext (member_id, roles, scopes)
+- Execute query via allowlisted query template
+- Apply RBAC (row-level + field-level redactions)
+- Return results + next_cursor
+
+Response shape
+- items: array
+- next_cursor: string | null
+- meta: { template_id, page_size, total_known?: number }
+
+Security gates
+- RBAC enforced server-side only
+- Deny unknown template_id
+- Deny unknown params keys
+- Clamp page_size
+- Rate limit per viewer
+- Audit log for admin templates (read events optional)
+
+Next steps
+- Implement API route: GET/POST /api/widgets/list (server-only)
+- Implement runtime function: runListGadget(template_id, params, viewerCtx)
+- Add unit tests for allowlist enforcement (deny unknown filters/sorts)

--- a/src/app/api/widgets/list/route.ts
+++ b/src/app/api/widgets/list/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { runListGadget } from "@/lib/widgets/listGadgetRuntime";
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  void body;
+
+  await runListGadget(
+    { templateId: "TODO", params: {} },
+    { memberId: null, roleIds: [], scopes: [] },
+  );
+
+  return NextResponse.json({ error: "TODO" }, { status: 501 });
+}

--- a/src/lib/widgets/listGadgetRuntime.ts
+++ b/src/lib/widgets/listGadgetRuntime.ts
@@ -1,0 +1,30 @@
+export type ViewerContext = {
+  memberId: string | null;
+  roleIds: string[];
+  scopes: string[];
+};
+
+export type ListGadgetRequest = {
+  templateId: string;
+  params: Record<string, unknown>;
+  cursor?: string | null;
+  pageSize?: number | null;
+};
+
+export type ListGadgetResponse<T> = {
+  items: T[];
+  nextCursor: string | null;
+  meta: {
+    templateId: string;
+    pageSize: number;
+  };
+};
+
+export async function runListGadget<T>(
+  req: ListGadgetRequest,
+  viewer: ViewerContext,
+): Promise<ListGadgetResponse<T>> {
+  void req;
+  void viewer;
+  throw new Error("TODO: implement runListGadget using query template registry + RBAC enforcement");
+}


### PR DESCRIPTION
Adds v1 runtime skeleton for RBAC-scoped list gadgets. No behavior yet; establishes server-side API and contracts.