### PR TITLE
docs(pages): navigation model + pages specs index

### DIFF
--- a/docs/pages/BLOCKS_AND_WIDGETS_V1.md
+++ b/docs/pages/BLOCKS_AND_WIDGETS_V1.md
@@ -1,0 +1,171 @@
+Copyright (c) Santa Barbara Newcomers Club. All rights reserved.
+
+# Blocks and Widgets (v1)
+Last updated: 2025-12-14
+
+## Purpose
+Define the initial block palette and the widget contract used by the Page Document.  
+Keep the palette intentionally small for safety and maintainability.
+
+## Design Principles
+- Small number of block types, each with clear behavior.
+- No arbitrary HTML injection by default.
+- All blocks must be renderable server-side.
+- Widgets are configured declaratively but execute safely via server code.
+- Data access for widgets is always RBAC-filtered server-side.
+- "Deny by default" for any capability not explicitly allowed.
+
+## Governance: Who Can Add Widget Types
+Only the Tech Chair can make a new widgetType available to a club site.
+
+Rule:
+- widgetType is a server-side allowlist (code + config) controlled by the Tech Chair.
+- Non-Tech-Chair editors may only choose from the allowlist.
+
+Rationale:
+- New widget types imply new capabilities, data access patterns, and security posture.
+
+## Block Types (v1)
+Recommended initial set:
+
+Content blocks:
+- heading
+- richText
+- divider
+- callout
+- buttonRow
+- image
+- spacer
+
+Structure blocks:
+- section
+- columns
+
+Widget blocks:
+- widget
+
+Special (restricted) widget types:
+- htmlEmbedWidget (Tech Chair only; see HTML widget policy)
+
+Notes:
+- section and columns may be implemented as layout constructs rather than blocks, but v1 can keep them as blocks for simplicity.
+- image should support alt text and optional caption.
+
+## Block Specs (v1)
+All blocks share:
+- id (string)
+- type (string)
+- props (object)
+- visibility (optional object)
+
+### heading
+props:
+- level (1-3)
+- text (string)
+
+### richText
+props:
+- format (string, default "tiptap-json")
+- content (object)
+
+### divider
+props:
+- variant (string, optional)
+
+### callout
+props:
+- tone (info|warning|success|neutral)
+- title (string, optional)
+- content (rich text object)
+
+### buttonRow
+props:
+- buttons (array)
+  - label (string)
+  - href (string)
+  - variant (primary|secondary|link)
+  - requiresAuth (bool, optional)
+
+### image
+props:
+- assetId (uuid) or src (string, for public assets only)
+- alt (string)
+- caption (string, optional)
+- size (small|medium|large, optional)
+
+### spacer
+props:
+- size (xs|sm|md|lg)
+
+### columns
+props:
+- columns (2|3)
+- gap (sm|md|lg)
+- blocksLeft (array of blocks)
+- blocksRight (array of blocks)
+- blocksThird (array of blocks, optional)
+
+## Widget Block Contract (v1)
+type = "widget"
+
+props:
+- widgetType (string)
+- config (object)
+- instanceId (uuid, optional)
+
+Rules:
+- widgetType must be in an allowlist controlled by the Tech Chair.
+- config must pass widgetType-specific schema validation.
+- instanceId references persistent widget-owned state (if needed).
+- widgets must not accept raw SQL, raw queries, or executable code via config.
+
+Widget types (initial candidates):
+- eventList
+- announcementList
+- quickLinks
+- photoGallery
+- adminQueueSummary (admin-only)
+- htmlEmbedWidget (restricted; Tech Chair only)
+
+## Widget Size and Editor UX
+Widgets should be handled consistently in the Page Document, but editor UX may differ:
+
+Small widgets:
+- Inline preview in the editor
+- Simple config panel
+
+Large widgets:
+- Collapsed block in the editor with a clear title and summary
+- "Configure" opens a side panel
+- Optional full-preview modal
+
+The page editor configures placement and presentation.  
+Domain editors manage underlying content and assets.
+
+## Persistent Data: Three Categories
+A) Presentation config (per page placement)
+- Stored in Page Document config
+
+B) Domain data (system-of-record)
+- Stored in first-class tables (events, members, finance, photos)
+- Accessed through RBAC-safe server APIs
+
+C) Widget-owned persistent state (rare)
+- Stored in WidgetInstance table keyed by instanceId
+- Must be auditable and RBAC-controlled
+- Must never allow arbitrary query execution
+
+## Validation and Backward Compatibility
+- Page Document has schemaVersion.
+- Each block and widget must have a stable schema.
+- When schemaVersion increases, provide a migration step:
+  - either a server-side normalize step or a stored migration for versions.
+
+## Security Notes
+- Widget config must never include raw SQL, arbitrary filters, or code.
+- If a widget supports filters/sorts, they must be from a whitelist and interpreted server-side.
+- The widget runtime must enforce deny-by-default capabilities.
+
+## HTML Widget (Special Case)
+The HTML widget is a privileged escape hatch and must follow a separate policy:
+- docs/pages/HTML_WIDGET_POLICY.md

