### PR TITLE
test(api): eligibility endpoint contract coverage

### DIFF
--- a/src/app/api/v1/events/[id]/eligibility/route.ts
+++ b/src/app/api/v1/events/[id]/eligibility/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { apiSuccess } from "@/lib/api";
+import { evaluateEventEligibility } from "@/server/eligibility";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * GET /api/v1/events/:id/eligibility
+ *
+ * Returns eligibility status for all ticket types for an event.
+ * Requires authentication.
+ *
+ * Response:
+ * {
+ *   eventId: string,
+ *   memberId: string | null,
+ *   ticketTypes: Array<{
+ *     id: string,
+ *     code: string,
+ *     name: string,
+ *     eligibility: {
+ *       allowed: boolean,
+ *       reasonCode: string,
+ *       reasonDetail?: string
+ *     }
+ *   }>
+ * }
+ */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { id: eventId } = await params;
+
+  // Authenticate request
+  const authResult = await requireAuth(request);
+  if (!authResult.ok) {
+    return authResult.response;
+  }
+
+  const { memberId } = authResult.context;
+
+  const result = await evaluateEventEligibility(memberId, eventId);
+
+  return apiSuccess(result);
+}

--- a/src/app/api/v1/tickets/[id]/eligibility/route.ts
+++ b/src/app/api/v1/tickets/[id]/eligibility/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import { apiSuccess } from "@/lib/api";
+import { evaluateTicketTypeEligibility } from "@/server/eligibility";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * GET /api/v1/tickets/:id/eligibility
+ *
+ * Returns eligibility status for a specific ticket type.
+ * Requires authentication.
+ *
+ * Response:
+ * {
+ *   ticketTypeId: string,
+ *   memberId: string | null,
+ *   eligibility: {
+ *     allowed: boolean,
+ *     reasonCode: string,
+ *     reasonDetail?: string
+ *   }
+ * }
+ */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const { id: ticketTypeId } = await params;
+
+  // Authenticate request
+  const authResult = await requireAuth(request);
+  if (!authResult.ok) {
+    return authResult.response;
+  }
+
+  const { memberId } = authResult.context;
+
+  const result = await evaluateTicketTypeEligibility(memberId, ticketTypeId);
+
+  return apiSuccess(result);
+}

--- a/src/server/eligibility/index.ts
+++ b/src/server/eligibility/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Eligibility Service
+ *
+ * Exports eligibility evaluation functions and types.
+ * Currently uses stub implementation pending PR #78.
+ */
+
+export * from "./types";
+export {
+  evaluateTicketEligibility,
+  evaluateEventEligibility,
+  evaluateTicketTypeEligibility,
+} from "./stub";

--- a/src/server/eligibility/stub.ts
+++ b/src/server/eligibility/stub.ts
@@ -1,0 +1,104 @@
+/**
+ * Eligibility Service Stub
+ *
+ * Temporary stub implementation for the eligibility service.
+ * Returns mock data until the full eligibility engine is implemented.
+ *
+ * TODO: Replace with real implementation from PR #78
+ */
+
+import {
+  EligibilityInput,
+  EligibilityResult,
+  EventEligibilityResponse,
+  TicketEligibilityResponse,
+} from "./types";
+
+/**
+ * Stub: Evaluate eligibility for a single ticket type.
+ *
+ * Returns STUB_ALLOWED for authenticated users, NOT_LOGGED_IN otherwise.
+ */
+export async function evaluateTicketEligibility(
+  input: EligibilityInput
+): Promise<EligibilityResult> {
+  const { memberId } = input;
+
+  if (!memberId) {
+    return {
+      allowed: false,
+      reasonCode: "NOT_LOGGED_IN",
+      reasonDetail: "User must be logged in to check ticket eligibility",
+    };
+  }
+
+  // Stub: always allow for authenticated users
+  return {
+    allowed: true,
+    reasonCode: "STUB_ALLOWED",
+    reasonDetail: "Stub implementation - eligibility engine pending PR #78",
+  };
+}
+
+/**
+ * Stub: Evaluate eligibility for all ticket types for an event.
+ *
+ * Returns mock ticket types with STUB_ALLOWED eligibility.
+ */
+export async function evaluateEventEligibility(
+  memberId: string | null,
+  eventId: string
+): Promise<EventEligibilityResponse> {
+  const baseEligibility = await evaluateTicketEligibility({
+    memberId,
+    eventId,
+  });
+
+  // Return mock ticket types for the stub
+  const mockTicketTypes = [
+    {
+      id: "stub-member-standard",
+      code: "MEMBER_STANDARD",
+      name: "Member Standard",
+      eligibility: baseEligibility,
+    },
+    {
+      id: "stub-sponsor-committee",
+      code: "SPONSOR_COMMITTEE",
+      name: "Sponsor Committee",
+      eligibility: baseEligibility,
+    },
+    {
+      id: "stub-working-committee",
+      code: "WORKING_COMMITTEE",
+      name: "Working Committee",
+      eligibility: baseEligibility,
+    },
+  ];
+
+  return {
+    eventId,
+    memberId,
+    ticketTypes: mockTicketTypes,
+  };
+}
+
+/**
+ * Stub: Evaluate eligibility for a specific ticket type by ID.
+ */
+export async function evaluateTicketTypeEligibility(
+  memberId: string | null,
+  ticketTypeId: string
+): Promise<TicketEligibilityResponse> {
+  const eligibility = await evaluateTicketEligibility({
+    memberId,
+    eventId: "stub-event",
+    ticketTypeId,
+  });
+
+  return {
+    ticketTypeId,
+    memberId,
+    eligibility,
+  };
+}

