### PR TITLE
docs: email deliverability monitoring + help widget + chatbot OSS options

### DIFF
--- a/docs/chatbot/CHAT_WIDGET_OPEN_SOURCE_OPTIONS.md
+++ b/docs/chatbot/CHAT_WIDGET_OPEN_SOURCE_OPTIONS.md
@@ -1,0 +1,60 @@
+Copyright (c) Santa Barbara Newcomers Club. All rights reserved.
+
+# Chatbot Widget: Open Source Options (v1)
+
+We want a chatbot widget that:
+- Is safe by default (read-only / deny-first)
+- Enforces RBAC server-side
+- Is auditable
+- Is maintainable by non-technical operators over time
+- Can be embedded (iframe-first) without exposing privileges
+
+## What We Actually Need
+
+UI:
+- Chat transcript + input
+- Optional streaming responses
+- Themeable (matches site theme)
+- Accessible
+- Works as a widget and as a full page
+
+Application layer (ClubOS-owned):
+- Chatbot safety contract (already documented)
+- RBAC-gated retrieval and responses
+- Audit logging for queries and access
+
+## OSS Strategy
+
+Option A (Recommended): ClubOS-native widget using proven UI primitives
+- Implement the widget directly in ClubOS using existing component primitives.
+- Keep ALL tool use / retrieval on the server behind our safety contract.
+- Treat the UI as a thin shell.
+
+Pros:
+- Small surface area, easiest to keep safe
+- Fits our widget security posture
+- Best long-term maintainability
+
+Cons:
+- Some assembly work (but straightforward)
+
+Option B: Embed a full open-source chatbot product
+- Treat it as an external integration and embed via sandboxed iframe.
+
+Pros:
+- Faster UI and rich features
+
+Cons:
+- Large dependency surface
+- Difficult to align with ClubOS RBAC/audit/deny-first design
+- Likely forces their data model and operational footprint
+
+Guidance:
+- Only consider if we can keep it strictly sandboxed and never grant it direct privileged access.
+
+## Recommendation
+
+Proceed with Option A:
+- Build a ClubOS-native ChatWidget.
+- Keep the “brains” and all data access server-side.
+- Integrate with Help Widget by passing prefilled question + server context bundle.

--- a/docs/email/EMAIL_DELIVERABILITY_MONITORING_V1.md
+++ b/docs/email/EMAIL_DELIVERABILITY_MONITORING_V1.md
@@ -1,0 +1,150 @@
+Copyright (c) Santa Barbara Newcomers Club. All rights reserved.
+
+# Email Deliverability Monitoring (v1)
+
+This spec defines how ClubOS monitors deliverability and enforces rules around repeated non-deliverability (bounces, deferrals/blocks, complaints).
+
+Goals:
+- Detect deliverability problems quickly.
+- Automatically suppress unsafe recipients (hard bounces / complaints).
+- Apply repeat-failure rules for soft bounces and deferrals/blocks.
+- Enforce suppression server-side (not just in the ESP).
+- Keep behavior auditable and reversible.
+
+Non-goals (v1):
+- Becoming a full ESP analytics product.
+- Replacing the provider’s suppression system.
+- Deep inbound email parsing beyond webhook/mailbox fallback.
+
+## Event Sources (Provider-Agnostic)
+
+Preferred:
+- Provider webhooks (SES/SNS, SendGrid Event Webhook, Mailgun Webhooks, Postmark Webhooks, etc.)
+
+Optional fallback:
+- A dedicated mailbox that receives provider feedback emails.
+
+Security:
+- Verify webhook authenticity (signatures/secrets when available).
+- Record whether signature verification succeeded.
+- Reject unverifiable events.
+
+## Normalized Event Taxonomy
+
+Delivery lifecycle:
+- processed
+- delivered
+- deferred
+- bounced.soft
+- bounced.hard
+- blocked
+- dropped
+
+Feedback:
+- complaint
+- unsubscribe (if provider signals it)
+
+## Persistence Model (Minimum)
+
+OutboundEmailMessage
+- id (internalMessageId UUID)
+- toEmail
+- memberId nullable
+- subject
+- provider (enum)
+- providerMessageId nullable
+- createdAt
+- tags (json) e.g. committee/event/invoice/template ids
+
+EmailDeliveryEvent
+- id
+- messageId (internalMessageId)
+- provider
+- providerMessageId nullable
+- eventType (normalized)
+- occurredAt
+- rawPayload (json)
+- signatureVerified (bool)
+- ingestSource (webhook|mailbox|poll)
+- errorCode nullable
+- smtpStatus nullable
+- classification (hard|soft|complaint|other)
+
+RecipientDeliverabilityHealth
+- email (pk)
+- memberId nullable
+- status (ok|watch|suppressed)
+- suppressedReason (hard_bounce|complaint|manual|repeat_soft_bounce|repeat_deferred)
+- suppressedAt nullable
+- lastDeliveredAt nullable
+- lastFailureAt nullable
+- rollingCounters (json) e.g. softBounces14d, softBounces30d, deferred7d, blocked14d
+- notes (text)
+
+## Rules Engine (v1)
+
+Hard bounce (required)
+- On bounced.hard:
+  - status = suppressed
+  - suppressedReason = hard_bounce
+  - block all future sends server-side
+
+Complaint (required)
+- On complaint:
+  - status = suppressed
+  - suppressedReason = complaint
+  - block all future sends server-side
+
+Repeat soft bounces (recommended defaults, configurable)
+- If soft bounces >= 3 in 14 days: suppress for 30 days
+- If soft bounces >= 5 in 30 days: suppress for 60 days
+
+Repeat deferred/blocked (recommended defaults, configurable)
+- If deferred/blocked >= 5 in 7 days: status = watch
+- If deferred/blocked >= 10 in 14 days: suppress for 14 days
+
+Manual override (required)
+- Authorized operator can suppress/unsuppress with a required reason.
+- Unsuppress warns if last event was complaint or hard bounce.
+
+## Enforcement Points (Non-Negotiable)
+
+Before enqueue/send:
+- Check RecipientDeliverabilityHealth.status server-side.
+- If suppressed: block send and record audit event.
+- Do not rely on client-side hiding or provider-only suppression.
+
+## Operator UI (v1)
+
+Minimum:
+- Lookup by email
+- Show current status + reason + key counters
+- Show last N normalized events
+- Manual suppress / unsuppress with reason
+- “Retry” only when not suppressed and failure is transient
+
+## Audit Log Events (Minimum)
+
+- email.sent (or email.enqueued)
+- email.deliveryEvent.ingested
+- email.recipient.suppressed
+- email.recipient.unsuppressed
+- email.recipient.statusChanged
+- permission.changed
+
+Each audit record includes:
+- actorId (system for automated)
+- timestamp
+- entity + id
+- action
+- metadata (recipientEmail, fromStatus, toStatus, reason, thresholds)
+
+## Permissions (Minimum)
+
+- email:deliverability:view
+- email:deliverability:manage (manual suppress/unsuppress)
+- email:deliverability:admin (configure thresholds/providers; Tech Chair)
+
+Open questions:
+- Do we want an automated “member email invalid” flag, and how is it presented?
+- Do we want a self-serve re-verify-email workflow (later)?