--- a/docs/pages/HTML_WIDGET_POLICY.md
+++ b/docs/pages/HTML_WIDGET_POLICY.md
@@ -1,0 +1,105 @@
+Copyright (c) Santa Barbara Newcomers Club. All rights reserved.
+
+# HTML Widget Policy (Restricted Escape Hatch)
+Last updated: 2025-12-14
+
+## Purpose
+Define rigorous safeguards for a privileged widget type that can contain raw HTML/JS.  
+This is an escape hatch for edge cases, not a primary authoring path.
+
+## Governance
+- Only the Tech Chair can:
+  - create an HTML widget instance
+  - edit an HTML widget instance
+  - publish a page that introduces or changes HTML widget content
+
+A site may additionally disable HTML widgets entirely.
+
+## Default Posture
+- Disabled by default on new deployments.
+- If enabled, "deny by default" for capabilities and integrations.
+
+## Allowed Use Cases (Examples)
+- Embedding a vetted third-party widget that cannot be supported otherwise (with strict sandboxing).
+- Temporary bridge during migration, with an explicit sunset plan.
+- Minimal markup (non-executable) for layout that cannot be achieved with standard blocks (preferred: extend block palette instead).
+
+## Disallowed Use Cases
+- Arbitrary scripts that access member data or privileged APIs.
+- Anything that attempts to bypass RBAC.
+- Tracking pixels or analytics scripts not approved by governance.
+- Inline credential storage or secrets.
+- Any code that makes network calls to unapproved domains.
+
+## Safeguards: At Instantiation / Configuration Time
+The system must enforce:
+
+1) Strong ownership + audit
+- creator must be Tech Chair
+- all edits recorded with actorId, timestamp, diff summary
+
+2) Static validation (required)
+- parse HTML and reject:
+  - <script> tags (unless explicitly allowed under a stricter "approved script" mode)
+  - inline event handlers (onclick=, onload=, etc.)
+  - javascript: URLs
+  - iframes without sandbox attributes
+
+3) Domain allowlist (required)
+- any iframe src or external asset src must match an allowlist of domains
+- allowlist is configured by Tech Chair
+- no wildcards unless explicitly approved
+
+4) Size limits (required)
+- enforce max HTML length
+- enforce max number of iframes/assets
+
+5) Secrets and tokens (required)
+- no secrets in HTML
+- no hard-coded tokens
+- no environment leakage
+- no access to server runtime secrets
+
+## Safeguards: At Render / Runtime
+The system must enforce:
+
+1) Iframe sandboxing (required for any executable content)
+- render executable embeds only inside a sandboxed iframe
+- sandbox attributes must be strict (minimal permissions)
+- no same-origin unless explicitly justified
+- no top-navigation unless explicitly justified
+
+2) CSP (Content Security Policy)
+- define CSP headers to restrict:
+  - script-src
+  - frame-src
+  - img-src
+  - connect-src
+- for HTML widget routes, use the strictest CSP compatible with the embed.
+
+3) Capability gating
+- HTML widget gets zero access to ClubOS APIs by default.
+- Any API access must go through a narrowly scoped server endpoint with RBAC checks and explicit allowlisting.
+
+4) RBAC is not optional
+- HTML widgets must not be used to display privileged data unless that data is fetched server-side and rendered via approved components.
+- If privileged display is required, create a proper widget type instead.
+
+## Publishing Controls
+- Publishing a page that changes HTML widget content should require:
+  - page:publish permission AND widget:html:admin permission
+- Require a change summary on publish for HTML changes.
+- Optional (recommended): two-person review for high-risk pages (finance/membership).
+
+## Operational Guidance
+- Prefer creating a proper widget type over using HTML.
+- If HTML is used, require a sunset ticket:
+  - why it exists
+  - what replaces it
+  - target removal date
+
+## Implementation Notes (for CC)
+- Treat HTML widget instances as stored objects with versioning (WidgetInstanceVersion).
+- Validate + sanitize on save.
+- Always re-validate on publish.
+- Render through sandboxed iframe boundary when any active content is present.