--- a/src/server/eligibility/types.ts
+++ b/src/server/eligibility/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Eligibility Engine Types
+ *
+ * Shared types for eligibility evaluation.
+ * These types define the contract between the eligibility service and API layer.
+ */
+
+/**
+ * Reason codes returned by the eligibility engine.
+ * These are stable strings for API consumers.
+ */
+export type EligibilityReasonCode =
+  | "ALLOWED"
+  | "NOT_LOGGED_IN"
+  | "MEMBER_NOT_FOUND"
+  | "EVENT_NOT_FOUND"
+  | "TICKET_TYPE_NOT_FOUND"
+  | "NOT_MEMBER_ON_EVENT_DATE"
+  | "NEWBIE_TO_NEWCOMER_ALLOWED"
+  | "WRONG_MEMBER_LEVEL"
+  | "NOT_IN_SPONSORING_COMMITTEE"
+  | "NOT_IN_WORKING_COMMITTEE"
+  | "OVERRIDE_ALLOWED"
+  | "OVERRIDE_DENIED"
+  | "STUB_ALLOWED";
+
+/**
+ * Result of evaluating ticket eligibility.
+ */
+export interface EligibilityResult {
+  allowed: boolean;
+  reasonCode: EligibilityReasonCode;
+  reasonDetail?: string;
+}
+
+/**
+ * Input parameters for eligibility evaluation.
+ */
+export interface EligibilityInput {
+  memberId: string | null;
+  eventId: string;
+  ticketTypeId?: string;
+  ticketTypeCode?: string;
+  asOfDate?: Date;
+}
+
+/**
+ * Ticket type with eligibility information.
+ */
+export interface TicketTypeEligibility {
+  id: string;
+  code: string;
+  name: string;
+  eligibility: EligibilityResult;
+}
+
+/**
+ * Response for event eligibility endpoint.
+ */
+export interface EventEligibilityResponse {
+  eventId: string;
+  memberId: string | null;
+  ticketTypes: TicketTypeEligibility[];
+}
+
+/**
+ * Response for single ticket eligibility endpoint.
+ */
+export interface TicketEligibilityResponse {
+  ticketTypeId: string;
+  memberId: string | null;
+  eligibility: EligibilityResult;
+}

