### PR TITLE
docs(chatbot): safety contract

### DIFF
--- a/docs/chatbot/CHATBOT_SAFETY_CONTRACT.md
+++ b/docs/chatbot/CHATBOT_SAFETY_CONTRACT.md
@@ -1,0 +1,18 @@
+# Chatbot Safety Contract
+
+## Allowed
+- Read-only queries
+- Template-backed queries
+- Deep links to UI
+
+## Forbidden
+- Mutations
+- Role changes
+- Approvals
+- Workflow initiation
+- Parameter inference
+
+## Enforcement
+- Server-side RBAC
+- Template registry
+- Deny-first routing


### PR DESCRIPTION
Locks chatbot behavior to read-only, non-escalating usage.