### PR TITLE
ops(runbook): prisma drift + local dev DB reset scripts

### DIFF
--- a/docs/runbooks/prisma-dev-db-reset.md
+++ b/docs/runbooks/prisma-dev-db-reset.md
@@ -1,0 +1,25 @@
+Prisma Dev DB Reset and Drift SOP
+
+Scope:
+- LOCAL DEV ONLY (clubos_dev on localhost:5432)
+- Never run against production.
+
+When to use:
+- Prisma reports drift or "migration(s) applied to the database but missing locally"
+- You switched branches and seed/migrations disagree
+
+Safe procedure:
+1) Confirm target is localhost and database is clubos_dev
+2) Reset dev DB
+3) Apply migrations
+4) Generate client
+5) Seed (if needed)
+6) Re-run failing test(s)
+
+Commands:
+- scripts/ops/db/check_drift.sh
+- scripts/ops/db/reset_dev_db.sh
+
+Notes:
+- If drift appears after switching branches, your dev DB likely contains migrations from another branch.
+- Always reset LOCAL dev DB before creating new migrations.

--- a/scripts/ops/db/check_drift.sh
+++ b/scripts/ops/db/check_drift.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "=== Prisma drift check (non-destructive) ==="
+echo "This inspects schema/migration alignment. It should NOT modify DB."
+echo
+
+npx prisma migrate dev --create-only --name _drift_check_tmp >/tmp/prisma_drift_check.log 2>&1 || true
+
+if grep -qi "Drift detected" /tmp/prisma_drift_check.log; then
+  echo "DRIFT DETECTED"
+  sed -n '1,220p' /tmp/prisma_drift_check.log
+  exit 1
+fi
+
+echo "No drift detected (or prisma did not report drift)."

--- a/scripts/ops/db/reset_dev_db.sh
+++ b/scripts/ops/db/reset_dev_db.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "=== LOCAL DEV DB RESET (DANGEROUS) ==="
+echo "This will drop and recreate the LOCAL dev DB."
+echo
+
+if [ "${PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION:-}" != "yes" ]; then
+  echo "ERROR: Set PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION=yes to proceed."
+  exit 2
+fi
+
+npx prisma migrate reset --force
+npx prisma migrate dev
+npx prisma generate
+
+if npm run -s | grep -qE "^  db:seed$"; then
+  npm run db:seed
+fi
+
+echo "DONE: reset + migrate + generate (+ seed if available)"


### PR DESCRIPTION
## Summary
- Add Prisma drift detection and local dev DB reset runbook
- Add helper scripts for common dev DB operations

## Files Added

**docs/runbooks/prisma-dev-db-reset.md**
- SOP for handling Prisma drift on local dev
- Clear scope: LOCAL DEV ONLY (never production)
- Step-by-step safe procedure

**scripts/ops/db/check_drift.sh**
- Non-destructive drift check
- Inspects schema/migration alignment
- Reports drift if detected

**scripts/ops/db/reset_dev_db.sh**
- Dangerous operation (requires consent env var)
- Full reset: drop, migrate, generate, seed
- `PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION=yes` required

## Use Cases
- Developer switches branches with different migrations
- Prisma reports "migration(s) applied but missing locally"
- Fresh local dev DB setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nRelease classification: experimental\n