--- a/docs/pages/NAVIGATION_MODEL_V1.md
+++ b/docs/pages/NAVIGATION_MODEL_V1.md
@@ -1,0 +1,194 @@
+Copyright (c) Santa Barbara Newcomers Club. All rights reserved.
+
+# Navigation Model (v1)
+Last updated: 2025-12-14
+
+## Purpose
+Define how menus (navigation) are constructed, stored, and rendered in a role-aware way.
+
+Goals:
+- Non-technical operators can manage navigation safely.
+- Visitors see navigation appropriate to their membership/role/group.
+- Multiple navigation styles are supported without rewriting content.
+- Navigation changes are auditable and reversible.
+
+Non-goals (v1):
+- Arbitrary CSS/HTML in menus by general editors.
+- Client-only hiding of unauthorized links.
+- A complex “drag-anything-anywhere” site builder.
+
+## Core Concepts
+- Navigation Set: a named menu configuration (e.g., "primary", "footer", "member").
+- Navigation Style: a rendering pattern (e.g., top bar, side rail, footer columns).
+- Menu Item: a typed entry (link, header, divider, section).
+- Visibility Rules: the conditions under which an item is shown.
+- Policy Decision: visibility is decided server-side based on the actor context.
+
+## Who Can Edit Navigation (v1)
+Recommended permissions:
+- nav:read (default)
+- nav:edit (edit navigation draft)
+- nav:publish (publish navigation)
+- nav:admin (manage nav sets used by themes/layouts)
+
+Default posture:
+- A small set of trusted roles (Tech Chair + designated content admins) can edit and publish nav.
+- Most editors manage pages, not global navigation.
+
+## Data Model (Proposed)
+Store navigation in Postgres with versioning.
+
+Tables:
+- NavigationSet
+  - id (uuid)
+  - key (string, unique)            "primary", "footer", "member"
+  - title (string)
+  - status (draft|published)
+  - currentPublishedVersionId (uuid, fk)
+  - createdAt, createdBy
+  - updatedAt, updatedBy
+
+- NavigationVersion
+  - id (uuid)
+  - navigationSetId (uuid, fk)
+  - versionNumber (int)
+  - documentJson (jsonb)
+  - publishedAt (timestamp, nullable)
+  - publishedBy (uuid, nullable)
+  - changeSummary (string, optional)
+
+Note:
+- NavigationVersion mirrors PageVersion for operator familiarity.
+- Rollback is pointer-based (fast rollback).
+
+## Navigation Document (v1)
+Top-level:
+- schemaVersion (int)
+- styleHints (optional object)     token-like hints, not CSS
+- items (array of MenuItem)
+
+MenuItem common fields:
+- id (string)
+- type (string)                   link|section|header|divider
+- label (string, optional)
+- visibility (optional object)
+
+MenuItem types:
+
+1) link
+- label (string)
+- href (string) OR pageSlug (string)
+- target (sameTab|newTab, optional)
+- iconKey (string, optional)
+- badge (string, optional)
+
+2) section
+- label (string)
+- items (array of MenuItem)
+
+3) header
+- label (string)
+
+4) divider
+- no props
+
+Visibility (v1):
+- audience (public|member|admin|custom)
+- rolesAny (array of role keys, optional)
+- groupsAny (array of group keys, optional)
+
+Rules:
+- Items are filtered server-side by visibility.
+- A section is hidden if it has no visible children after filtering.
+- pageSlug resolves to a page only if that page is visible to the actor.
+
+## Multiple Navigation Styles
+We support multiple navigation styles via:
+- multiple Navigation Sets (primary/footer/member/etc.)
+- theme/layout chooses which set(s) to render and where
+- a renderer uses "style" (layout component) + "document" (data)
+
+Examples of styles:
+- Top bar (primary) + optional dropdown sections
+- Side rail (member/admin dashboard)
+- Footer columns (footer)
+
+Style choice is not stored in each item as CSS. Instead:
+- theme defines how a given nav set is rendered
+- nav document may include minor style hints such as "compact" or "showIcons" (optional)
+
+## Construction Workflow (Operator UX)
+Two ways to build nav (v1):
+A) Direct nav editor
+- A simple tree editor for the Navigation Set:
+  - add items
+  - reorder
+  - set visibility
+  - set link target (pageSlug or URL)
+  - preview as role
+  - publish and rollback
+
+B) Template-driven nav (optional)
+- Theme can ship a default nav template.
+- Operator can “copy to editable” to manage local nav thereafter.
+
+## Rendering Workflow (Runtime)
+When rendering any page:
+1) Determine the active theme/layout for the page.
+2) Determine which nav sets are required (e.g., primary + footer).
+3) Load current published NavigationVersion for each required set.
+4) Filter items server-side based on actor context:
+   - anonymous/member/role/group
+5) Resolve pageSlug -> href only if page is visible to actor.
+6) Render using the theme’s nav components:
+   - TopBarNav
+   - SideRailNav
+   - FooterNav
+
+Security rule:
+- Do not render links the actor cannot access.
+- Do not rely on client-side hiding.
+
+## Link Resolution
+- For internal pages:
+  - use pageSlug and generate href from routing rules
+  - if the page is not visible, omit the item
+- For external links:
+  - allow https:// only by default
+  - optional domain allowlist for “official” outbound links
+
+## Admin vs Member Navigation
+We keep separate nav sets:
+- "primary" for public site
+- "member" for authenticated members
+- "admin" for admin console
+
+Rationale:
+- Keeps public navigation simple.
+- Makes admin navigation explicit and auditable.
+
+## Audit Log Events (Minimum)
+- nav.created
+- nav.draft.updated
+- nav.published
+- nav.rolledBack
+- permission.changed (if nav permissions change)
+
+Audit record includes:
+- actorId
+- timestamp
+- navigationSet key
+- fromVersion -> toVersion
+- changeSummary
+
+## Operational Safety
+- Publish requires change summary (recommended).
+- Preview as role must be one click.
+- One-click rollback to previous version.
+- Warn on broken external links (best-effort validation on save).
+- Warn if a nav item points to a page slug that no longer exists.
+
+## Open Questions
+- Do we allow per-link "requiresAuth" flag, or rely only on visibility rules?
+- Do we allow scheduled publish/unpublish for navigation (later)?
+- Do we want a governance role beyond Tech Chair for site-wide nav editing (e.g., "Content Admin")?

