### PR TITLE
docs(code): query runtime guardrails

### DIFF
--- a/docs/code/QUERY_RUNTIME_GUARDS.md
+++ b/docs/code/QUERY_RUNTIME_GUARDS.md
@@ -1,0 +1,12 @@
+# Query Runtime Guards
+
+## Invariants
+- All queries MUST reference a registered template
+- All params MUST pass allowlist validation
+- ViewerContext is REQUIRED
+- No direct execution paths exist
+
+## Deny Conditions
+- Missing template_id -> 403
+- Unknown params -> 400
+- Missing viewerContext -> 401


### PR DESCRIPTION
Documents non-negotiable runtime enforcement rules. No behavior changes.