--- a/docs/widgets/HELP_WIDGET_V1.md
+++ b/docs/widgets/HELP_WIDGET_V1.md
@@ -1,0 +1,89 @@
+Copyright (c) Santa Barbara Newcomers Club. All rights reserved.
+
+# Help Widget (v1)
+
+A small, context-aware widget that shows 4–5 preformatted help questions based on the user’s context. Clicking a question opens the chatbot widget with the question prefilled and a server-generated context bundle attached.
+
+Goals:
+- Help non-technical members and volunteers quickly.
+- Provide guided questions that are safe and relevant.
+- Integrate with the chatbot without becoming an admin command console.
+
+Non-goals (v1):
+- Replacing full documentation.
+- Free-form privileged actions through chat.
+
+## UX Behavior
+
+Display:
+- “Need help?” header
+- 4–5 suggested questions
+- Optional “More help” link (to a help page)
+
+Click behavior:
+- Opens chat panel (or navigates to /help/chat)
+- Prefills selected question
+- Attaches context (server-side) for grounding and RBAC-safe support
+
+Examples:
+- “What does this page do?”
+- “Why can’t I see or edit this?”
+- “What should I do next?”
+- “How do I contact the right person?”
+
+Rules:
+- Suggestions are generated server-side.
+- Do not render suggestions (or links) the actor cannot access.
+- Do not rely on client-side hiding.
+
+## Context Inputs (Server-Side)
+
+Minimum:
+- actor roles/groups
+- pageSlug
+- module context (events/membership/finance/etc.)
+- error state (optional)
+- relevant entity ids already in scope (optional)
+
+## Suggestion Generation (v1)
+
+Recommended approach:
+- Deterministic rules table (safest), optionally with LLM phrasing later.
+
+Examples:
+- If pageSlug matches admin/events:
+  - “How do I create an event?”
+  - “How do I email registrants?”
+
+- If anonymous:
+  - “How do I join?”
+  - “How do I log in?”
+
+## Integration with Chatbot
+
+Contract:
+- Help widget can open the chatbot in guidance/read-only mode.
+- Any privileged action must occur through explicit UI flows and permissions, not chat.
+
+Payload to chatbot:
+- prefilledQuestion
+- context bundle (server-generated):
+  - pageSlug
+  - actorRoles
+  - siteId
+  - allowedModules
+  - relevantEntityIds (optional)
+
+## Persistence
+
+Default:
+- No per-instance persistence required.
+
+Optional site-level config:
+- enabled (bool)
+- maxQuestions (default 5)
+- customQuestionsByPagePattern (json)
+
+Permissions:
+- content:helpWidget:edit
+- content:helpWidget:admin (Tech Chair)


### PR DESCRIPTION
Adds v1 specs for deliverability monitoring and repeated non-deliverability rules, a context-aware Help widget that feeds the chatbot, and a short OSS strategy for the chatbot widget (ClubOS-native UI + server-side safety contract).