--- a/docs/pages/PAGE_EDITOR_V1.md
+++ b/docs/pages/PAGE_EDITOR_V1.md
@@ -1,0 +1,120 @@
+Copyright (c) Santa Barbara Newcomers Club. All rights reserved.
+
+# Page Editor (v1)
+Last updated: 2025-12-14
+
+## Purpose
+Define a page editing experience suitable for non-technical volunteers and admins.  
+The editor assembles typed blocks and configures widgets safely.
+
+## Target Personas
+- Older volunteer admins (little to no technical background)
+- Committee chairs and officers who need to update content occasionally
+- Technical chair or contractor who maintains templates and themes
+- Support chatbot (read-only) that helps explain what is visible and why
+
+## Editor Style Recommendation
+Block-based editor with guardrails:
+- Notion-like block composition
+- Strong block palette restrictions
+- Role-aware preview
+- Draft/publish workflow with versioning and rollback
+
+For rich text inside blocks:
+- Use a proven editor (example: Tiptap / ProseMirror family)
+- Store rich text as structured JSON, not HTML
+
+## Core Editor Capabilities (v1)
+1) Create and manage pages
+- Create page (slug, title)
+- Edit draft
+- Publish and rollback
+- Archive page
+
+2) Compose page
+- Add blocks from allowed palette
+- Reorder blocks (drag handle)
+- Edit block props
+- Insert widget blocks and configure widget settings
+
+3) Preview
+- Preview the page as:
+  - Anonymous
+  - Member
+  - Selected role
+  - Selected group membership
+- Preview must not grant additional access; it only simulates visibility.
+
+4) Safety and supportability
+- Autosave drafts
+- Clear validation errors (human-readable)
+- Change summary required on publish (recommended; may be optional in v1)
+- Audit log entries for publish and rollback
+
+## Widget Availability and Restrictions
+- The widget palette is driven by a server-side allowlist controlled by the Tech Chair.
+- Non-Tech-Chair editors can only select existing approved widget types.
+- Only the Tech Chair can:
+  - add/enable a new widget type for a site
+  - create or configure an HTML widget instance that contains raw HTML/JS (see HTML widget policy)
+
+Editor UX requirement:
+- Restricted widgets must be visibly labeled (e.g., "Tech Chair only").
+- Attempting to edit or publish restricted widget content without permission must fail with a clear message.
+
+## Editor UX Patterns (v1)
+- Left: page outline (regions and blocks)
+- Center: live preview
+- Right: properties panel for selected block/widget
+
+Block controls:
+- Add block above/below
+- Duplicate block
+- Delete block
+- Move block up/down
+
+Widget controls:
+- Title and widgetType label always visible
+- Summary of key settings
+- "Configure" opens a panel
+- Large widgets may show a placeholder preview or open a modal preview
+
+## Permissions (v1)
+Define editor permissions:
+- page:read (view published)
+- page:edit (edit drafts)
+- page:publish (publish/rollback)
+- page:admin (manage visibility policies, layouts, templates)
+- widget:catalog:admin (Tech Chair only; manage widget allowlist)
+- widget:html:admin (Tech Chair only; create/configure HTML widgets)
+
+Default posture:
+- Most volunteers can read.
+- Only designated roles can edit.
+- Publish is limited to a small set of roles.
+- Widget catalog and HTML widgets are Tech Chair only.
+
+## Themes and Templates (v1)
+A page chooses from an allowlist:
+- layout (e.g., default, landing, dashboard)
+- template (optional; a starter Page Document)
+- themeVariant (optional; limited set)
+
+Editors cannot write CSS.  
+Themes and CSS are maintained by technical roles.
+
+## Accessibility Requirements (v1)
+- Heading levels must be valid
+- Images require alt text
+- Buttons must have accessible labels
+- Color/tone choices must remain accessible in themes
+
+## Reliability Requirements
+- Draft saving must be robust under poor connectivity.
+- Editor must provide clear confirmation on save/publish.
+- If preview rendering fails, the editor must show an understandable error and preserve the draft.
+
+## Open Questions
+- Do we allow inline editing in the preview, or edit in the side panel only?
+- Do we support multi-region layouts in v1 or keep a single main region?
+- Do we allow per-block visibility settings in v1 or only per-page visibility?

