### PR TITLE
ops(runbook): prisma drift recovery (dev only)

### DIFF
--- a/docs/runbooks/prisma-dev-db-reset.md
+++ b/docs/runbooks/prisma-dev-db-reset.md
@@ -1,0 +1,105 @@
+# Prisma Dev DB Reset and Drift Recovery
+
+## Scope
+
+**LOCAL DEV ONLY** - `clubos_dev` on `localhost:5432`
+
+Never run these procedures against production databases.
+
+## When to Use
+
+- Prisma reports "drift detected" or schema mismatch
+- Error: "migration(s) applied to the database but missing locally"
+- You switched branches and migrations/seed data disagree
+- Fresh local dev environment setup
+
+## Symptoms of Drift
+
+```
+Error: P3006
+Migration `20241201_xyz` failed to apply cleanly to the shadow database.
+```
+
+```
+Drift detected: Your database schema is not in sync with your migration history.
+```
+
+## Safe Recovery Procedure
+
+### Step 1: Confirm Target Database
+
+```bash
+# Verify you're targeting LOCAL dev DB
+echo $DATABASE_URL
+# Should show: postgresql://...@localhost:5432/clubos_dev
+```
+
+**STOP** if DATABASE_URL points to anything other than localhost.
+
+### Step 2: Check Drift (Non-Destructive)
+
+```bash
+scripts/ops/db/check_drift.sh
+```
+
+This inspects alignment without modifying the database.
+
+### Step 3: Reset Dev DB (If Needed)
+
+```bash
+# Requires explicit consent
+PRISMA_RESET_CONSENT=yes scripts/ops/db/reset_dev_db.sh
+```
+
+This will:
+
+1. Drop and recreate the local dev database
+2. Apply all migrations from scratch
+3. Regenerate Prisma client
+4. Run seed script (if available)
+
+### Step 4: Verify
+
+```bash
+npm run typecheck
+npm run test-admin  # or relevant test suite
+```
+
+## Helper Scripts
+
+| Script | Purpose | Destructive? |
+|--------|---------|--------------|
+| `scripts/ops/db/check_drift.sh` | Detect drift, print status | No |
+| `scripts/ops/db/reset_dev_db.sh` | Full dev DB reset | Yes (requires consent) |
+
+## Common Scenarios
+
+### Switched Branches with Different Migrations
+
+Your dev DB has migrations from branch A, but you're now on branch B with different migrations.
+
+**Solution:** Reset dev DB to get a clean slate matching current branch.
+
+### Created Migration on Wrong Branch
+
+You accidentally ran `prisma migrate dev` on the wrong branch.
+
+**Solution:**
+
+1. Delete the unwanted migration file from `prisma/migrations/`
+2. Reset dev DB
+3. Switch to correct branch
+4. Re-run migrations
+
+### Shadow Database Errors
+
+Prisma uses a shadow database for migration validation. If it reports shadow DB issues:
+
+**Solution:** Reset dev DB - this clears both main and shadow databases.
+
+## Safety Notes
+
+- These scripts only affect LOCAL development databases
+- Production databases require different procedures and approvals
+- Always verify `DATABASE_URL` before running destructive commands
+- The consent environment variable prevents accidental execution

--- a/scripts/ops/db/check_drift.sh
+++ b/scripts/ops/db/check_drift.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Check for Prisma schema drift (non-destructive)
+# This script inspects migration/schema alignment without modifying the database.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "=== Prisma Drift Check ==="
+echo "Target: LOCAL DEV ONLY"
+echo
+
+# Verify we're targeting localhost
+if [[ "${DATABASE_URL:-}" != *"localhost"* && "${DATABASE_URL:-}" != *"127.0.0.1"* ]]; then
+  echo "ERROR: DATABASE_URL does not point to localhost."
+  echo "This script is for LOCAL DEV ONLY."
+  echo "Current DATABASE_URL: ${DATABASE_URL:-<not set>}"
+  exit 1
+fi
+
+echo "Database URL check: OK (localhost)"
+echo
+
+# Run migrate status to check alignment
+echo "Checking migration status..."
+echo
+
+MIGRATE_OUTPUT=$(npx prisma migrate status 2>&1) || true
+
+echo "$MIGRATE_OUTPUT"
+echo
+
+# Check for drift indicators
+if echo "$MIGRATE_OUTPUT" | grep -qi "drift detected"; then
+  echo
+  echo "=========================================="
+  echo "DRIFT DETECTED"
+  echo "=========================================="
+  echo
+  echo "Next steps:"
+  echo "1. Review the drift details above"
+  echo "2. If safe, run: PRISMA_RESET_CONSENT=yes scripts/ops/db/reset_dev_db.sh"
+  echo "3. See docs/runbooks/prisma-dev-db-reset.md for full procedure"
+  exit 1
+fi
+
+if echo "$MIGRATE_OUTPUT" | grep -qi "database schema is not in sync"; then
+  echo
+  echo "=========================================="
+  echo "SCHEMA OUT OF SYNC"
+  echo "=========================================="
+  echo
+  echo "Next steps:"
+  echo "1. Run: PRISMA_RESET_CONSENT=yes scripts/ops/db/reset_dev_db.sh"
+  echo "2. See docs/runbooks/prisma-dev-db-reset.md for full procedure"
+  exit 1
+fi
+
+if echo "$MIGRATE_OUTPUT" | grep -qi "pending migration"; then
+  echo
+  echo "=========================================="
+  echo "PENDING MIGRATIONS"
+  echo "=========================================="
+  echo
+  echo "Next steps:"
+  echo "1. Run: npx prisma migrate dev"
+  echo "2. Or if issues persist: PRISMA_RESET_CONSENT=yes scripts/ops/db/reset_dev_db.sh"
+  exit 0
+fi
+
+echo "=========================================="
+echo "NO DRIFT DETECTED"
+echo "=========================================="
+echo "Database schema is in sync with migrations."

