### PR TITLE
fix(types): resolve officer and governance type errors [P9]

### DIFF
--- a/src/app/api/v1/officer/board-records/route.ts
+++ b/src/app/api/v1/officer/board-records/route.ts
@@ -12,7 +12,7 @@ import {
   createBoardRecord,
   listBoardRecords,
 } from "@/lib/governance/boardRecords";
-import type { BoardRecordStatus } from "@prisma/client";
+import type { BoardRecordStatus } from "@/lib/governance/types";
 
 /**
  * GET /api/v1/officer/board-records

--- a/src/app/api/v1/officer/governance/annotations/route.ts
+++ b/src/app/api/v1/officer/governance/annotations/route.ts
@@ -12,7 +12,7 @@ import {
   listAnnotations,
   getAnnotationCounts,
 } from "@/lib/governance/annotations";
-import type { AnnotationSeverity } from "@prisma/client";
+import type { AnnotationSeverity } from "@/lib/governance/types";
 
 /**
  * GET /api/v1/officer/governance/annotations

--- a/src/app/api/v1/officer/governance/flags/route.ts
+++ b/src/app/api/v1/officer/governance/flags/route.ts
@@ -12,7 +12,7 @@ import {
   createGovernanceFlag,
   listGovernanceFlags,
 } from "@/lib/governance/flags";
-import type { GovernanceFlagType, GovernanceFlagStatus } from "@prisma/client";
+import type { GovernanceFlagType, GovernanceFlagStatus } from "@/lib/governance/types";
 
 /**
  * GET /api/v1/officer/governance/flags

--- a/src/app/api/v1/officer/meetings/[id]/route.ts
+++ b/src/app/api/v1/officer/meetings/[id]/route.ts
@@ -10,7 +10,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireCapability, hasCapability } from "@/lib/auth";
 import { auditMutation } from "@/lib/audit";
 import { getMeeting, updateMeeting, deleteMeeting } from "@/lib/meetings/meetings";
-import type { MeetingType } from "@prisma/client";
+import type { MeetingType } from "@/lib/governance/types";
 
 type RouteParams = {
   params: Promise<{ id: string }>;

--- a/src/app/api/v1/officer/meetings/route.ts
+++ b/src/app/api/v1/officer/meetings/route.ts
@@ -9,7 +9,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireCapability } from "@/lib/auth";
 import { auditMutation } from "@/lib/audit";
 import { createMeeting, listMeetings, getMeetingsNeedingMinutes } from "@/lib/meetings/meetings";
-import type { MeetingType } from "@prisma/client";
+import type { MeetingType } from "@/lib/governance/types";
 
 /**
  * GET /api/v1/officer/meetings

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -59,7 +59,29 @@ export type Capability =
   | "transitions:approve"   // Approve transition plans
   | "users:manage"          // Create/update user roles and entitlements
   | "admin:full"            // Full admin access (implies all capabilities)
-  | "debug:readonly";       // Debug read-only access (for support, default OFF)
+  | "debug:readonly"        // Debug read-only access (for support, default OFF)
+  // Officer portal: Meetings
+  | "meetings:read"                     // View meetings list and details
+  | "meetings:motions:read"             // View motions within meetings
+  | "meetings:motions:annotate"         // Add annotations to motions
+  | "meetings:minutes:draft:create"     // Create draft minutes
+  | "meetings:minutes:draft:edit"       // Edit draft minutes
+  | "meetings:minutes:draft:submit"     // Submit draft for review
+  | "meetings:minutes:read_all"         // View all minutes including drafts
+  | "meetings:minutes:revise"           // Revise minutes after submission
+  | "meetings:minutes:finalize"         // Finalize minutes
+  // Officer portal: Board Records
+  | "board_records:read"                // View board records
+  | "board_records:draft:create"        // Create draft board records
+  | "board_records:draft:edit"          // Edit draft board records
+  | "board_records:draft:submit"        // Submit draft for review
+  // Officer portal: Governance
+  | "governance:flags:create"           // Create governance flags
+  | "governance:flags:resolve"          // Resolve governance flags
+  | "governance:rules:manage"           // Manage rules guidance
+  // Content publishing
+  | "content:board:publish"             // Publish board content
+  | "content:board:request_publish";    // Request board content publication
 
 /**
  * Map of which capabilities each role has.

--- a/src/lib/governance/annotations.ts
+++ b/src/lib/governance/annotations.ts
@@ -1,0 +1,9 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars */
+export async function createAnnotation(_p: any): Promise<any> { throw new Error("Not implemented"); }
+export async function listAnnotations(_p: any): Promise<any> { throw new Error("Not implemented"); }
+export async function getAnnotationCounts(_p: any): Promise<any> { throw new Error("Not implemented"); }
+export async function getAnnotation(_id: string): Promise<any> { throw new Error("Not implemented"); }
+export async function updateAnnotation(_id: string, _d: any): Promise<any> { throw new Error("Not implemented"); }
+export async function deleteAnnotation(_id: string): Promise<void> { throw new Error("Not implemented"); }
+export async function resolveAnnotation(_id: string, _memberId?: string): Promise<any> { throw new Error("Not implemented"); }
+export async function reopenAnnotation(_id: string): Promise<any> { throw new Error("Not implemented"); }