--- a/docs/pages/PAGE_MODEL_AND_RENDERING.md
+++ b/docs/pages/PAGE_MODEL_AND_RENDERING.md
@@ -1,0 +1,170 @@
+Copyright (c) Santa Barbara Newcomers Club. All rights reserved.
+
+# Page Model and Rendering (v1)
+Last updated: 2025-12-14
+
+## Purpose
+Define a safe, maintainable way to build and render pages at runtime using declarative "page documents".  
+Pages are data. Rendering is code.
+
+Goals:
+- Non-technical volunteers can create and maintain pages safely.
+- Role-aware experiences (RBAC) are enforced server-side.
+- Edits are versioned, auditable, and reversible.
+- The system remains maintainable by an hourly contractor or an AI assistant.
+
+Non-goals (v1):
+- Arbitrary HTML editing by general editors.
+- User-supplied scripts.
+- Visual design freedom that bypasses themes/tokens.
+
+## Core Concepts
+- Page: A logical page identified by slug and audience rules.
+- Page Version: An immutable snapshot of the Page Document at publish time.
+- Page Document: JSON that declares layout and blocks. It is not executable code.
+- Block: A typed unit that renders via approved React components.
+- Widget Block: A block whose content is computed at render time by a server-side widget runtime using RBAC-safe APIs.
+
+## Governance: Widget Types and HTML Widgets
+- Only the Tech Chair can make a new widgetType available to a club site (server-side allowlist).
+- Only the Tech Chair can create/configure an HTML widget instance that contains raw HTML/JS.
+- The HTML widget is an escape hatch and must follow docs/pages/HTML_WIDGET_POLICY.md.
+
+## Data Model (Proposed Tables)
+Pages and versions should be stored in Postgres.
+
+Suggested tables:
+- Page
+  - id (uuid)
+  - slug (string, unique)
+  - title (string)
+  - status (draft|published|archived)
+  - visibilityPolicyId (uuid, optional)
+  - createdAt, createdBy
+  - updatedAt, updatedBy
+
+- PageVersion
+  - id (uuid)
+  - pageId (uuid, fk)
+  - versionNumber (int)
+  - documentJson (jsonb)
+  - publishedAt (timestamp)
+  - publishedBy (uuid)
+  - changeSummary (string, optional)
+
+- PageDraft (optional in v1; may be stored as Page.status=draft + Page.documentJson)
+  - id (uuid)
+  - pageId (uuid)
+  - documentJson (jsonb)
+  - updatedAt, updatedBy
+
+- VisibilityPolicy (optional in v1; may be embedded in Page Document initially)
+  - id (uuid)
+  - rulesJson (jsonb)
+  - createdAt, createdBy
+
+## Page Document (v1) Structure
+The Page Document is declarative JSON with a schemaVersion.
+
+Top-level:
+- schemaVersion (int)
+- layout (string)  
+- regions (array of Region)
+
+Region:
+- id (string)  
+- blocks (array of Block)
+
+Block (common fields):
+- id (string)
+- type (string)
+- props (object)
+- visibility (optional object)
+
+Visibility (v1):
+- audience (public|member|admin|custom)
+- groupsAny (array of group keys, optional)
+- rolesAny (array of role keys, optional)
+
+Widget Block:
+- type = "widget"
+- props.widgetType (string)
+- props.config (object)
+- props.instanceId (uuid, optional)
+
+The Page Document must be validated server-side against a JSON schema and a whitelist of allowed block types and widget types.
+
+## Runtime Rendering Flow
+Server-rendered or hybrid rendering is acceptable.  
+The key requirement is RBAC enforcement server-side.
+
+Render flow:
+1. Resolve the request context:
+   - actor identity (anonymous or authenticated)
+   - roles and groups
+   - effective permissions
+
+2. Load the page:
+   - find Page by slug
+   - load the currently published PageVersion (for public routes)
+   - optionally load draft if in editor/preview mode and authorized
+
+3. Validate and normalize:
+   - validate schemaVersion
+   - validate allowed blocks
+   - validate widgetType allowlist (site-level)
+   - fill defaults
+
+4. Render blocks in order:
+   - for content blocks, render via approved components
+   - for widget blocks, call Widget Runtime:
+     - enforce deny-by-default capabilities
+     - fetch RBAC-filtered data via server APIs
+     - return safe view model for rendering
+
+5. Apply visibility:
+   - do not rely on client-only filtering
+   - remove blocks server-side that actor cannot see
+
+## Widget Runtime: Safety Requirements
+Widget runtime must:
+- Enforce RBAC server-side for all data access.
+- Deny by default any capability not explicitly allowed for that widget type.
+- Log access for sensitive widgets (finance, membership, PII-adjacent).
+- Avoid arbitrary query execution from page document config.
+- Accept only validated configuration objects (schema per widgetType).
+
+## Preview as Role (Admin-only)
+Editors must be able to preview the page as:
+- Anonymous
+- Member
+- Specific role (e.g., Chair, VP, Board)
+- Specific group membership (v1: pick from existing groups)
+
+Preview mode must never grant additional access.  
+Preview only simulates visibility and rendered content.
+
+## Themes and CSS (Integration Point)
+Page documents must not contain CSS.  
+Styling is controlled by:
+- Theme tokens (design system variables)
+- Approved layouts
+- Component-level variants
+
+Future extension:
+- Allow per-page theme variant selection (e.g., "default", "event", "membership") with a limited whitelist.
+
+## Audit and Rollback
+- Every publish creates a new immutable PageVersion.
+- A rollback operation sets the current published pointer to an earlier version (or creates a new version copying old content).
+- All publishes and rollbacks are written to an audit log:
+  - who
+  - when
+  - what page
+  - from version -> to version
+  - reason / changeSummary
+
+## Open Questions (Track in issues)
+- Do we store drafts as a separate table or on Page?
+- Do we implement VisibilityPolicy as a reusable object in v1 or later?
+- How do we localize page content in future versions?

