### PR TITLE
test(env): replace direct process.env assignments with vi.stubEnv

### DIFF
--- a/scripts/dev/check-env-hygiene.sh
+++ b/scripts/dev/check-env-hygiene.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# Check Test Environment Hygiene
+#
+# This script fails if tests contain direct process.env assignments,
+# which cause TypeScript errors and can leak between tests.
+#
+# Charter P9: Fail closed - tests must be deterministic
+#
+# Usage: ./scripts/dev/check-env-hygiene.sh
+#
+# Correct pattern:
+#   vi.stubEnv("NODE_ENV", "production");
+#   vi.unstubAllEnvs(); // in afterEach
+#
+# Incorrect pattern (will fail this check):
+#   process.env.NODE_ENV = "production";
+#
+
+set -euo pipefail
+
+echo "== Test Environment Hygiene Check =="
+echo ""
+
+# Pattern to detect direct process.env assignments (not comparisons)
+PATTERN='process\.env\.[A-Z_]+\s*=\s*[^=]'
+
+# Search in tests directory
+VIOLATIONS=$(grep -rn --include="*.ts" --include="*.tsx" -E "$PATTERN" tests/ 2>/dev/null || true)
+
+if [ -n "$VIOLATIONS" ]; then
+    echo "ERROR: Found direct process.env assignments in tests"
+    echo ""
+    echo "These cause TypeScript errors and can leak between tests."
+    echo "Use vi.stubEnv() and vi.unstubAllEnvs() instead."
+    echo ""
+    echo "Violations:"
+    echo "$VIOLATIONS"
+    echo ""
+    echo "Fix: Replace with:"
+    echo '  vi.stubEnv("NODE_ENV", "production");'
+    echo ""
+    echo "  afterEach(() => {"
+    echo "    vi.unstubAllEnvs();"
+    echo "  });"
+    echo ""
+    exit 1
+fi
+
+echo "OK: No direct process.env assignments found in tests"
+exit 0

--- a/tests/helpers/env.ts
+++ b/tests/helpers/env.ts
@@ -1,0 +1,62 @@
+/**
+ * Test Environment Helpers
+ *
+ * Provides utilities for safely stubbing environment variables in tests.
+ * Uses Vitest's vi.stubEnv() to avoid TypeScript errors from direct assignment.
+ *
+ * Usage:
+ *   import { stubProductionEnv, unstubAllEnvs } from "@/tests/helpers/env";
+ *
+ *   describe("Production Safety", () => {
+ *     afterEach(() => {
+ *       unstubAllEnvs();
+ *     });
+ *
+ *     it("should behave differently in production", () => {
+ *       stubProductionEnv();
+ *       // test code...
+ *     });
+ *   });
+ */
+
+import { vi } from "vitest";
+
+/**
+ * Stub NODE_ENV to "production" for testing production-only behavior.
+ * Must call unstubAllEnvs() in afterEach to prevent test leakage.
+ */
+export function stubProductionEnv(): void {
+  vi.stubEnv("NODE_ENV", "production");
+}
+
+/**
+ * Stub NODE_ENV to "development" for testing dev-only behavior.
+ * Must call unstubAllEnvs() in afterEach to prevent test leakage.
+ */
+export function stubDevelopmentEnv(): void {
+  vi.stubEnv("NODE_ENV", "development");
+}
+
+/**
+ * Stub NODE_ENV to "test" for testing test-specific behavior.
+ * Must call unstubAllEnvs() in afterEach to prevent test leakage.
+ */
+export function stubTestEnv(): void {
+  vi.stubEnv("NODE_ENV", "test");
+}
+
+/**
+ * Stub any environment variable.
+ * Must call unstubAllEnvs() in afterEach to prevent test leakage.
+ */
+export function stubEnv(key: string, value: string): void {
+  vi.stubEnv(key, value);
+}
+
+/**
+ * Remove all environment stubs. Call this in afterEach to ensure
+ * clean state between tests.
+ */
+export function unstubAllEnvs(): void {
+  vi.unstubAllEnvs();
+}

--- a/tests/unit/payments-idempotency.spec.ts
+++ b/tests/unit/payments-idempotency.spec.ts
@@ -274,19 +274,19 @@ describe("Payment Idempotency", () => {
 });
 
 describe("Production Safety", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("fake provider returns false for isAvailable in production", () => {
-    const originalEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
 
     const provider = new FakePaymentProvider();
     expect(provider.isAvailable()).toBe(false);
-
-    process.env.NODE_ENV = originalEnv;
   });
 
   it("fake provider throws error on createPaymentIntent in production", async () => {
-    const originalEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
 
     const provider = new FakePaymentProvider();
 
@@ -297,7 +297,5 @@ describe("Production Safety", () => {
         idempotencyKey: "test-key",
       })
     ).rejects.toThrow("Fake payment provider is not available in production");
-
-    process.env.NODE_ENV = originalEnv;
   });
 });


### PR DESCRIPTION
## Summary
- Replace `process.env.NODE_ENV = ...` with `vi.stubEnv("NODE_ENV", ...)`
- Add `vi.unstubAllEnvs()` in afterEach to prevent test leakage
- Add CI guardrail script to detect direct env assignments
- Add test helper for standardized env stubbing

## Charter Compliance
- **P9** (Fail closed): Tests must be deterministic - no leakage between tests
- General test hygiene: TypeScript treats `process.env.NODE_ENV` as read-only

## Changes
- `tests/unit/payments-idempotency.spec.ts` - Use vi.stubEnv pattern
- `scripts/dev/check-env-hygiene.sh` - CI guardrail script
- `tests/helpers/env.ts` - Helper utilities for env stubbing

## Test plan
- [x] `npm run test:unit -- tests/unit/payments-idempotency.spec.ts` passes (9 tests)
- [x] `scripts/dev/check-env-hygiene.sh` passes (no violations)
- [x] No direct `process.env.X =` assignments in tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)