### PR TITLE
docs(arch): open source audit

### DIFF
--- a/docs/architecture/OPEN_SOURCE_CANDIDATES.md
+++ b/docs/architecture/OPEN_SOURCE_CANDIDATES.md
@@ -1,0 +1,16 @@
+# Open Source Candidates
+
+## RBAC / Policy
+- OPA (Open Policy Agent) — mature, policy-as-code
+- Casbin — strong RBAC/ABAC support
+
+## Query Layer
+- Hasura allowlisted queries (conceptual reference)
+- Prisma + Zod validation
+
+## Audit / Logging
+- OpenTelemetry
+- Temporal audit patterns
+
+## Recommendation
+Prefer integration over reimplementation where feasible.


### PR DESCRIPTION
Identifies mature OSS candidates to avoid rebuilding core primitives.