--- a/docs/pages/PREVIEW_AS_ROLE_AND_VERSIONING.md
+++ b/docs/pages/PREVIEW_AS_ROLE_AND_VERSIONING.md
@@ -1,0 +1,81 @@
+Copyright (c) Santa Barbara Newcomers Club. All rights reserved.
+
+# Preview-as-Role and Versioning
+Last updated: 2025-12-14
+
+## Purpose
+Define the safety and governance model for previewing pages as different roles and for publishing with rollback.
+
+## Preview-as-Role (Admin-only)
+Preview-as-role is for understanding what a user will see.  
+It is not a way to gain access.
+
+Preview modes:
+- Anonymous
+- Member
+- Selected role
+- Selected group membership (from known groups)
+
+Rules:
+- Preview never bypasses RBAC checks for data access.
+- Preview only changes the visibility evaluation and the widget render context.
+- Preview is clearly labeled in the UI to avoid confusion.
+
+Implementation notes:
+- The server computes an "effective actor context" for preview.
+- The widget runtime uses that effective context for RBAC filtering.
+- Sensitive widgets may show redacted views or "not authorized" even in preview, unless the preview role truly has permission.
+
+## Draft vs Published
+- Draft is editable and not visible to normal users.
+- Published is immutable per version.
+
+Rules:
+- Public routes load the currently published version.
+- Editors can load drafts only if they have page:edit permission.
+- Publishing creates a new PageVersion with a new version number.
+
+## Publishing Workflow (v1)
+Minimum:
+- Validate the Page Document
+- Save new PageVersion
+- Update the "current published version" pointer for the Page
+- Record an audit log entry
+
+Recommended:
+- Require a change summary on publish
+- Require stronger permission for publish than for edit
+
+## Rollback Workflow
+Rollback options:
+- Fast rollback: change the published pointer to a previous PageVersion
+- Copy rollback: create a new PageVersion from an older version and publish it
+
+Rules:
+- Rollbacks are recorded in the audit log with reason.
+- The UI must show which version is currently live.
+
+## Audit Log Events (Minimum)
+- page.created
+- page.draft.updated
+- page.published
+- page.rolledBack
+- widgetInstance.updated (if applicable)
+- permission.changed (if applicable)
+
+Each audit record should include:
+- actorId
+- timestamp
+- entity type and id
+- action
+- metadata (page slug, from version, to version)
+
+## Operational Safety for Volunteer Operators
+- Make publish explicit and slightly slower than saving a draft.
+- Provide "Preview as member" and "Preview as anonymous" as one-click options.
+- Provide a one-click rollback to the previous version.
+- Provide clear messages when a block or widget is hidden due to visibility rules.
+
+## Open Questions
+- Do we require two-person review for high-risk pages (finance) in v1?
+- Do we want scheduled publish/unpublish in later versions?