--- a/src/lib/governance/boardRecords.ts
+++ b/src/lib/governance/boardRecords.ts
@@ -1,0 +1,9 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars */
+export async function createBoardRecord(_p: any): Promise<any> { throw new Error("Not implemented"); }
+export async function listBoardRecords(_p: any): Promise<any> { throw new Error("Not implemented"); }
+export async function getBoardRecord(_id: string): Promise<any> { throw new Error("Not implemented"); }
+export async function updateBoardRecord(_id: string, _d: any): Promise<any> { throw new Error("Not implemented"); }
+export async function deleteBoardRecord(_id: string): Promise<void> { throw new Error("Not implemented"); }
+export async function submitBoardRecord(_id: string, _m: string): Promise<any> { throw new Error("Not implemented"); }
+export async function approveBoardRecord(..._args: any[]): Promise<any> { throw new Error("Not implemented"); }
+export async function publishBoardRecord(_id: string, _m: string): Promise<any> { throw new Error("Not implemented"); }

--- a/src/lib/governance/flags.ts
+++ b/src/lib/governance/flags.ts
@@ -1,0 +1,9 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars */
+export async function createGovernanceFlag(_p: any): Promise<any> { throw new Error("Not implemented"); }
+export async function listGovernanceFlags(_p: any): Promise<any> { throw new Error("Not implemented"); }
+export async function getGovernanceFlag(_id: string): Promise<any> { throw new Error("Not implemented"); }
+export async function updateGovernanceFlag(_id: string, _d: any): Promise<any> { throw new Error("Not implemented"); }
+export async function deleteGovernanceFlag(_id: string): Promise<void> { throw new Error("Not implemented"); }
+export async function startFlagReview(_id: string, _m: string): Promise<any> { throw new Error("Not implemented"); }
+export async function resolveGovernanceFlag(..._args: any[]): Promise<any> { throw new Error("Not implemented"); }
+export async function dismissGovernanceFlag(..._args: any[]): Promise<any> { throw new Error("Not implemented"); }

--- a/src/lib/governance/rulesGuidance.ts
+++ b/src/lib/governance/rulesGuidance.ts
@@ -1,0 +1,8 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars */
+export async function createRulesGuidance(_p: any): Promise<any> { throw new Error("Not implemented"); }
+export async function listRulesGuidance(_p: any): Promise<any> { throw new Error("Not implemented"); }
+export async function searchRulesGuidance(..._args: any[]): Promise<any[]> { throw new Error("Not implemented"); }
+export async function getGuidanceCategories(): Promise<string[]> { throw new Error("Not implemented"); }
+export async function getRulesGuidance(_id: string): Promise<any> { throw new Error("Not implemented"); }
+export async function updateRulesGuidance(_id: string, _d: any): Promise<any> { throw new Error("Not implemented"); }
+export async function deleteRulesGuidance(_id: string): Promise<void> { throw new Error("Not implemented"); }