--- a/scripts/ops/db/reset_dev_db.sh
+++ b/scripts/ops/db/reset_dev_db.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Reset local dev database (DESTRUCTIVE)
+# Requires explicit consent via environment variable.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "=== LOCAL DEV DB RESET ==="
+echo "This is a DESTRUCTIVE operation."
+echo
+
+# Safety check 1: Require explicit consent
+if [[ "${PRISMA_RESET_CONSENT:-}" != "yes" ]]; then
+  echo "ERROR: This script requires explicit consent."
+  echo
+  echo "To proceed, run:"
+  echo "  PRISMA_RESET_CONSENT=yes $0"
+  echo
+  echo "See docs/runbooks/prisma-dev-db-reset.md for full procedure."
+  exit 2
+fi
+
+# Safety check 2: Verify localhost target
+if [[ "${DATABASE_URL:-}" != *"localhost"* && "${DATABASE_URL:-}" != *"127.0.0.1"* ]]; then
+  echo "ERROR: DATABASE_URL does not point to localhost."
+  echo "This script is for LOCAL DEV ONLY."
+  echo "Current DATABASE_URL: ${DATABASE_URL:-<not set>}"
+  echo
+  echo "REFUSING TO PROCEED - this may be a production database."
+  exit 1
+fi
+
+echo "Safety checks passed:"
+echo "  - Consent: PRISMA_RESET_CONSENT=yes"
+echo "  - Target: localhost (local dev)"
+echo
+
+echo "Proceeding with reset in 3 seconds..."
+echo "(Press Ctrl+C to abort)"
+sleep 3
+
+echo
+echo "[1/4] Resetting database..."
+npx prisma migrate reset --force
+
+echo
+echo "[2/4] Applying migrations..."
+npx prisma migrate dev
+
+echo
+echo "[3/4] Regenerating Prisma client..."
+npx prisma generate
+
+echo
+echo "[4/4] Running seed (if available)..."
+if npm run --silent 2>/dev/null | grep -qE "^\s*db:seed$"; then
+  npm run db:seed
+  echo "Seed completed."
+else
+  echo "No db:seed script found, skipping."
+fi
+
+echo
+echo "=========================================="
+echo "DEV DB RESET COMPLETE"
+echo "=========================================="
+echo
+echo "Next steps:"
+echo "1. Run: npm run typecheck"
+echo "2. Run: npm run test-admin (or relevant tests)"


### PR DESCRIPTION
Adds/updates runbook + helper scripts for safe local drift recovery.

## Summary

- Add comprehensive runbook for Prisma drift recovery
- Add non-destructive drift check script
- Add dev DB reset script with safety guards

## Files Added

**docs/runbooks/prisma-dev-db-reset.md**
- Full SOP for handling Prisma drift
- Common scenarios and solutions
- Clear scope: LOCAL DEV ONLY

**scripts/ops/db/check_drift.sh**
- Non-destructive drift detection
- Verifies localhost target
- Prints next steps based on status

**scripts/ops/db/reset_dev_db.sh**
- Full dev DB reset (drop, migrate, generate, seed)
- Requires `PRISMA_RESET_CONSENT=yes` to run
- Verifies localhost target before proceeding
- 3-second abort window

## Safety Features

- Both scripts verify DATABASE_URL points to localhost
- Reset script requires explicit consent env var
- Clear error messages guide users to documentation

References #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)