--- a/docs/pages/README.md
+++ b/docs/pages/README.md
@@ -1,0 +1,28 @@
+Copyright (c) Santa Barbara Newcomers Club. All rights reserved.
+
+# Pages System Specs (v1)
+
+This folder defines the **page runtime**, **editor model**, **widget model**, and **navigation model** for ClubOS.
+
+These documents are intended to be the implementation contract for the first production-grade publishing system.
+
+## Index
+- PAGE_MODEL_AND_RENDERING.md
+  - Page + PageVersion model, server-side rendering rules, publish pointer, and safety posture.
+- PAGE_EDITOR_V1.md
+  - Operator-facing editor behavior, palette rules, permissions, and safe publish workflow.
+- BLOCKS_AND_WIDGETS_V1.md
+  - Block model vs widget model; widget allowlist control; restricted widget handling.
+- WIDGET_PERSISTENCE_MODEL.md
+  - Widget instance persistence and versioning patterns; where durable data lives.
+- PREVIEW_AS_ROLE_AND_VERSIONING.md
+  - Preview-as-role, preview-as-version, and rollback semantics.
+- NAVIGATION_MODEL_V1.md
+  - Menus/navigation sets, role-aware filtering, multi-style rendering, and auditability.
+- HTML_WIDGET_POLICY.md
+  - Escape-hatch policy for raw HTML/JS widgets (Tech Chair only) with sandbox/CSP/capability gating.
+
+## Implementation Notes
+- Visibility is enforced **server-side** (no client-side hiding of unauthorized content).
+- Publishing is explicit, auditable, and reversible (pointer rollback).
+- Widget types are allowlisted and controlled by the Tech Chair; HTML widget is restricted and heavily sandboxed.