--- a/src/lib/governance/types.ts
+++ b/src/lib/governance/types.ts
@@ -1,0 +1,55 @@
+/**
+ * Governance Types
+ *
+ * Local type definitions for governance domain to avoid
+ * modifying Prisma schema until feature is production-ready.
+ *
+ * Charter P9: Fail closed - using explicit string unions
+ * instead of open string types.
+ */
+
+// Board record lifecycle status
+export type BoardRecordStatus =
+  | "DRAFT"
+  | "SUBMITTED"
+  | "IN_REVIEW"
+  | "PUBLISHED"
+  | "ARCHIVED";
+
+// Meeting types for governance
+export type MeetingType =
+  | "BOARD"
+  | "EXECUTIVE"
+  | "SPECIAL"
+  | "ANNUAL";
+
+// Governance flag types for review workflows
+export type GovernanceFlagType =
+  | "RULES_QUESTION"
+  | "BYLAWS_CHECK"
+  | "INSURANCE_REVIEW"
+  | "LEGAL_REVIEW"
+  | "OTHER";
+
+// Governance flag lifecycle status
+export type GovernanceFlagStatus =
+  | "OPEN"
+  | "IN_REVIEW"
+  | "RESOLVED"
+  | "DISMISSED";
+
+// Annotation severity levels
+export type AnnotationSeverity =
+  | "INFO"
+  | "SUGGESTION"
+  | "WARNING"
+  | "ERROR";
+
+// Minutes document status
+export type MinutesStatus =
+  | "DRAFT"
+  | "SUBMITTED"
+  | "IN_REVIEW"
+  | "APPROVED"
+  | "PUBLISHED"
+  | "ARCHIVED";

--- a/src/lib/meetings/meetings.ts
+++ b/src/lib/meetings/meetings.ts
@@ -1,0 +1,7 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars */
+export async function createMeeting(_p: any): Promise<any> { throw new Error("Not implemented"); }
+export async function listMeetings(_p: any): Promise<any> { throw new Error("Not implemented"); }
+export async function getMeetingsNeedingMinutes(): Promise<any[]> { throw new Error("Not implemented"); }
+export async function getMeeting(_id: string): Promise<any> { throw new Error("Not implemented"); }
+export async function updateMeeting(_id: string, _d: any): Promise<any> { throw new Error("Not implemented"); }
+export async function deleteMeeting(_id: string): Promise<void> { throw new Error("Not implemented"); }

--- a/src/lib/meetings/minutes.ts
+++ b/src/lib/meetings/minutes.ts
@@ -1,0 +1,10 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars */
+export async function createMinutes(_p: any): Promise<any> { throw new Error("Not implemented"); }
+export async function getMinutesByMeeting(_id: string): Promise<any> { throw new Error("Not implemented"); }
+export async function updateMinutes(_id: string, _d: any): Promise<any> { throw new Error("Not implemented"); }
+export async function submitMinutesForReview(..._args: any[]): Promise<any> { throw new Error("Not implemented"); }
+export async function reviewMinutes(..._args: any[]): Promise<any> { throw new Error("Not implemented"); }
+export async function reviseMinutes(..._args: any[]): Promise<any> { throw new Error("Not implemented"); }
+export async function finalizeMinutes(_id: string, _m: string): Promise<any> { throw new Error("Not implemented"); }
+export async function requestMinutesPublish(..._args: any[]): Promise<any> { throw new Error("Not implemented"); }
+export async function publishMinutes(_id: string, _m: string, _url?: string): Promise<any> { throw new Error("Not implemented"); }


### PR DESCRIPTION
## Summary

- Add officer/governance capabilities to auth.ts Capability type:
  - `meetings:read`, `meetings:motions:*`, `meetings:minutes:*`
  - `board_records:read`, `board_records:draft:*`
  - `governance:flags:*`, `governance:rules:manage`
  - `content:board:publish`, `content:board:request_publish`

- Create local governance/types.ts with type definitions:
  - BoardRecordStatus, MeetingType, GovernanceFlagType
  - GovernanceFlagStatus, AnnotationSeverity, MinutesStatus

- Create stub modules (not-implemented placeholders):
  - `src/lib/governance/boardRecords.ts`, `annotations.ts`, `flags.ts`, `rulesGuidance.ts`
  - `src/lib/meetings/meetings.ts`, `minutes.ts`

- Update route imports from `@prisma/client` to `@/lib/governance/types`

- Fix payments-idempotency.spec.ts:
  - Replace process.env.NODE_ENV assignment with vi.stubEnv()
  - Add vi.unstubAllEnvs() in afterEach
  - Fix mockImplementation type issue with mockResolvedValueOnce

## Test plan

- [x] `npm run typecheck` passes cleanly
- [x] `npm run test:unit` passes (307 tests)

## Charter References

- **P9 (Fail closed)**: Local types use explicit string unions instead of open string types
- **P2 (Default deny)**: Capabilities are explicitly listed, not inferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)