### PR TITLE
feat: add withJobRun helper for cron idempotency

### DIFF
--- a/docs/OPS/cron-jobs.md
+++ b/docs/OPS/cron-jobs.md
@@ -1,0 +1,244 @@
+# Cron Jobs Operations Guide
+
+This document describes the cron job infrastructure for ClubOS, including authentication, idempotency, and monitoring.
+
+## Overview
+
+ClubOS uses cron-over-HTTP for scheduled tasks, designed for reliability and observability in a volunteer-run environment.
+
+**Key Features:**
+
+- **Authentication**: All POST endpoints require `CRON_SECRET` Bearer token
+- **Idempotency**: Jobs only run once per scheduled date via `withJobRun` wrapper
+- **Observability**: Job executions are logged to `JobRun` table with status tracking
+- **Fail Closed**: Missing or invalid configuration results in errors, not silent failures
+
+## Cron Endpoints
+
+### POST /api/cron/transitions
+
+Processes scheduled leadership transitions and closes completed event host records.
+
+**Schedule**: Daily at 8:00 UTC (midnight Pacific PST, 1am PDT)
+
+**Authentication**: `Authorization: Bearer <CRON_SECRET>`
+
+**Response (success):**
+```json
+{
+  "success": true,
+  "transitionsApplied": 0,
+  "eventHostsClosed": 0,
+  "runId": "uuid",
+  "requestId": "req-xxx-xxx",
+  "processedAt": "2025-01-15T08:00:00.000Z"
+}
+```
+
+**Response (skipped - already ran today):**
+```json
+{
+  "success": true,
+  "skipped": true,
+  "reason": "Job already executed for this date",
+  "runId": "uuid",
+  "requestId": "req-xxx-xxx"
+}
+```
+
+### GET /api/cron/transitions
+
+Health check endpoint (no auth required).
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "upcomingTransitionDates": ["2025-02-01T00:00:00.000Z", "2025-08-01T00:00:00.000Z"],
+  "dueTransitionsCount": 0,
+  "lastRun": {
+    "id": "uuid",
+    "scheduledFor": "2025-01-15T00:00:00.000Z",
+    "status": "SUCCESS",
+    "startedAt": "2025-01-15T08:00:00.000Z",
+    "finishedAt": "2025-01-15T08:00:05.000Z",
+    "error": null
+  }
+}
+```
+
+## Health Endpoints
+
+### GET /api/health/db
+
+Database connectivity check.
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "timestamp": "2025-01-15T08:00:00.000Z",
+  "requestId": "req-xxx-xxx",
+  "checks": {
+    "database": {
+      "status": "ok",
+      "latencyMs": 5
+    }
+  }
+}
+```
+
+### GET /api/health/auth
+
+Authentication system health check.
+
+- **Public**: Returns basic status only
+- **Admin**: Returns detailed configuration status
+
+### GET /api/health/cron
+
+Cron system health check.
+
+- **Public**: Returns basic status only
+- **Admin**: Returns detailed cron status including last runs
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `CRON_SECRET` | Bearer token for cron auth (min 16 chars) | Yes |
+| `AUTH_SECRET` | NextAuth.js secret (min 32 chars) | Yes |
+
+### Vercel Cron Configuration
+
+Add to `vercel.json`:
+
+```json
+{
+  "crons": [
+    {
+      "path": "/api/cron/transitions",
+      "schedule": "0 8 * * *"
+    }
+  ]
+}
+```
+
+## Idempotency with withJobRun
+
+The `withJobRun` helper ensures jobs only execute once per scheduled date:
+
+```typescript
+import { withJobRun, generateRequestId, verifyCronAuth } from "@/lib/cron";
+
+export async function POST(req: NextRequest) {
+  const requestId = generateRequestId();
+
+  // Verify authentication
+  const authResult = verifyCronAuth(req);
+  if (!authResult.authorized) {
+    return cronErrorResponse(authResult.error, authResult.statusCode);
+  }
+
+  // Execute with idempotency
+  const result = await withJobRun(
+    "my-job",
+    new Date(),
+    async () => {
+      // Your job logic here
+      return { processed: 42 };
+    },
+    { requestId }
+  );
+
+  return NextResponse.json({ success: true, ...result });
+}
+```
+
+### How It Works
+
+1. `withJobRun` attempts to create a `JobRun` record with `UNIQUE(jobName, scheduledFor)`
+2. If the record already exists (constraint violation), the job is skipped
+3. If created, the job executes and status is updated to `SUCCESS` or `FAILED`
+4. The `runId` is returned in all responses for tracing
+
+## JobRun Database Model
+
+```prisma
+enum JobRunStatus {
+  PENDING
+  RUNNING
+  SUCCESS
+  FAILED
+  SKIPPED
+}
+
+model JobRun {
+  id           String       @id @default(uuid())
+  jobName      String
+  scheduledFor DateTime     @db.Date
+  requestId    String?
+  status       JobRunStatus @default(PENDING)
+  startedAt    DateTime?
+  finishedAt   DateTime?
+  errorSummary String?
+  metadata     Json?
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @updatedAt
+
+  @@unique([jobName, scheduledFor])
+}
+```
+
+## Monitoring and Troubleshooting
+
+### Check Last Job Run
+
+```bash
+curl https://your-app.vercel.app/api/cron/transitions
+```
+
+Look at `lastRun.status`:
+- `SUCCESS`: Job completed normally
+- `FAILED`: Job had an error (check `lastRun.error`)
+- `RUNNING`: Job is currently executing (or crashed mid-execution)
+- `PENDING`: Job was created but never started (unusual)
+
+### Manual Trigger (Testing)
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $CRON_SECRET" \
+  https://your-app.vercel.app/api/cron/transitions
+```
+
+### View Job History
+
+Query the `JobRun` table directly:
+
+```sql
+SELECT * FROM "JobRun"
+WHERE "jobName" = 'transitions'
+ORDER BY "createdAt" DESC
+LIMIT 10;
+```
+
+### Common Issues
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| 401 Unauthorized | Invalid or missing `CRON_SECRET` | Check env var is set correctly |
+| 500 Server error | `CRON_SECRET` not configured | Set `CRON_SECRET` in env |
+| Job skipped | Already ran today | Expected behavior - check `lastRun` |
+| Job stuck in RUNNING | Crash during execution | Manual intervention needed |
+
+## Security Notes
+
+Per Charter Principle P9 (Security must fail closed):
+
+- If `CRON_SECRET` is not configured or too short, the endpoint returns 500
+- Invalid tokens return 401 (never 403 to avoid information leakage)
+- Request IDs are included for audit trail
+- No sensitive information is logged or returned in responses

--- a/src/lib/cron/auth.ts
+++ b/src/lib/cron/auth.ts
@@ -1,0 +1,81 @@
+/**
+ * Cron Authentication Helpers
+ *
+ * Charter Principles:
+ * - P9: Security must fail closed
+ * - P2: Default deny, least privilege
+ *
+ * Provides authentication for cron endpoints using CRON_SECRET.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+export interface CronAuthResult {
+  authorized: boolean;
+  error?: string;
+  statusCode?: number;
+}
+
+/**
+ * Verify cron authentication using Bearer token.
+ *
+ * Checks the Authorization header against CRON_SECRET env var.
+ * Fails closed if CRON_SECRET is not configured.
+ *
+ * @param req - The incoming request
+ * @returns CronAuthResult indicating if the request is authorized
+ */
+export function verifyCronAuth(req: NextRequest): CronAuthResult {
+  const cronSecret = process.env.CRON_SECRET;
+
+  // P9: Fail closed if CRON_SECRET not configured
+  if (!cronSecret || cronSecret.length < 16) {
+    console.error("[cron-auth] CRON_SECRET not configured or too short");
+    return {
+      authorized: false,
+      error: "Server configuration error",
+      statusCode: 500,
+    };
+  }
+
+  const authHeader = req.headers.get("authorization");
+
+  // Check for missing auth header
+  if (!authHeader) {
+    return {
+      authorized: false,
+      error: "Unauthorized",
+      statusCode: 401,
+    };
+  }
+
+  // Check Bearer token format and value
+  const expectedToken = `Bearer ${cronSecret}`;
+  if (authHeader !== expectedToken) {
+    console.warn("[cron-auth] Invalid cron token provided");
+    return {
+      authorized: false,
+      error: "Unauthorized",
+      statusCode: 401,
+    };
+  }
+
+  return { authorized: true };
+}
+
+/**
+ * Create a standardized error response for cron endpoints.
+ *
+ * @param message - Error message
+ * @param statusCode - HTTP status code
+ * @returns NextResponse with JSON error body
+ */
+export function cronErrorResponse(
+  message: string,
+  statusCode: number = 500
+): NextResponse {
+  return NextResponse.json(
+    { error: message },
+    { status: statusCode }
+  );
+}

--- a/src/lib/cron/index.ts
+++ b/src/lib/cron/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Cron Job Utilities
+ *
+ * Provides idempotent job execution, authentication, and observability
+ * for cron-over-HTTP endpoints.
+ *
+ * Charter Principles:
+ * - P7: Observability is a product feature
+ * - P9: Security must fail closed
+ */
+
+export {
+  withJobRun,
+  generateRequestId,
+  getLatestJobRun,
+  getJobRunHistory,
+  type JobRunOptions,
+  type JobRunResult,
+} from "./withJobRun";
+
+export {
+  verifyCronAuth,
+  cronErrorResponse,
+  type CronAuthResult,
+} from "./auth";

--- a/src/lib/cron/withJobRun.ts
+++ b/src/lib/cron/withJobRun.ts
@@ -1,0 +1,204 @@
+/**
+ * withJobRun - Idempotent job execution wrapper
+ *
+ * Charter Principles:
+ * - P7: Observability is a product feature (tracks job executions)
+ * - P9: Security must fail closed (handles errors gracefully)
+ *
+ * Uses the UNIQUE(jobName, scheduledFor) constraint to ensure
+ * a job only runs once per scheduled date.
+ */
+
+import { prisma } from "@/lib/prisma";
+import { JobRunStatus, Prisma } from "@prisma/client";
+
+export interface JobRunOptions {
+  requestId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface JobRunResult<T> {
+  runId: string;
+  executed: boolean;
+  status: JobRunStatus;
+  result?: T;
+  error?: string;
+}
+
+/**
+ * Generate a unique request ID for tracing
+ */
+export function generateRequestId(): string {
+  const timestamp = Date.now().toString(36);
+  const random = Math.random().toString(36).substring(2, 8);
+  return `req-${timestamp}-${random}`;
+}
+
+/**
+ * Wrap a job function with idempotency guarantee.
+ *
+ * If a job with the same name has already been executed for the given date,
+ * it will be skipped and return the existing run's status.
+ *
+ * @param jobName - Unique identifier for the job (e.g., "transitions")
+ * @param scheduledFor - The date the job is scheduled for (truncated to date)
+ * @param fn - The async function to execute
+ * @param options - Optional request ID and metadata
+ * @returns JobRunResult with execution status and optional result
+ */
+export async function withJobRun<T>(
+  jobName: string,
+  scheduledFor: Date,
+  fn: () => Promise<T>,
+  options: JobRunOptions = {}
+): Promise<JobRunResult<T>> {
+  const { requestId, metadata } = options;
+
+  // Normalize to date only (midnight UTC)
+  const normalizedDate = new Date(
+    Date.UTC(
+      scheduledFor.getFullYear(),
+      scheduledFor.getMonth(),
+      scheduledFor.getDate()
+    )
+  );
+
+  // Try to create a new job run (idempotency check via UNIQUE constraint)
+  let jobRun;
+  try {
+    jobRun = await prisma.jobRun.create({
+      data: {
+        jobName,
+        scheduledFor: normalizedDate,
+        requestId,
+        status: "PENDING",
+        metadata: metadata as Prisma.JsonObject,
+      },
+    });
+  } catch (error) {
+    // Check if this is a unique constraint violation (job already exists)
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      // Job already ran for this date - return SKIPPED
+      const existingRun = await prisma.jobRun.findUnique({
+        where: {
+          jobName_scheduledFor: {
+            jobName,
+            scheduledFor: normalizedDate,
+          },
+        },
+      });
+
+      if (existingRun) {
+        console.log(`[${jobName}] Job already executed for ${normalizedDate.toISOString().split("T")[0]}`, {
+          runId: existingRun.id,
+          status: existingRun.status,
+          requestId,
+        });
+
+        return {
+          runId: existingRun.id,
+          executed: false,
+          status: existingRun.status,
+        };
+      }
+    }
+    throw error;
+  }
+
+  // Mark as running
+  await prisma.jobRun.update({
+    where: { id: jobRun.id },
+    data: {
+      status: "RUNNING",
+      startedAt: new Date(),
+    },
+  });
+
+  console.log(`[${jobName}] Starting job execution`, {
+    runId: jobRun.id,
+    scheduledFor: normalizedDate.toISOString().split("T")[0],
+    requestId,
+  });
+
+  try {
+    // Execute the job function
+    const result = await fn();
+
+    // Mark as successful
+    await prisma.jobRun.update({
+      where: { id: jobRun.id },
+      data: {
+        status: "SUCCESS",
+        finishedAt: new Date(),
+      },
+    });
+
+    console.log(`[${jobName}] Job completed successfully`, {
+      runId: jobRun.id,
+      requestId,
+    });
+
+    return {
+      runId: jobRun.id,
+      executed: true,
+      status: "SUCCESS",
+      result,
+    };
+  } catch (error) {
+    // Mark as failed
+    const errorMessage =
+      error instanceof Error ? error.message : String(error);
+
+    await prisma.jobRun.update({
+      where: { id: jobRun.id },
+      data: {
+        status: "FAILED",
+        finishedAt: new Date(),
+        errorSummary: errorMessage.substring(0, 1000), // Truncate long errors
+      },
+    });
+
+    console.error(`[${jobName}] Job execution failed`, {
+      runId: jobRun.id,
+      error: errorMessage,
+      requestId,
+    });
+
+    return {
+      runId: jobRun.id,
+      executed: true,
+      status: "FAILED",
+      error: errorMessage,
+    };
+  }
+}
+
+/**
+ * Get the most recent job run for a given job name
+ */
+export async function getLatestJobRun(jobName: string) {
+  return prisma.jobRun.findFirst({
+    where: { jobName },
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+/**
+ * Get job run history for a given job name
+ */
+export async function getJobRunHistory(
+  jobName: string,
+  options: { limit?: number; offset?: number } = {}
+) {
+  const { limit = 10, offset = 0 } = options;
+
+  return prisma.jobRun.findMany({
+    where: { jobName },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+    skip: offset,
+  });
+}

--- a/tests/api/cron-transitions.spec.ts
+++ b/tests/api/cron-transitions.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * Cron Transitions API Tests
+ *
+ * Tests for the /api/cron/transitions endpoint:
+ * - Authentication (CRON_SECRET Bearer token)
+ * - Idempotency (calling twice runs once)
+ * - Health check endpoint
+ *
+ * Charter Principles:
+ * - P9: Security must fail closed (auth tests)
+ * - P7: Observability is a product feature (JobRun tracking)
+ */
+
+import { test, expect } from "@playwright/test";
+import { prisma } from "@/lib/prisma";
+
+const BASE = process.env.PW_BASE_URL ?? "http://localhost:3000";
+const CRON_ENDPOINT = `${BASE}/api/cron/transitions`;
+
+// Get cron secret from environment or use test value
+const CRON_SECRET = process.env.CRON_SECRET ?? "test-cron-secret-minimum-16-chars";
+
+test.describe("POST /api/cron/transitions", () => {
+  test.describe("Authentication (P9: fail closed)", () => {
+    test("returns 401 without authorization header", async ({ request }) => {
+      const response = await request.post(CRON_ENDPOINT);
+
+      expect(response.status()).toBe(401);
+
+      const data = await response.json();
+      expect(data.error).toBe("Unauthorized");
+    });
+
+    test("returns 401 with invalid authorization header", async ({ request }) => {
+      const response = await request.post(CRON_ENDPOINT, {
+        headers: {
+          Authorization: "Bearer invalid-secret",
+        },
+      });
+
+      expect(response.status()).toBe(401);
+
+      const data = await response.json();
+      expect(data.error).toBe("Unauthorized");
+    });
+
+    test("returns 401 with wrong authorization scheme", async ({ request }) => {
+      const response = await request.post(CRON_ENDPOINT, {
+        headers: {
+          Authorization: `Basic ${CRON_SECRET}`,
+        },
+      });
+
+      expect(response.status()).toBe(401);
+
+      const data = await response.json();
+      expect(data.error).toBe("Unauthorized");
+    });
+
+    test("succeeds with valid Bearer token", async ({ request }) => {
+      const response = await request.post(CRON_ENDPOINT, {
+        headers: {
+          Authorization: `Bearer ${CRON_SECRET}`,
+        },
+      });
+
+      // Should succeed (200) or skip (200 with skipped: true)
+      expect(response.status()).toBe(200);
+
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.requestId).toMatch(/^req-[a-z0-9]+-[a-z0-9]+$/);
+    });
+  });
+
+  test.describe("Idempotency", () => {
+    test.beforeAll(async () => {
+      // Clean up any existing job runs for today to ensure clean test
+      const today = new Date();
+      const todayNormalized = new Date(
+        Date.UTC(today.getFullYear(), today.getMonth(), today.getDate())
+      );
+
+      await prisma.jobRun.deleteMany({
+        where: {
+          jobName: "transitions",
+          scheduledFor: todayNormalized,
+        },
+      });
+    });
+
+    test("calling same cron twice runs only once", async ({ request }) => {
+      // First call - should execute
+      const response1 = await request.post(CRON_ENDPOINT, {
+        headers: {
+          Authorization: `Bearer ${CRON_SECRET}`,
+        },
+      });
+
+      expect(response1.status()).toBe(200);
+      const data1 = await response1.json();
+      expect(data1.success).toBe(true);
+
+      // Capture runId from first execution
+      const firstRunId = data1.runId;
+      expect(firstRunId).toBeDefined();
+
+      // If it wasn't skipped, it should not have skipped flag
+      if (!data1.skipped) {
+        expect(data1.skipped).toBeUndefined();
+      }
+
+      // Second call - should be skipped (already ran today)
+      const response2 = await request.post(CRON_ENDPOINT, {
+        headers: {
+          Authorization: `Bearer ${CRON_SECRET}`,
+        },
+      });
+
+      expect(response2.status()).toBe(200);
+      const data2 = await response2.json();
+      expect(data2.success).toBe(true);
+      expect(data2.skipped).toBe(true);
+      expect(data2.reason).toBe("Job already executed for this date");
+      expect(data2.runId).toBe(firstRunId); // Same run ID
+    });
+
+    test("returns runId in all responses", async ({ request }) => {
+      const response = await request.post(CRON_ENDPOINT, {
+        headers: {
+          Authorization: `Bearer ${CRON_SECRET}`,
+        },
+      });
+
+      expect(response.status()).toBe(200);
+      const data = await response.json();
+
+      expect(data.runId).toBeDefined();
+      expect(typeof data.runId).toBe("string");
+      expect(data.runId).toHaveLength(36); // UUID format
+    });
+  });
+});
+
+test.describe("GET /api/cron/transitions (Health Check)", () => {
+  test("returns 200 with ok status", async ({ request }) => {
+    const response = await request.get(CRON_ENDPOINT);
+
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+    expect(data.status).toBe("ok");
+  });
+
+  test("includes upcoming transition dates", async ({ request }) => {
+    const response = await request.get(CRON_ENDPOINT);
+
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+    expect(Array.isArray(data.upcomingTransitionDates)).toBe(true);
+    expect(typeof data.dueTransitionsCount).toBe("number");
+  });
+
+  test("includes last run information when available", async ({ request }) => {
+    // First, trigger a run to ensure there's a record
+    await request.post(CRON_ENDPOINT, {
+      headers: {
+        Authorization: `Bearer ${CRON_SECRET}`,
+      },
+    });
+
+    // Now check the health endpoint
+    const response = await request.get(CRON_ENDPOINT);
+
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+    // lastRun may be null if no runs exist, or an object if runs exist
+    if (data.lastRun) {
+      expect(data.lastRun.id).toBeDefined();
+      expect(data.lastRun.scheduledFor).toBeDefined();
+      expect(data.lastRun.status).toBeDefined();
+    }
+  });
+
+  test("does not require authentication", async ({ request }) => {
+    // GET endpoint should work without auth
+    const response = await request.get(CRON_ENDPOINT);
+
+    expect(response.status()).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

Implements cron-over-HTTP safety features for a volunteer-run system:

- Add `src/lib/cron/` with `withJobRun` wrapper for idempotent job execution
- Use `UNIQUE(jobName, scheduledFor)` constraint to ensure jobs run once per day
- Add `verifyCronAuth` helper for CRON_SECRET Bearer token authentication
- Update `cron/transitions` endpoint to use `withJobRun` for idempotency
- Add `cron-transitions.spec.ts` tests for auth denial and idempotency
- Add `docs/OPS/cron-jobs.md` operations documentation

## Key Features

### Idempotency

The `withJobRun` helper ensures jobs only execute once per scheduled date:
1. Attempts to create a `JobRun` record with `UNIQUE(jobName, scheduledFor)`
2. If the record already exists (constraint violation), the job is skipped
3. Status is updated to `SUCCESS` or `FAILED` after execution
4. `runId` is returned in all responses for tracing

### Authentication

- `verifyCronAuth` validates `Authorization: Bearer <CRON_SECRET>` header
- Missing or invalid tokens return 401
- Missing/short CRON_SECRET returns 500 (fail closed per P9)

## Charter Principles

- **P7**: Observability is a product feature (JobRun tracking)
- **P9**: Security must fail closed (auth failure returns errors, not silent pass)

## Files Changed

| File | Description |
|------|-------------|
| `src/lib/cron/withJobRun.ts` | Idempotent job execution wrapper |
| `src/lib/cron/auth.ts` | Cron authentication helper |
| `src/lib/cron/index.ts` | Public exports |
| `src/app/api/cron/transitions/route.ts` | Updated to use withJobRun |
| `tests/api/cron-transitions.spec.ts` | Auth and idempotency tests |
| `docs/OPS/cron-jobs.md` | Operations documentation |

## Test Plan

- [ ] Run `npm run typecheck` - no new errors
- [ ] Run tests: `npx playwright test tests/api/cron-transitions.spec.ts`
- [ ] Verify POST without auth returns 401
- [ ] Verify POST with valid auth succeeds
- [ ] Verify second POST same day returns skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)