--- a/tests/api/v1/eligibility.spec.ts
+++ b/tests/api/v1/eligibility.spec.ts
@@ -1,0 +1,267 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Eligibility API Contract Tests
+ *
+ * Tests for:
+ * - GET /api/v1/events/:id/eligibility
+ * - GET /api/v1/tickets/:id/eligibility
+ *
+ * These tests validate:
+ * - 401 response schema (consistent error shape)
+ * - 200 response schema (includes decision + reasonCodes)
+ */
+
+const BASE_URL = process.env.PW_BASE_URL || "http://localhost:3000";
+
+test.describe("GET /api/v1/events/:id/eligibility", () => {
+  test.describe("401 Unauthorized", () => {
+    test("returns 401 when no auth header", async ({ request }) => {
+      const response = await request.get(
+        `${BASE_URL}/api/v1/events/test-event-id/eligibility`
+      );
+
+      expect(response.status()).toBe(401);
+    });
+
+    test("401 response has consistent error shape", async ({ request }) => {
+      const response = await request.get(
+        `${BASE_URL}/api/v1/events/test-event-id/eligibility`
+      );
+
+      expect(response.status()).toBe(401);
+      const body = await response.json();
+
+      // Validate error response structure
+      expect(body).toHaveProperty("error");
+      expect(body).toHaveProperty("message");
+      expect(typeof body.error).toBe("string");
+      expect(typeof body.message).toBe("string");
+    });
+
+    test("returns 401 with invalid token", async ({ request }) => {
+      const response = await request.get(
+        `${BASE_URL}/api/v1/events/test-event-id/eligibility`,
+        {
+          headers: { Authorization: "Bearer invalid-token-xyz" },
+        }
+      );
+
+      expect(response.status()).toBe(401);
+      const body = await response.json();
+      expect(body).toHaveProperty("error");
+      expect(body).toHaveProperty("message");
+    });
+  });
+
+  test.describe("200 Success", () => {
+    test("returns 200 when authenticated", async ({ request }) => {
+      const response = await request.get(
+        `${BASE_URL}/api/v1/events/test-event-id/eligibility`,
+        {
+          headers: { Authorization: "Bearer test-member-token" },
+        }
+      );
+
+      expect(response.status()).toBe(200);
+    });
+
+    test("200 response has correct top-level structure", async ({ request }) => {
+      const response = await request.get(
+        `${BASE_URL}/api/v1/events/test-event-id/eligibility`,
+        {
+          headers: { Authorization: "Bearer test-member-token" },
+        }
+      );
+
+      expect(response.status()).toBe(200);
+      const body = await response.json();
+
+      // Validate response structure
+      expect(body).toHaveProperty("eventId");
+      expect(body).toHaveProperty("memberId");
+      expect(body).toHaveProperty("ticketTypes");
+
+      expect(typeof body.eventId).toBe("string");
+      expect(body.eventId).toBe("test-event-id");
+      expect(Array.isArray(body.ticketTypes)).toBe(true);
+    });
+
+    test("ticketTypes array has correct item structure", async ({ request }) => {
+      const response = await request.get(
+        `${BASE_URL}/api/v1/events/test-event-id/eligibility`,
+        {
+          headers: { Authorization: "Bearer test-member-token" },
+        }
+      );
+
+      expect(response.status()).toBe(200);
+      const body = await response.json();
+
+      expect(body.ticketTypes.length).toBeGreaterThan(0);
+
+      const ticketType = body.ticketTypes[0];
+      expect(ticketType).toHaveProperty("id");
+      expect(ticketType).toHaveProperty("code");
+      expect(ticketType).toHaveProperty("name");
+      expect(ticketType).toHaveProperty("eligibility");
+
+      expect(typeof ticketType.id).toBe("string");
+      expect(typeof ticketType.code).toBe("string");
+      expect(typeof ticketType.name).toBe("string");
+    });
+
+    test("eligibility object has decision and reasonCode", async ({ request }) => {
+      const response = await request.get(
+        `${BASE_URL}/api/v1/events/test-event-id/eligibility`,
+        {
+          headers: { Authorization: "Bearer test-member-token" },
+        }
+      );
+
+      expect(response.status()).toBe(200);
+      const body = await response.json();
+
+      const eligibility = body.ticketTypes[0].eligibility;
+
+      // Must have decision (allowed) and reasonCode
+      expect(eligibility).toHaveProperty("allowed");
+      expect(eligibility).toHaveProperty("reasonCode");
+
+      expect(typeof eligibility.allowed).toBe("boolean");
+      expect(typeof eligibility.reasonCode).toBe("string");
+
+      // reasonDetail is optional
+      if (eligibility.reasonDetail !== undefined) {
+        expect(typeof eligibility.reasonDetail).toBe("string");
+      }
+    });
+
+    test("stub returns STUB_ALLOWED for authenticated users", async ({ request }) => {
+      const response = await request.get(
+        `${BASE_URL}/api/v1/events/test-event-id/eligibility`,
+        {
+          headers: { Authorization: "Bearer test-member-token" },
+        }
+      );
+
+      expect(response.status()).toBe(200);
+      const body = await response.json();
+
+      // Verify stub behavior
+      const eligibility = body.ticketTypes[0].eligibility;
+      expect(eligibility.allowed).toBe(true);
+      expect(eligibility.reasonCode).toBe("STUB_ALLOWED");
+    });
+  });
+});
+
+test.describe("GET /api/v1/tickets/:id/eligibility", () => {
+  test.describe("401 Unauthorized", () => {
+    test("returns 401 when no auth header", async ({ request }) => {
+      const response = await request.get(
+        `${BASE_URL}/api/v1/tickets/test-ticket-id/eligibility`
+      );
+
+      expect(response.status()).toBe(401);
+    });
+
+    test("401 response has consistent error shape", async ({ request }) => {
+      const response = await request.get(
+        `${BASE_URL}/api/v1/tickets/test-ticket-id/eligibility`
+      );
+
+      expect(response.status()).toBe(401);
+      const body = await response.json();
+
+      // Validate error response structure
+      expect(body).toHaveProperty("error");
+      expect(body).toHaveProperty("message");
+      expect(typeof body.error).toBe("string");
+      expect(typeof body.message).toBe("string");
+    });
+
+    test("returns 401 with invalid token", async ({ request }) => {
+      const response = await request.get(
+        `${BASE_URL}/api/v1/tickets/test-ticket-id/eligibility`,
+        {
+          headers: { Authorization: "Bearer bad-token-123" },
+        }
+      );
+
+      expect(response.status()).toBe(401);
+      const body = await response.json();
+      expect(body).toHaveProperty("error");
+      expect(body).toHaveProperty("message");
+    });
+  });
+
+  test.describe("200 Success", () => {
+    test("returns 200 when authenticated", async ({ request }) => {
+      const response = await request.get(
+        `${BASE_URL}/api/v1/tickets/test-ticket-id/eligibility`,
+        {
+          headers: { Authorization: "Bearer test-member-token" },
+        }
+      );
+
+      expect(response.status()).toBe(200);
+    });
+
+    test("200 response has correct structure", async ({ request }) => {
+      const response = await request.get(
+        `${BASE_URL}/api/v1/tickets/test-ticket-id/eligibility`,
+        {
+          headers: { Authorization: "Bearer test-member-token" },
+        }
+      );
+
+      expect(response.status()).toBe(200);
+      const body = await response.json();
+
+      // Validate response structure
+      expect(body).toHaveProperty("ticketTypeId");
+      expect(body).toHaveProperty("memberId");
+      expect(body).toHaveProperty("eligibility");
+
+      expect(typeof body.ticketTypeId).toBe("string");
+      expect(body.ticketTypeId).toBe("test-ticket-id");
+    });
+
+    test("eligibility object has decision and reasonCode", async ({ request }) => {
+      const response = await request.get(
+        `${BASE_URL}/api/v1/tickets/test-ticket-id/eligibility`,
+        {
+          headers: { Authorization: "Bearer test-member-token" },
+        }
+      );
+
+      expect(response.status()).toBe(200);
+      const body = await response.json();
+
+      const eligibility = body.eligibility;
+
+      // Must have decision (allowed) and reasonCode
+      expect(eligibility).toHaveProperty("allowed");
+      expect(eligibility).toHaveProperty("reasonCode");
+
+      expect(typeof eligibility.allowed).toBe("boolean");
+      expect(typeof eligibility.reasonCode).toBe("string");
+    });
+
+    test("stub returns STUB_ALLOWED for authenticated users", async ({ request }) => {
+      const response = await request.get(
+        `${BASE_URL}/api/v1/tickets/test-ticket-id/eligibility`,
+        {
+          headers: { Authorization: "Bearer test-member-token" },
+        }
+      );
+
+      expect(response.status()).toBe(200);
+      const body = await response.json();
+
+      expect(body.eligibility.allowed).toBe(true);
+      expect(body.eligibility.reasonCode).toBe("STUB_ALLOWED");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds read-only eligibility endpoints with contract tests
- `GET /api/v1/events/:id/eligibility` - Returns eligibility for all ticket types
- `GET /api/v1/tickets/:id/eligibility` - Returns eligibility for a specific ticket type

## Contract Tests

Tests validate:
- 401 response schema (consistent `error` + `message` shape)
- 200 response schema (includes `decision` + `reasonCodes`)
- Stub returns `STUB_ALLOWED` for authenticated users

## Implementation

Uses stub implementation until full eligibility engine merges (see #78).

## Files Added

| File | Purpose |
|------|---------|
| `src/server/eligibility/types.ts` | Shared types |
| `src/server/eligibility/stub.ts` | Stub implementation |
| `src/server/eligibility/index.ts` | Module exports |
| `src/app/api/v1/events/[id]/eligibility/route.ts` | Events endpoint |
| `src/app/api/v1/tickets/[id]/eligibility/route.ts` | Tickets endpoint |
| `tests/api/v1/eligibility.spec.ts` | Contract tests |

## Quality Gates

- ✅ `npm run typecheck`
- ✅ `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)