--- a/docs/pages/WIDGET_PERSISTENCE_MODEL.md
+++ b/docs/pages/WIDGET_PERSISTENCE_MODEL.md
@@ -1,0 +1,90 @@
+Copyright (c) Santa Barbara Newcomers Club. All rights reserved.
+
+# Widget Persistence Model
+Last updated: 2025-12-14
+
+## Purpose
+Define where widget state lives, and how to keep it auditable and maintainable.
+
+## The Three Kinds of Widget State
+A) Presentation config (per page placement)
+- Stored in the Page Document under widget.props.config
+- Examples:
+  - "limit": 5
+  - "mode": "upcoming"
+  - "showThumbnails": true
+
+B) Domain data (system-of-record)
+- Stored in first-class tables
+- Examples:
+  - events, registrations, members, payments, albums, photos
+- Widgets query this via RBAC-safe server APIs.
+
+C) Widget-owned persistent state (rare)
+- Stored in a WidgetInstance record referenced by widget.props.instanceId
+- Examples:
+  - curated lists
+  - saved filters (from a whitelist)
+  - per-widget editorial content like announcements
+
+## WidgetInstance Table (Proposed)
+- WidgetInstance
+  - id (uuid)
+  - widgetType (string)
+  - ownerScope (string, e.g., "global" or "committee:activities")
+  - configJson (jsonb)
+  - dataJson (jsonb)
+  - createdAt, createdBy
+  - updatedAt, updatedBy
+
+Rules:
+- widgetType must be allowlisted.
+- configJson and dataJson must be schema-validated per widgetType.
+- ownerScope restricts who can edit the instance.
+
+## Audit and Versioning
+Widget-owned persistent state must be auditable.
+
+Recommended:
+- WidgetInstanceVersion
+  - id (uuid)
+  - widgetInstanceId (uuid)
+  - versionNumber (int)
+  - configJson (jsonb)
+  - dataJson (jsonb)
+  - createdAt, createdBy
+  - changeSummary (string, optional)
+
+At minimum:
+- write to a general audit log on update.
+
+## RBAC Requirements
+- Reading widget instances must be RBAC-checked.
+- Updating widget instances must be RBAC-checked and logged.
+- Widgets must not embed sensitive data in the Page Document.
+- Widgets must fetch sensitive data at render time, server-side, for the current actor.
+
+## Safety Constraints
+- No arbitrary queries stored in widget state.
+- Filters and sorts must be whitelisted and interpreted server-side.
+- Deny-by-default: if a widgetType has not explicitly allowed a capability, it cannot use it.
+
+## Examples
+1) Small homepage list widget
+- Page Document stores config (limit, sort)
+- Widget queries domain tables for items allowed by RBAC
+- No widget-owned persistent data
+
+2) Photo gallery widget
+- Domain data stores albums/photos and access rules
+- Page Document stores config (albumId, layout)
+- Optional WidgetInstance if the gallery is curated beyond a simple album selection
+
+3) Editorial announcements
+- Announcements are often widget-owned data
+- Use WidgetInstance with auditable versions
+- Page Document references instanceId and presentation config
+
+## Open Questions
+- Should we always use domain tables for editorial items to avoid WidgetInstance complexity?
+- Do we need per-committee ownership scopes in v1, or can we start with global and evolve?


### PR DESCRIPTION
Adds docs/pages/NAVIGATION_MODEL_V1.md and an index README for the pages system specs (rendering/editor/widgets/navigation/HTML widget policy).