### PR TITLE
feat(comms): Email templates and composer system

### DIFF
--- a/docs/comms/EMAIL_SYSTEM.md
+++ b/docs/comms/EMAIL_SYSTEM.md
@@ -1,0 +1,255 @@
+# Email System Documentation
+
+## Overview
+
+The ClubOS email system provides a complete solution for composing and sending emails using sbnewcomers.org addresses. It includes:
+
+- **Email Identities**: Manage from-addresses with role-based access control
+- **Message Templates**: Reusable templates with variable substitution
+- **Email Composer**: Interface for composing and sending emails
+- **Outbox**: Track email delivery status
+
+## Architecture
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│  Email Identity │────▶│  Email Composer │────▶│  Email Outbox   │
+│  (from-address) │     │  (templates +   │     │  (status track) │
+│  Role-based     │     │   recipients)   │     │                 │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+                               │
+                               ▼
+                        ┌─────────────────┐
+                        │  SMTP Provider  │
+                        │  (stub in dev)  │
+                        └─────────────────┘
+```
+
+## Email Identities
+
+### What They Are
+
+Email identities represent the "from" addresses available for sending emails (e.g., `president@sbnewcomers.org`). Each identity has:
+
+- **Email**: The actual email address
+- **Display Name**: Shown in email clients (e.g., "SBNC President")
+- **Allowed Roles**: Which roles can send using this identity
+- **Reply-To**: Optional different reply address
+
+### Role-Based Access
+
+Identities are controlled by roles. Only users with matching roles can send from that identity:
+
+| Identity | Allowed Roles |
+|----------|---------------|
+| `president@sbnewcomers.org` | president, admin |
+| `vp@sbnewcomers.org` | vp-activities, admin |
+| `webmaster@sbnewcomers.org` | webmaster, admin |
+| `info@sbnewcomers.org` | president, vp-activities, webmaster, admin |
+
+Admin role can always use any identity.
+
+### API Endpoints
+
+| Endpoint | Method | Description | Capability Required |
+|----------|--------|-------------|---------------------|
+| `/api/v1/admin/comms/identities` | GET | List all identities | comms:manage |
+| `/api/v1/admin/comms/identities` | POST | Create identity | admin:full |
+| `/api/v1/admin/comms/identities/:id` | GET | Get identity | comms:manage |
+| `/api/v1/admin/comms/identities/:id` | PUT | Update identity | admin:full |
+| `/api/v1/admin/comms/identities/:id` | DELETE | Deactivate identity | admin:full |
+
+## Message Templates
+
+### Template Variables
+
+Templates support variable substitution using `{{category.field}}` syntax:
+
+**Member Variables**
+- `{{member.firstName}}` - Member first name
+- `{{member.lastName}}` - Member last name
+- `{{member.fullName}}` - Full name
+- `{{member.email}}` - Email address
+- `{{member.phone}}` - Phone number
+
+**Event Variables**
+- `{{event.title}}` - Event title
+- `{{event.description}}` - Event description
+- `{{event.location}}` - Event location
+- `{{event.startDate}}` - Start date (formatted)
+- `{{event.startTime}}` - Start time (formatted)
+- `{{event.endDate}}` - End date
+- `{{event.endTime}}` - End time
+- `{{event.category}}` - Event category
+
+**Club Variables**
+- `{{club.name}}` - Club name
+- `{{club.website}}` - Club website URL
+- `{{club.email}}` - Club contact email
+
+**System Variables**
+- `{{currentYear}}` - Current year
+- `{{currentDate}}` - Current date
+
+### Template Safety
+
+All variable values are HTML-escaped to prevent XSS attacks. Missing values render as empty strings.
+
+### API Endpoints
+
+| Endpoint | Method | Description | Capability Required |
+|----------|--------|-------------|---------------------|
+| `/api/v1/admin/comms/templates` | GET | List templates | comms:manage |
+| `/api/v1/admin/comms/templates` | POST | Create template | comms:manage |
+| `/api/v1/admin/comms/templates/:id` | GET | Get template | comms:manage |
+| `/api/v1/admin/comms/templates/:id` | PUT | Update template | comms:manage |
+| `/api/v1/admin/comms/templates/:id` | DELETE | Deactivate template | comms:manage |
+| `/api/v1/admin/comms/templates/:id/preview` | POST | Preview with sample data | comms:manage |
+| `/api/v1/admin/comms/templates/:id/test-send` | POST | Send test email | comms:send |
+| `/api/v1/admin/comms/templates/tokens` | GET | List available tokens | comms:manage |
+
+## Email Composer
+
+### Compose Flow
+
+1. Select from-address identity (role-restricted)
+2. Choose template or write custom content
+3. Add recipients (manual or from saved lists)
+4. Preview the email
+5. Send immediately, schedule, or save as draft
+
+### API Endpoint
+
+| Endpoint | Method | Description | Capability Required |
+|----------|--------|-------------|---------------------|
+| `/api/v1/admin/comms/compose` | POST | Compose and send | comms:send |
+
+### Compose Request Body
+
+```json
+{
+  "identityId": "uuid",
+  "templateId": "uuid (optional)",
+  "subject": "string (required if no template)",
+  "bodyHtml": "string (required if no template)",
+  "recipients": [
+    { "email": "user@example.com", "name": "John Doe", "memberId": "uuid (optional)" }
+  ],
+  "scheduledFor": "ISO date string (optional)",
+  "sendImmediately": true,
+  "idempotencyKey": "client-key (optional)"
+}
+```
+
+## Email Outbox
+
+### Status Lifecycle
+
+```
+DRAFT → QUEUED → SENDING → SENT → DELIVERED
+                    │          │
+                    │          └→ BOUNCED
+                    └→ FAILED
+```
+
+| Status | Description |
+|--------|-------------|
+| DRAFT | Composed but not queued |
+| QUEUED | Ready to send |
+| SENDING | Currently being processed |
+| SENT | Delivered to SMTP |
+| DELIVERED | Delivery confirmed |
+| BOUNCED | Permanent delivery failure |
+| FAILED | Send failed (SMTP error) |
+
+### API Endpoint
+
+| Endpoint | Method | Description | Capability Required |
+|----------|--------|-------------|---------------------|
+| `/api/v1/admin/comms/outbox` | GET | List outbox items | comms:manage |
+
+## UI Pages
+
+| Path | Description |
+|------|-------------|
+| `/admin/comms/identities` | Manage email identities |
+| `/admin/comms/templates` | Manage message templates |
+| `/admin/comms/compose` | Compose and send emails |
+
+## Permissions
+
+### Capabilities
+
+- **comms:manage** - Create/edit templates, view identities, view outbox
+- **comms:send** - Send emails (test send, compose)
+- **admin:full** - Create/edit identities, full access
+
+### Role Mapping
+
+| Role | comms:manage | comms:send |
+|------|--------------|------------|
+| admin | ✓ | ✓ |
+| president | ✗ | ✗ |
+| webmaster | ✓ | ✗ |
+
+Note: Webmaster can manage templates but cannot send without additional capability.
+
+## Security Considerations
+
+### Charter Compliance
+
+- **P1 (Provable Identity)**: All sends are attributed to authenticated users
+- **P2 (Default Deny)**: Role-based identity access, capability checks on all endpoints
+- **P3 (State Machine)**: Email lifecycle uses explicit OutboxStatus enum
+- **P4 (No Hidden Rules)**: Token documentation available via API
+- **P5 (Reversible)**: Soft delete for identities and templates
+- **N5 (Idempotent)**: Idempotency keys prevent duplicate sends
+- **N7 (PII)**: Minimal member data in templates, no unnecessary exposure
+- **N8 (Template Safety)**: HTML escaping, preview before send
+
+### Audit Trail
+
+All significant actions are logged to AuditLog:
+- Identity create/update/delete
+- Template create/update/delete
+- Test sends
+- Compose sends
+
+## Testing
+
+### Test Send
+
+Use the test-send endpoint to verify templates before sending to real recipients:
+
+```bash
+curl -X POST /api/v1/admin/comms/templates/:id/test-send \
+  -H "Content-Type: application/json" \
+  -d '{"to": "test@example.com", "identityId": "uuid"}'
+```
+
+### E2E Tests
+
+```bash
+# Run comms-specific tests
+npm run test-admin -- --grep comms
+```
+
+## Configuration
+
+### Environment Variables
+
+```env
+# SMTP Configuration (future)
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=user
+SMTP_PASS=password
+
+# Default uses stub provider in development
+```
+
+### Database Migration
+
+```bash
+npx prisma migrate dev --name add-email-identity-outbox
+```

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -107,6 +107,10 @@ model Member {
   deliveryLogs     DeliveryLog[]
   auditLogs        AuditLog[]
 
+  // Email outbox relations
+  outboxRecipient  EmailOutbox[]     @relation()
+  outboxCreated    EmailOutbox[]     @relation("OutboxCreatedBy")
+
   @@index([membershipStatusId])
 }
 
@@ -668,6 +672,7 @@ model MessageTemplate {
 
   template         Template?         @relation(fields: [templateId], references: [id])
   messageCampaigns MessageCampaign[]
+  outboxItems      EmailOutbox[]
 
   @@index([isActive])
 }
@@ -694,6 +699,7 @@ model MessageCampaign {
   audienceRule    AudienceRule?   @relation(fields: [audienceRuleId], references: [id])
   createdBy       Member?         @relation(fields: [createdById], references: [id])
   deliveryLogs    DeliveryLog[]
+  outboxItems     EmailOutbox[]
 
   @@index([status])
   @@index([scheduledAt])
@@ -768,4 +774,93 @@ model JobRun {
   @@index([status])
   @@index([scheduledFor])
   @@index([createdAt])
+}
+
+// ============================================================================
+// EMAIL IDENTITY AND OUTBOX SYSTEM
+// Copyright (c) Santa Barbara Newcomers Club
+// Charter P1: Provable identity - emails sent from verified identities only
+// Charter P2: Default deny - role-based control of from-addresses
+// Charter P3: State machine for email lifecycle
+// ============================================================================
+
+// Email send status lifecycle
+enum OutboxStatus {
+  DRAFT      // Composed but not yet queued
+  QUEUED     // Ready to send
+  SENDING    // Currently being processed
+  SENT       // Successfully delivered to SMTP
+  DELIVERED  // Delivery confirmed (if tracking available)
+  BOUNCED    // Delivery failed permanently
+  FAILED     // Send failed (SMTP error)
+}
+
+// EmailIdentity - Sender identities (from-addresses) for sbnewcomers.org
+// Charter P2: Role-based control of who can send as which address
+model EmailIdentity {
+  id          String   @id @default(uuid()) @db.Uuid
+  email       String   @unique // e.g., president@sbnewcomers.org
+  displayName String // e.g., "SBNC President"
+  description String? // Purpose of this identity
+  replyTo     String? // Optional reply-to address
+  isActive    Boolean  @default(true)
+  isDefault   Boolean  @default(false) // Default identity for new campaigns
+  smtpConfig  Json? // SMTP settings if different from default
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  // Roles that can use this identity (stored as JSON array of role slugs)
+  // e.g., ["president", "admin"] means only those roles can send as this address
+  allowedRoles Json @default("[]")
+
+  outboxItems EmailOutbox[]
+
+  @@index([isActive])
+  @@index([isDefault])
+}
+
+// EmailOutbox - Individual email items pending/sent
+// Charter P3: Explicit state machine for email lifecycle
+// Charter N5: Idempotent - use idempotencyKey to prevent duplicates
+model EmailOutbox {
+  id              String       @id @default(uuid()) @db.Uuid
+  idempotencyKey  String?      @unique // Client-provided key to prevent duplicate sends
+  identityId      String       @db.Uuid
+  campaignId      String?      @db.Uuid // Link to campaign if part of one
+  recipientEmail  String
+  recipientId     String?      @db.Uuid // Link to member if known
+  recipientName   String? // Display name for recipient
+  subject         String
+  bodyHtml        String       @db.Text
+  bodyText        String?      @db.Text
+  templateId      String?      @db.Uuid // Template used (for reference)
+  templateData    Json? // Variables used for rendering
+  status          OutboxStatus @default(DRAFT)
+  scheduledFor    DateTime? // When to send (null = immediate)
+  sentAt          DateTime? // When actually sent
+  deliveredAt     DateTime? // When delivery confirmed
+  bouncedAt       DateTime?
+  bounceReason    String?
+  providerMsgId   String? // Message ID from SMTP/provider
+  errorMessage    String? // Error details if failed
+  retryCount      Int          @default(0)
+  lastRetryAt     DateTime?
+  createdById     String?      @db.Uuid // Who composed this email
+  createdAt       DateTime     @default(now())
+  updatedAt       DateTime     @updatedAt
+
+  identity  EmailIdentity    @relation(fields: [identityId], references: [id])
+  campaign  MessageCampaign? @relation(fields: [campaignId], references: [id])
+  recipient Member?          @relation(fields: [recipientId], references: [id])
+  template  MessageTemplate? @relation(fields: [templateId], references: [id])
+  createdBy Member?          @relation("OutboxCreatedBy", fields: [createdById], references: [id])
+
+  @@index([status])
+  @@index([identityId])
+  @@index([campaignId])
+  @@index([recipientId])
+  @@index([recipientEmail])
+  @@index([scheduledFor])
+  @@index([createdAt])
+  @@index([status, scheduledFor])
 }

--- a/src/app/admin/comms/compose/EmailComposer.tsx
+++ b/src/app/admin/comms/compose/EmailComposer.tsx
@@ -1,0 +1,496 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+
+type EmailIdentity = {
+  id: string;
+  email: string;
+  displayName: string;
+  canUse: boolean;
+};
+
+type MessageTemplate = {
+  id: string;
+  name: string;
+  slug: string;
+  subject: string;
+};
+
+type Recipient = {
+  email: string;
+  name: string;
+};
+
+type PreviewData = {
+  subject: string;
+  html: string;
+};
+
+export default function EmailComposer() {
+  const [identities, setIdentities] = useState<EmailIdentity[]>([]);
+  const [templates, setTemplates] = useState<MessageTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  // Form state
+  const [selectedIdentityId, setSelectedIdentityId] = useState("");
+  const [selectedTemplateId, setSelectedTemplateId] = useState("");
+  const [subject, setSubject] = useState("");
+  const [bodyHtml, setBodyHtml] = useState("");
+  const [recipients, setRecipients] = useState<Recipient[]>([]);
+  const [newRecipientEmail, setNewRecipientEmail] = useState("");
+  const [newRecipientName, setNewRecipientName] = useState("");
+  const [scheduledFor, setScheduledFor] = useState("");
+  const [sendImmediately, setSendImmediately] = useState(false);
+
+  // Preview state
+  const [preview, setPreview] = useState<PreviewData | null>(null);
+  const [showPreview, setShowPreview] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [identitiesRes, templatesRes] = await Promise.all([
+        fetch("/api/v1/admin/comms/identities?onlyUsable=true"),
+        fetch("/api/v1/admin/comms/templates"),
+      ]);
+
+      if (!identitiesRes.ok || !templatesRes.ok) {
+        throw new Error("Failed to fetch data");
+      }
+
+      const [identitiesData, templatesData] = await Promise.all([
+        identitiesRes.json(),
+        templatesRes.json(),
+      ]);
+
+      setIdentities(identitiesData.items);
+      setTemplates(templatesData.items);
+
+      // Set default identity
+      const defaultIdentity = identitiesData.items.find((i: EmailIdentity) => i.canUse);
+      if (defaultIdentity) {
+        setSelectedIdentityId(defaultIdentity.id);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // When template is selected, populate subject
+  useEffect(() => {
+    if (selectedTemplateId) {
+      const template = templates.find((t) => t.id === selectedTemplateId);
+      if (template) {
+        setSubject(template.subject);
+      }
+    }
+  }, [selectedTemplateId, templates]);
+
+  const addRecipient = () => {
+    if (!newRecipientEmail) return;
+
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(newRecipientEmail)) {
+      setError("Invalid email address");
+      return;
+    }
+
+    if (recipients.some((r) => r.email === newRecipientEmail)) {
+      setError("Recipient already added");
+      return;
+    }
+
+    setRecipients([...recipients, { email: newRecipientEmail, name: newRecipientName }]);
+    setNewRecipientEmail("");
+    setNewRecipientName("");
+    setError(null);
+  };
+
+  const removeRecipient = (email: string) => {
+    setRecipients(recipients.filter((r) => r.email !== email));
+  };
+
+  const handlePreview = async () => {
+    if (!selectedTemplateId) {
+      setError("Select a template to preview");
+      return;
+    }
+
+    try {
+      const res = await fetch(`/api/v1/admin/comms/templates/${selectedTemplateId}/preview`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+
+      if (!res.ok) throw new Error("Failed to generate preview");
+
+      const data = await res.json();
+      setPreview({
+        subject: data.preview.subject,
+        html: data.preview.html,
+      });
+      setShowPreview(true);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  const handleTestSend = async () => {
+    const testEmail = prompt("Enter email address for test send:");
+    if (!testEmail) return;
+
+    if (!selectedTemplateId || !selectedIdentityId) {
+      setError("Select a template and identity first");
+      return;
+    }
+
+    try {
+      const res = await fetch(`/api/v1/admin/comms/templates/${selectedTemplateId}/test-send`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          to: testEmail,
+          identityId: selectedIdentityId,
+        }),
+      });
+
+      if (!res.ok) {
+        const errData = await res.json();
+        throw new Error(errData.message || "Failed to send test email");
+      }
+
+      const data = await res.json();
+      setSuccess(`Test email sent to ${testEmail} (ID: ${data.messageId})`);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      setSuccess(null);
+    }
+  };
+
+  const handleSend = async () => {
+    setError(null);
+    setSuccess(null);
+
+    if (!selectedIdentityId) {
+      setError("Select a sender identity");
+      return;
+    }
+
+    if (recipients.length === 0) {
+      setError("Add at least one recipient");
+      return;
+    }
+
+    if (!selectedTemplateId && !subject) {
+      setError("Select a template or enter a subject");
+      return;
+    }
+
+    const payload: Record<string, unknown> = {
+      identityId: selectedIdentityId,
+      recipients: recipients.map((r) => ({ email: r.email, name: r.name || undefined })),
+      sendImmediately,
+    };
+
+    if (selectedTemplateId) {
+      payload.templateId = selectedTemplateId;
+    } else {
+      payload.subject = subject;
+      payload.bodyHtml = bodyHtml || "<p>No content</p>";
+    }
+
+    if (scheduledFor) {
+      payload.scheduledFor = new Date(scheduledFor).toISOString();
+    }
+
+    try {
+      const res = await fetch("/api/v1/admin/comms/compose", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const errData = await res.json();
+        throw new Error(errData.message || "Failed to send email");
+      }
+
+      const data = await res.json();
+      const statusMsg = sendImmediately
+        ? `Sent ${data.outboxCount} email(s)`
+        : scheduledFor
+          ? `Scheduled ${data.outboxCount} email(s)`
+          : `Queued ${data.outboxCount} email(s) as drafts`;
+
+      setSuccess(statusMsg);
+      setRecipients([]);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <div style={{ maxWidth: "800px" }}>
+      {error && (
+        <div style={{ padding: "12px", backgroundColor: "#fee", color: "#c00", marginBottom: "16px", borderRadius: "4px" }}>
+          {error}
+        </div>
+      )}
+      {success && (
+        <div style={{ padding: "12px", backgroundColor: "#e6f4ea", color: "#1e7e34", marginBottom: "16px", borderRadius: "4px" }}>
+          {success}
+        </div>
+      )}
+
+      {/* From Address */}
+      <div style={{ marginBottom: "20px" }}>
+        <label style={{ display: "block", marginBottom: "8px", fontWeight: 600, fontSize: "14px" }}>
+          From address *
+        </label>
+        <select
+          value={selectedIdentityId}
+          onChange={(e) => setSelectedIdentityId(e.target.value)}
+          style={{ width: "100%", padding: "10px", borderRadius: "4px", border: "1px solid #ccc", fontSize: "14px" }}
+          data-test-id="identity-select"
+        >
+          <option value="">Select sender identity...</option>
+          {identities.map((identity) => (
+            <option key={identity.id} value={identity.id}>
+              {identity.displayName} &lt;{identity.email}&gt;
+            </option>
+          ))}
+        </select>
+        {identities.length === 0 && (
+          <small style={{ color: "#c00" }}>No identities available. You may not have permission to send emails.</small>
+        )}
+      </div>
+
+      {/* Template Selection */}
+      <div style={{ marginBottom: "20px" }}>
+        <label style={{ display: "block", marginBottom: "8px", fontWeight: 600, fontSize: "14px" }}>
+          Template
+        </label>
+        <select
+          value={selectedTemplateId}
+          onChange={(e) => setSelectedTemplateId(e.target.value)}
+          style={{ width: "100%", padding: "10px", borderRadius: "4px", border: "1px solid #ccc", fontSize: "14px" }}
+          data-test-id="template-select"
+        >
+          <option value="">No template (custom email)</option>
+          {templates.map((template) => (
+            <option key={template.id} value={template.id}>
+              {template.name}
+            </option>
+          ))}
+        </select>
+        {selectedTemplateId && (
+          <div style={{ marginTop: "8px", display: "flex", gap: "8px" }}>
+            <button
+              type="button"
+              onClick={handlePreview}
+              style={{ padding: "6px 12px", cursor: "pointer", borderRadius: "4px", border: "1px solid #ccc" }}
+            >
+              Preview
+            </button>
+            <button
+              type="button"
+              onClick={handleTestSend}
+              style={{ padding: "6px 12px", cursor: "pointer", borderRadius: "4px", border: "1px solid #ccc" }}
+            >
+              Test send
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Custom Subject (if no template) */}
+      {!selectedTemplateId && (
+        <div style={{ marginBottom: "20px" }}>
+          <label style={{ display: "block", marginBottom: "8px", fontWeight: 600, fontSize: "14px" }}>
+            Subject *
+          </label>
+          <input
+            type="text"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            placeholder="Email subject line"
+            style={{ width: "100%", padding: "10px", borderRadius: "4px", border: "1px solid #ccc", fontSize: "14px" }}
+            data-test-id="subject-input"
+          />
+        </div>
+      )}
+
+      {/* Custom Body (if no template) */}
+      {!selectedTemplateId && (
+        <div style={{ marginBottom: "20px" }}>
+          <label style={{ display: "block", marginBottom: "8px", fontWeight: 600, fontSize: "14px" }}>
+            Body (HTML)
+          </label>
+          <textarea
+            value={bodyHtml}
+            onChange={(e) => setBodyHtml(e.target.value)}
+            placeholder="<p>Your email content here...</p>"
+            rows={8}
+            style={{ width: "100%", padding: "10px", borderRadius: "4px", border: "1px solid #ccc", fontSize: "14px", fontFamily: "monospace" }}
+            data-test-id="body-input"
+          />
+        </div>
+      )}
+
+      {/* Recipients */}
+      <div style={{ marginBottom: "20px" }}>
+        <label style={{ display: "block", marginBottom: "8px", fontWeight: 600, fontSize: "14px" }}>
+          Recipients *
+        </label>
+        <div style={{ display: "flex", gap: "8px", marginBottom: "8px" }}>
+          <input
+            type="email"
+            value={newRecipientEmail}
+            onChange={(e) => setNewRecipientEmail(e.target.value)}
+            placeholder="email@example.com"
+            style={{ flex: 2, padding: "8px", borderRadius: "4px", border: "1px solid #ccc" }}
+            data-test-id="recipient-email-input"
+          />
+          <input
+            type="text"
+            value={newRecipientName}
+            onChange={(e) => setNewRecipientName(e.target.value)}
+            placeholder="Name (optional)"
+            style={{ flex: 1, padding: "8px", borderRadius: "4px", border: "1px solid #ccc" }}
+          />
+          <button
+            type="button"
+            onClick={addRecipient}
+            style={{ padding: "8px 16px", cursor: "pointer", borderRadius: "4px", border: "1px solid #ccc" }}
+            data-test-id="add-recipient-button"
+          >
+            Add
+          </button>
+        </div>
+        {recipients.length > 0 && (
+          <div style={{ border: "1px solid #eee", borderRadius: "4px", padding: "8px" }}>
+            {recipients.map((r, i) => (
+              <div key={i} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "4px 0" }}>
+                <span>
+                  {r.name ? `${r.name} <${r.email}>` : r.email}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => removeRecipient(r.email)}
+                  style={{ color: "#c00", cursor: "pointer", border: "none", background: "none" }}
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+        {recipients.length === 0 && (
+          <small style={{ color: "#666" }}>Add recipients above or select a mailing list</small>
+        )}
+      </div>
+
+      {/* Schedule */}
+      <div style={{ marginBottom: "20px" }}>
+        <label style={{ display: "block", marginBottom: "8px", fontWeight: 600, fontSize: "14px" }}>
+          Schedule (optional)
+        </label>
+        <input
+          type="datetime-local"
+          value={scheduledFor}
+          onChange={(e) => setScheduledFor(e.target.value)}
+          style={{ padding: "8px", borderRadius: "4px", border: "1px solid #ccc" }}
+          data-test-id="schedule-input"
+        />
+      </div>
+
+      {/* Send Options */}
+      <div style={{ marginBottom: "24px" }}>
+        <label style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+          <input
+            type="checkbox"
+            checked={sendImmediately}
+            onChange={(e) => setSendImmediately(e.target.checked)}
+          />
+          Send immediately (skip queue)
+        </label>
+      </div>
+
+      {/* Send Button */}
+      <div style={{ display: "flex", gap: "12px" }}>
+        <button
+          type="button"
+          onClick={handleSend}
+          disabled={!selectedIdentityId || recipients.length === 0}
+          style={{
+            padding: "12px 24px",
+            backgroundColor: sendImmediately ? "#0066cc" : "#28a745",
+            color: "#fff",
+            border: "none",
+            borderRadius: "4px",
+            cursor: "pointer",
+            fontSize: "14px",
+            fontWeight: 600,
+            opacity: (!selectedIdentityId || recipients.length === 0) ? 0.5 : 1,
+          }}
+          data-test-id="send-button"
+        >
+          {sendImmediately ? "Send now" : scheduledFor ? "Schedule" : "Save as draft"}
+        </button>
+      </div>
+
+      {/* Preview Modal */}
+      {showPreview && preview && (
+        <div style={{
+          position: "fixed",
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          backgroundColor: "rgba(0,0,0,0.5)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          zIndex: 1000,
+        }}>
+          <div style={{
+            backgroundColor: "#fff",
+            borderRadius: "8px",
+            padding: "24px",
+            maxWidth: "700px",
+            maxHeight: "80vh",
+            overflow: "auto",
+            width: "90%",
+          }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "16px" }}>
+              <h3 style={{ margin: 0 }}>Email preview</h3>
+              <button
+                onClick={() => setShowPreview(false)}
+                style={{ cursor: "pointer", border: "none", background: "none", fontSize: "20px" }}
+              >
+                ×
+              </button>
+            </div>
+            <div style={{ marginBottom: "16px" }}>
+              <strong>Subject:</strong> {preview.subject}
+            </div>
+            <div style={{ border: "1px solid #eee", borderRadius: "4px", padding: "16px" }}>
+              <div dangerouslySetInnerHTML={{ __html: preview.html }} />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/comms/compose/page.tsx
+++ b/src/app/admin/comms/compose/page.tsx
@@ -1,0 +1,17 @@
+import EmailComposer from "./EmailComposer";
+
+export default function AdminComposeEmailPage() {
+  return (
+    <div data-test-id="admin-comms-compose-root" style={{ padding: "20px" }}>
+      <div style={{ marginBottom: "12px" }}>
+        <h1 style={{ fontSize: "24px", margin: 0 }}>Compose email</h1>
+      </div>
+      <p style={{ marginBottom: "16px", color: "#666" }}>
+        Compose and send emails using templates or custom content.
+        Select a from-address, recipients, and schedule delivery.
+      </p>
+
+      <EmailComposer />
+    </div>
+  );
+}

--- a/src/app/admin/comms/identities/IdentitiesTable.tsx
+++ b/src/app/admin/comms/identities/IdentitiesTable.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+
+type EmailIdentity = {
+  id: string;
+  email: string;
+  displayName: string;
+  description: string | null;
+  replyTo: string | null;
+  isActive: boolean;
+  isDefault: boolean;
+  allowedRoles: string[];
+  canUse: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type FormData = {
+  email: string;
+  displayName: string;
+  description: string;
+  replyTo: string;
+  allowedRoles: string[];
+  isDefault: boolean;
+};
+
+const AVAILABLE_ROLES = [
+  { value: "admin", label: "Admin" },
+  { value: "president", label: "President" },
+  { value: "vp-activities", label: "VP Activities" },
+  { value: "webmaster", label: "Webmaster" },
+];
+
+export default function IdentitiesTable() {
+  const [identities, setIdentities] = useState<EmailIdentity[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [formData, setFormData] = useState<FormData>({
+    email: "",
+    displayName: "",
+    description: "",
+    replyTo: "",
+    allowedRoles: [],
+    isDefault: false,
+  });
+
+  const fetchIdentities = useCallback(async () => {
+    try {
+      const res = await fetch("/api/v1/admin/comms/identities?includeInactive=true");
+      if (!res.ok) throw new Error("Failed to fetch identities");
+      const data = await res.json();
+      setIdentities(data.items);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchIdentities();
+  }, [fetchIdentities]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const url = editingId
+      ? `/api/v1/admin/comms/identities/${editingId}`
+      : "/api/v1/admin/comms/identities";
+
+    try {
+      const res = await fetch(url, {
+        method: editingId ? "PUT" : "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...formData,
+          description: formData.description || null,
+          replyTo: formData.replyTo || null,
+        }),
+      });
+
+      if (!res.ok) {
+        const errData = await res.json();
+        throw new Error(errData.message || "Failed to save identity");
+      }
+
+      setShowForm(false);
+      setEditingId(null);
+      setFormData({
+        email: "",
+        displayName: "",
+        description: "",
+        replyTo: "",
+        allowedRoles: [],
+        isDefault: false,
+      });
+      fetchIdentities();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  const handleEdit = (identity: EmailIdentity) => {
+    setEditingId(identity.id);
+    setFormData({
+      email: identity.email,
+      displayName: identity.displayName,
+      description: identity.description || "",
+      replyTo: identity.replyTo || "",
+      allowedRoles: identity.allowedRoles,
+      isDefault: identity.isDefault,
+    });
+    setShowForm(true);
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm("Deactivate this identity? It can be reactivated later.")) return;
+
+    try {
+      const res = await fetch(`/api/v1/admin/comms/identities/${id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error("Failed to delete identity");
+      fetchIdentities();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    }
+  };
+
+  const toggleRole = (role: string) => {
+    setFormData((prev) => ({
+      ...prev,
+      allowedRoles: prev.allowedRoles.includes(role)
+        ? prev.allowedRoles.filter((r) => r !== role)
+        : [...prev.allowedRoles, role],
+    }));
+  };
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <div>
+      {error && (
+        <div style={{ padding: "12px", backgroundColor: "#fee", color: "#c00", marginBottom: "16px", borderRadius: "4px" }}>
+          {error}
+        </div>
+      )}
+
+      <button
+        onClick={() => {
+          setShowForm(!showForm);
+          setEditingId(null);
+          setFormData({
+            email: "",
+            displayName: "",
+            description: "",
+            replyTo: "",
+            allowedRoles: [],
+            isDefault: false,
+          });
+        }}
+        style={{
+          padding: "8px 16px",
+          backgroundColor: "#0066cc",
+          color: "#fff",
+          border: "none",
+          borderRadius: "4px",
+          cursor: "pointer",
+          marginBottom: "16px",
+        }}
+        data-test-id="add-identity-button"
+      >
+        {showForm ? "Cancel" : "Add identity"}
+      </button>
+
+      {showForm && (
+        <form onSubmit={handleSubmit} style={{ marginBottom: "24px", padding: "16px", backgroundColor: "#f5f5f5", borderRadius: "8px" }}>
+          <div style={{ marginBottom: "12px" }}>
+            <label style={{ display: "block", marginBottom: "4px", fontWeight: 500 }}>
+              Email address *
+            </label>
+            <input
+              type="email"
+              value={formData.email}
+              onChange={(e) => setFormData((p) => ({ ...p, email: e.target.value }))}
+              placeholder="president@sbnewcomers.org"
+              required
+              disabled={!!editingId}
+              style={{ width: "100%", padding: "8px", borderRadius: "4px", border: "1px solid #ccc" }}
+              data-test-id="identity-email-input"
+            />
+            <small style={{ color: "#666" }}>Must be a sbnewcomers.org address</small>
+          </div>
+
+          <div style={{ marginBottom: "12px" }}>
+            <label style={{ display: "block", marginBottom: "4px", fontWeight: 500 }}>
+              Display name *
+            </label>
+            <input
+              type="text"
+              value={formData.displayName}
+              onChange={(e) => setFormData((p) => ({ ...p, displayName: e.target.value }))}
+              placeholder="SBNC President"
+              required
+              style={{ width: "100%", padding: "8px", borderRadius: "4px", border: "1px solid #ccc" }}
+              data-test-id="identity-display-name-input"
+            />
+          </div>
+
+          <div style={{ marginBottom: "12px" }}>
+            <label style={{ display: "block", marginBottom: "4px", fontWeight: 500 }}>
+              Description
+            </label>
+            <input
+              type="text"
+              value={formData.description}
+              onChange={(e) => setFormData((p) => ({ ...p, description: e.target.value }))}
+              placeholder="For official club communications"
+              style={{ width: "100%", padding: "8px", borderRadius: "4px", border: "1px solid #ccc" }}
+            />
+          </div>
+
+          <div style={{ marginBottom: "12px" }}>
+            <label style={{ display: "block", marginBottom: "4px", fontWeight: 500 }}>
+              Reply-to address
+            </label>
+            <input
+              type="email"
+              value={formData.replyTo}
+              onChange={(e) => setFormData((p) => ({ ...p, replyTo: e.target.value }))}
+              placeholder="Optional - replies go here"
+              style={{ width: "100%", padding: "8px", borderRadius: "4px", border: "1px solid #ccc" }}
+            />
+          </div>
+
+          <div style={{ marginBottom: "12px" }}>
+            <label style={{ display: "block", marginBottom: "4px", fontWeight: 500 }}>
+              Allowed roles
+            </label>
+            <div style={{ display: "flex", gap: "12px", flexWrap: "wrap" }}>
+              {AVAILABLE_ROLES.map((role) => (
+                <label key={role.value} style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+                  <input
+                    type="checkbox"
+                    checked={formData.allowedRoles.includes(role.value)}
+                    onChange={() => toggleRole(role.value)}
+                  />
+                  {role.label}
+                </label>
+              ))}
+            </div>
+            <small style={{ color: "#666" }}>Only selected roles can send from this identity</small>
+          </div>
+
+          <div style={{ marginBottom: "16px" }}>
+            <label style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+              <input
+                type="checkbox"
+                checked={formData.isDefault}
+                onChange={(e) => setFormData((p) => ({ ...p, isDefault: e.target.checked }))}
+              />
+              Set as default identity
+            </label>
+          </div>
+
+          <button
+            type="submit"
+            style={{
+              padding: "8px 16px",
+              backgroundColor: "#0066cc",
+              color: "#fff",
+              border: "none",
+              borderRadius: "4px",
+              cursor: "pointer",
+            }}
+            data-test-id="save-identity-button"
+          >
+            {editingId ? "Update identity" : "Create identity"}
+          </button>
+        </form>
+      )}
+
+      <table style={{ width: "100%", borderCollapse: "collapse" }} data-test-id="identities-table">
+        <thead>
+          <tr style={{ borderBottom: "2px solid #ddd" }}>
+            <th style={{ textAlign: "left", padding: "8px" }}>Email</th>
+            <th style={{ textAlign: "left", padding: "8px" }}>Display name</th>
+            <th style={{ textAlign: "left", padding: "8px" }}>Allowed roles</th>
+            <th style={{ textAlign: "center", padding: "8px" }}>Status</th>
+            <th style={{ textAlign: "center", padding: "8px" }}>Can use</th>
+            <th style={{ textAlign: "right", padding: "8px" }}>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {identities.map((identity) => (
+            <tr key={identity.id} style={{ borderBottom: "1px solid #eee", opacity: identity.isActive ? 1 : 0.5 }}>
+              <td style={{ padding: "8px" }}>
+                {identity.email}
+                {identity.isDefault && (
+                  <span style={{ marginLeft: "8px", fontSize: "12px", backgroundColor: "#0066cc", color: "#fff", padding: "2px 6px", borderRadius: "4px" }}>
+                    Default
+                  </span>
+                )}
+              </td>
+              <td style={{ padding: "8px" }}>{identity.displayName}</td>
+              <td style={{ padding: "8px" }}>
+                {identity.allowedRoles.length > 0
+                  ? identity.allowedRoles.join(", ")
+                  : <span style={{ color: "#999" }}>Admin only</span>}
+              </td>
+              <td style={{ padding: "8px", textAlign: "center" }}>
+                <span style={{
+                  padding: "2px 8px",
+                  borderRadius: "4px",
+                  fontSize: "12px",
+                  backgroundColor: identity.isActive ? "#e6f4ea" : "#fce8e6",
+                  color: identity.isActive ? "#1e7e34" : "#c5221f",
+                }}>
+                  {identity.isActive ? "Active" : "Inactive"}
+                </span>
+              </td>
+              <td style={{ padding: "8px", textAlign: "center" }}>
+                {identity.canUse ? "Yes" : "No"}
+              </td>
+              <td style={{ padding: "8px", textAlign: "right" }}>
+                <button
+                  onClick={() => handleEdit(identity)}
+                  style={{ marginRight: "8px", padding: "4px 8px", cursor: "pointer" }}
+                >
+                  Edit
+                </button>
+                {identity.isActive && (
+                  <button
+                    onClick={() => handleDelete(identity.id)}
+                    style={{ padding: "4px 8px", cursor: "pointer", color: "#c00" }}
+                  >
+                    Deactivate
+                  </button>
+                )}
+              </td>
+            </tr>
+          ))}
+          {identities.length === 0 && (
+            <tr>
+              <td colSpan={6} style={{ padding: "24px", textAlign: "center", color: "#666" }}>
+                No email identities configured. Add one to start sending emails.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/admin/comms/identities/page.tsx
+++ b/src/app/admin/comms/identities/page.tsx
@@ -1,0 +1,17 @@
+import IdentitiesTable from "./IdentitiesTable";
+
+export default function AdminEmailIdentitiesPage() {
+  return (
+    <div data-test-id="admin-comms-identities-root" style={{ padding: "20px" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "12px" }}>
+        <h1 style={{ fontSize: "24px", margin: 0 }}>Email identities</h1>
+      </div>
+      <p style={{ marginBottom: "16px", color: "#666" }}>
+        Manage sender identities (from-addresses) for sbnewcomers.org emails.
+        Each identity can be restricted to specific roles.
+      </p>
+
+      <IdentitiesTable />
+    </div>
+  );
+}

--- a/src/app/api/v1/admin/comms/compose/route.ts
+++ b/src/app/api/v1/admin/comms/compose/route.ts
@@ -1,0 +1,275 @@
+// Copyright (c) Santa Barbara Newcomers Club
+// Email Composer API - compose and send emails
+// Charter: P1 (provable identity), P2 (role-based from-address), P3 (state machine)
+// Charter: N5 (idempotent via idempotencyKey), N7 (minimize PII exposure)
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireCapability } from "@/lib/auth";
+import { replaceTokens, getEmailProvider, type TokenContext } from "@/lib/publishing/email";
+import { canUseIdentity } from "../identities/route";
+
+/**
+ * POST /api/v1/admin/comms/compose
+ *
+ * Compose and optionally send an email
+ *
+ * Body:
+ * - identityId: Email identity to send from (required)
+ * - templateId: Template to use (optional - if not provided, use raw subject/body)
+ * - subject: Subject line (required if no templateId)
+ * - bodyHtml: HTML body (required if no templateId)
+ * - bodyText: Plain text body (optional)
+ * - recipients: Array of { email, name?, memberId?, context? }
+ * - scheduledFor: ISO date string for scheduled send (optional)
+ * - idempotencyKey: Client key to prevent duplicates (optional)
+ * - sendImmediately: If true, send now instead of queueing (default: false)
+ */
+export async function POST(request: NextRequest) {
+  const auth = await requireCapability(request, "comms:send");
+  if (!auth.ok) return auth.response;
+
+  const body = await request.json();
+  const {
+    identityId,
+    templateId,
+    subject: rawSubject,
+    bodyHtml: rawBodyHtml,
+    bodyText: rawBodyText,
+    recipients,
+    scheduledFor,
+    idempotencyKey,
+    sendImmediately,
+  } = body;
+
+  // Validate identity
+  if (!identityId) {
+    return NextResponse.json(
+      { error: "Missing required field", message: "identityId is required" },
+      { status: 400 }
+    );
+  }
+
+  const identity = await prisma.emailIdentity.findUnique({
+    where: { id: identityId },
+  });
+
+  if (!identity || !identity.isActive) {
+    return NextResponse.json(
+      { error: "Invalid identity", message: "Email identity not found or inactive" },
+      { status: 400 }
+    );
+  }
+
+  // Check role-based access to identity
+  if (!canUseIdentity(auth.context.globalRole, identity.allowedRoles as string[])) {
+    return NextResponse.json(
+      { error: "Access denied", message: "You are not authorized to send from this identity" },
+      { status: 403 }
+    );
+  }
+
+  // Get template if provided
+  let template = null;
+  if (templateId) {
+    template = await prisma.messageTemplate.findUnique({
+      where: { id: templateId },
+    });
+    if (!template) {
+      return NextResponse.json(
+        { error: "Invalid template", message: "Template not found" },
+        { status: 400 }
+      );
+    }
+  }
+
+  // Validate we have subject and body from template or raw input
+  const subjectTemplate = template?.subject || rawSubject;
+  const bodyHtmlTemplate = template?.bodyHtml || rawBodyHtml;
+  const bodyTextTemplate = template?.bodyText || rawBodyText;
+
+  if (!subjectTemplate || !bodyHtmlTemplate) {
+    return NextResponse.json(
+      { error: "Missing content", message: "Either templateId or subject+bodyHtml required" },
+      { status: 400 }
+    );
+  }
+
+  // Validate recipients
+  if (!recipients || !Array.isArray(recipients) || recipients.length === 0) {
+    return NextResponse.json(
+      { error: "Missing recipients", message: "At least one recipient is required" },
+      { status: 400 }
+    );
+  }
+
+  // Validate recipient format
+  for (const r of recipients) {
+    if (!r.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(r.email)) {
+      return NextResponse.json(
+        { error: "Invalid recipient", message: `Invalid email: ${r.email}` },
+        { status: 400 }
+      );
+    }
+  }
+
+  // Check idempotency
+  if (idempotencyKey) {
+    const existing = await prisma.emailOutbox.findUnique({
+      where: { idempotencyKey },
+    });
+    if (existing) {
+      return NextResponse.json(
+        {
+          success: true,
+          message: "Already processed (idempotent)",
+          outboxId: existing.id,
+          status: existing.status,
+        },
+        { status: 200 }
+      );
+    }
+  }
+
+  // Parse scheduled time
+  let scheduledDate: Date | null = null;
+  if (scheduledFor) {
+    scheduledDate = new Date(scheduledFor);
+    if (isNaN(scheduledDate.getTime())) {
+      return NextResponse.json(
+        { error: "Invalid date", message: "scheduledFor must be a valid ISO date" },
+        { status: 400 }
+      );
+    }
+  }
+
+  // Create outbox entries for each recipient
+  const outboxItems = [];
+  const provider = getEmailProvider();
+  const results: Array<{ email: string; success: boolean; messageId?: string; error?: string }> = [];
+
+  for (const recipient of recipients) {
+    // Build context for this recipient
+    const context: TokenContext = {
+      member: recipient.memberId
+        ? await getMemberContext(recipient.memberId)
+        : {
+            id: "unknown",
+            firstName: recipient.name?.split(" ")[0] || "Member",
+            lastName: recipient.name?.split(" ").slice(1).join(" ") || "",
+            email: recipient.email,
+          },
+      ...(recipient.context || {}),
+    };
+
+    // Render template
+    const renderedSubject = replaceTokens(subjectTemplate, context);
+    const renderedHtml = replaceTokens(bodyHtmlTemplate, context);
+    const renderedText = bodyTextTemplate ? replaceTokens(bodyTextTemplate, context) : null;
+
+    // Determine initial status
+    const initialStatus = sendImmediately ? "SENDING" : scheduledDate ? "QUEUED" : "DRAFT";
+
+    // Create outbox entry
+    const outboxItem = await prisma.emailOutbox.create({
+      data: {
+        idempotencyKey: idempotencyKey ? `${idempotencyKey}-${recipient.email}` : null,
+        identityId: identity.id,
+        recipientEmail: recipient.email,
+        recipientId: recipient.memberId || null,
+        recipientName: recipient.name || null,
+        subject: renderedSubject,
+        bodyHtml: renderedHtml,
+        bodyText: renderedText,
+        templateId: template?.id || null,
+        templateData: context as unknown as Record<string, unknown>,
+        status: initialStatus,
+        scheduledFor: scheduledDate,
+        createdById: auth.context.memberId === "e2e-admin" ? null : auth.context.memberId,
+      },
+    });
+
+    outboxItems.push(outboxItem);
+
+    // Send immediately if requested
+    if (sendImmediately) {
+      const sendResult = await provider.send({
+        to: recipient.email,
+        subject: renderedSubject,
+        html: renderedHtml,
+        text: renderedText || undefined,
+        from: `${identity.displayName} <${identity.email}>`,
+        replyTo: identity.replyTo || undefined,
+      });
+
+      // Update outbox status
+      await prisma.emailOutbox.update({
+        where: { id: outboxItem.id },
+        data: {
+          status: sendResult.success ? "SENT" : "FAILED",
+          sentAt: sendResult.success ? new Date() : null,
+          providerMsgId: sendResult.messageId || null,
+          errorMessage: sendResult.error || null,
+        },
+      });
+
+      results.push({
+        email: recipient.email,
+        success: sendResult.success,
+        messageId: sendResult.messageId,
+        error: sendResult.error,
+      });
+    }
+  }
+
+  // Audit log
+  await prisma.auditLog.create({
+    data: {
+      action: "CREATE",
+      resourceType: "email_outbox",
+      resourceId: outboxItems[0]?.id || "batch",
+      memberId: auth.context.memberId === "e2e-admin" ? null : auth.context.memberId,
+      metadata: {
+        recipientCount: recipients.length,
+        templateId: template?.id || null,
+        identityId: identity.id,
+        sendImmediately,
+        scheduledFor: scheduledDate?.toISOString() || null,
+      },
+    },
+  });
+
+  return NextResponse.json({
+    success: true,
+    outboxCount: outboxItems.length,
+    outboxIds: outboxItems.map((i) => i.id),
+    status: sendImmediately ? "sent" : scheduledDate ? "scheduled" : "draft",
+    results: sendImmediately ? results : undefined,
+  });
+}
+
+/**
+ * Helper to get member context
+ */
+async function getMemberContext(memberId: string): Promise<TokenContext["member"]> {
+  const member = await prisma.member.findUnique({
+    where: { id: memberId },
+  });
+
+  if (!member) {
+    return {
+      id: memberId,
+      firstName: "Member",
+      lastName: "",
+      email: "unknown@example.com",
+    };
+  }
+
+  return {
+    id: member.id,
+    firstName: member.firstName,
+    lastName: member.lastName,
+    email: member.email,
+    phone: member.phone,
+  };
+}

--- a/src/app/api/v1/admin/comms/identities/[id]/route.ts
+++ b/src/app/api/v1/admin/comms/identities/[id]/route.ts
@@ -1,0 +1,126 @@
+// Copyright (c) Santa Barbara Newcomers Club
+// Individual Email Identity API
+// Charter: P1, P2, P5 (reversible actions)
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireCapability } from "@/lib/auth";
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/**
+ * GET /api/v1/admin/comms/identities/:id
+ */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const auth = await requireCapability(request, "comms:manage");
+  if (!auth.ok) return auth.response;
+
+  const { id } = await params;
+  const identity = await prisma.emailIdentity.findUnique({
+    where: { id },
+  });
+
+  if (!identity) {
+    return NextResponse.json(
+      { error: "Not found", message: "Email identity not found" },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json(identity);
+}
+
+/**
+ * PUT /api/v1/admin/comms/identities/:id
+ */
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+  const auth = await requireCapability(request, "admin:full");
+  if (!auth.ok) return auth.response;
+
+  const { id } = await params;
+  const body = await request.json();
+  const { displayName, description, replyTo, allowedRoles, isActive, isDefault } = body;
+
+  const existing = await prisma.emailIdentity.findUnique({ where: { id } });
+  if (!existing) {
+    return NextResponse.json(
+      { error: "Not found", message: "Email identity not found" },
+      { status: 404 }
+    );
+  }
+
+  // If setting as default, unset other defaults
+  if (isDefault && !existing.isDefault) {
+    await prisma.emailIdentity.updateMany({
+      where: { isDefault: true },
+      data: { isDefault: false },
+    });
+  }
+
+  const updated = await prisma.emailIdentity.update({
+    where: { id },
+    data: {
+      displayName: displayName ?? existing.displayName,
+      description: description !== undefined ? description : existing.description,
+      replyTo: replyTo !== undefined ? replyTo : existing.replyTo,
+      allowedRoles: allowedRoles ?? existing.allowedRoles,
+      isActive: isActive ?? existing.isActive,
+      isDefault: isDefault ?? existing.isDefault,
+    },
+  });
+
+  // Audit log
+  await prisma.auditLog.create({
+    data: {
+      action: "UPDATE",
+      resourceType: "email_identity",
+      resourceId: id,
+      memberId: auth.context.memberId === "e2e-admin" ? null : auth.context.memberId,
+      before: existing as unknown as Record<string, unknown>,
+      after: updated as unknown as Record<string, unknown>,
+    },
+  });
+
+  return NextResponse.json(updated);
+}
+
+/**
+ * DELETE /api/v1/admin/comms/identities/:id
+ *
+ * Soft delete - sets isActive to false
+ * Charter P5: Reversible actions
+ */
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  const auth = await requireCapability(request, "admin:full");
+  if (!auth.ok) return auth.response;
+
+  const { id } = await params;
+  const existing = await prisma.emailIdentity.findUnique({ where: { id } });
+
+  if (!existing) {
+    return NextResponse.json(
+      { error: "Not found", message: "Email identity not found" },
+      { status: 404 }
+    );
+  }
+
+  // Soft delete - deactivate instead of hard delete
+  const updated = await prisma.emailIdentity.update({
+    where: { id },
+    data: { isActive: false, isDefault: false },
+  });
+
+  // Audit log
+  await prisma.auditLog.create({
+    data: {
+      action: "DELETE",
+      resourceType: "email_identity",
+      resourceId: id,
+      memberId: auth.context.memberId === "e2e-admin" ? null : auth.context.memberId,
+      before: existing as unknown as Record<string, unknown>,
+      after: updated as unknown as Record<string, unknown>,
+    },
+  });
+
+  return NextResponse.json({ success: true, message: "Identity deactivated" });
+}

--- a/src/app/api/v1/admin/comms/identities/route.ts
+++ b/src/app/api/v1/admin/comms/identities/route.ts
@@ -1,0 +1,122 @@
+// Copyright (c) Santa Barbara Newcomers Club
+// Email Identities API - manages from-addresses for sbnewcomers.org
+// Charter: P1 (identity provable), P2 (default deny, role-based), P4 (no hidden rules)
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireCapability, hasCapability, type GlobalRole } from "@/lib/auth";
+
+/**
+ * Check if a role can use a specific email identity
+ * Charter P2: Role-based control of from-addresses
+ */
+export function canUseIdentity(role: GlobalRole, allowedRoles: string[]): boolean {
+  // Admin can use any identity
+  if (hasCapability(role, "admin:full")) return true;
+
+  // Check if role is in allowed list
+  return allowedRoles.includes(role);
+}
+
+/**
+ * GET /api/v1/admin/comms/identities
+ *
+ * List all email identities. Returns only identities the user can send as
+ * unless they have admin:full capability.
+ */
+export async function GET(request: NextRequest) {
+  // Charter P1/P2: Require comms:manage capability
+  const auth = await requireCapability(request, "comms:manage");
+  if (!auth.ok) return auth.response;
+
+  const { searchParams } = new URL(request.url);
+  const includeInactive = searchParams.get("includeInactive") === "true";
+  const onlyUsable = searchParams.get("onlyUsable") === "true";
+
+  const where: Record<string, unknown> = {};
+  if (!includeInactive) {
+    where.isActive = true;
+  }
+
+  const identities = await prisma.emailIdentity.findMany({
+    where,
+    orderBy: [{ isDefault: "desc" }, { displayName: "asc" }],
+  });
+
+  // Filter to only identities this user can use if requested
+  const result = onlyUsable
+    ? identities.filter((id) =>
+        canUseIdentity(auth.context.globalRole, id.allowedRoles as string[])
+      )
+    : identities;
+
+  // Add canUse flag for UI
+  const itemsWithAccess = result.map((id) => ({
+    ...id,
+    canUse: canUseIdentity(auth.context.globalRole, id.allowedRoles as string[]),
+  }));
+
+  return NextResponse.json({ items: itemsWithAccess });
+}
+
+/**
+ * POST /api/v1/admin/comms/identities
+ *
+ * Create a new email identity. Requires admin:full capability.
+ */
+export async function POST(request: NextRequest) {
+  // Charter P2: Only admin can create identities
+  const auth = await requireCapability(request, "admin:full");
+  if (!auth.ok) return auth.response;
+
+  const body = await request.json();
+  const { email, displayName, description, replyTo, allowedRoles, isDefault } = body;
+
+  // Validate required fields
+  if (!email || !displayName) {
+    return NextResponse.json(
+      { error: "Missing required fields", message: "email and displayName are required" },
+      { status: 400 }
+    );
+  }
+
+  // Validate email format
+  if (!email.endsWith("@sbnewcomers.org")) {
+    return NextResponse.json(
+      { error: "Invalid email", message: "Email must be a sbnewcomers.org address" },
+      { status: 400 }
+    );
+  }
+
+  // If setting as default, unset other defaults
+  if (isDefault) {
+    await prisma.emailIdentity.updateMany({
+      where: { isDefault: true },
+      data: { isDefault: false },
+    });
+  }
+
+  const identity = await prisma.emailIdentity.create({
+    data: {
+      email,
+      displayName,
+      description: description || null,
+      replyTo: replyTo || null,
+      allowedRoles: allowedRoles || [],
+      isDefault: isDefault || false,
+    },
+  });
+
+  // Audit log
+  await prisma.auditLog.create({
+    data: {
+      action: "CREATE",
+      resourceType: "email_identity",
+      resourceId: identity.id,
+      memberId: auth.context.memberId === "e2e-admin" ? null : auth.context.memberId,
+      after: identity as unknown as Record<string, unknown>,
+    },
+  });
+
+  return NextResponse.json(identity, { status: 201 });
+}

--- a/src/app/api/v1/admin/comms/outbox/route.ts
+++ b/src/app/api/v1/admin/comms/outbox/route.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Santa Barbara Newcomers Club
+// Email Outbox API - track email delivery status
+// Charter: P3 (state machine), P7 (observability)
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireCapability } from "@/lib/auth";
+
+/**
+ * GET /api/v1/admin/comms/outbox
+ *
+ * List outbox items with filtering and pagination
+ *
+ * Query params:
+ * - status: Filter by status (DRAFT, QUEUED, SENDING, SENT, DELIVERED, BOUNCED, FAILED)
+ * - identityId: Filter by sender identity
+ * - page, pageSize: Pagination
+ */
+export async function GET(request: NextRequest) {
+  const auth = await requireCapability(request, "comms:manage");
+  if (!auth.ok) return auth.response;
+
+  const { searchParams } = new URL(request.url);
+  const status = searchParams.get("status");
+  const identityId = searchParams.get("identityId");
+  const page = Math.max(1, parseInt(searchParams.get("page") || "1", 10));
+  const pageSize = Math.min(100, Math.max(1, parseInt(searchParams.get("pageSize") || "20", 10)));
+
+  const where: Record<string, unknown> = {};
+  if (status) {
+    where.status = status;
+  }
+  if (identityId) {
+    where.identityId = identityId;
+  }
+
+  const [items, totalItems] = await Promise.all([
+    prisma.emailOutbox.findMany({
+      where,
+      include: {
+        identity: {
+          select: { email: true, displayName: true },
+        },
+        template: {
+          select: { name: true, slug: true },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+    }),
+    prisma.emailOutbox.count({ where }),
+  ]);
+
+  // Get status counts for dashboard
+  const statusCounts = await prisma.emailOutbox.groupBy({
+    by: ["status"],
+    _count: true,
+  });
+
+  const counts = Object.fromEntries(
+    statusCounts.map((s) => [s.status, s._count])
+  );
+
+  return NextResponse.json({
+    items,
+    page,
+    pageSize,
+    totalItems,
+    totalPages: Math.ceil(totalItems / pageSize),
+    statusCounts: counts,
+  });
+}

--- a/src/app/api/v1/admin/comms/templates/[id]/preview/route.ts
+++ b/src/app/api/v1/admin/comms/templates/[id]/preview/route.ts
@@ -1,0 +1,137 @@
+// Copyright (c) Santa Barbara Newcomers Club
+// Template Preview API - renders template with sample or provided data
+// Charter: N8 (template safety - preview before commit)
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireCapability } from "@/lib/auth";
+import { replaceTokens, type TokenContext } from "@/lib/publishing/email";
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+// Sample data for preview
+const SAMPLE_CONTEXT: TokenContext = {
+  member: {
+    id: "sample-member-id",
+    firstName: "Jane",
+    lastName: "Doe",
+    email: "jane.doe@example.com",
+    phone: "(805) 555-1234",
+  },
+  event: {
+    id: "sample-event-id",
+    title: "Monthly Coffee Social",
+    description: "Join us for coffee and conversation at our favorite local café.",
+    location: "Pierre Lafond Coffee, 516 San Ysidro Rd",
+    startTime: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 1 week from now
+    endTime: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000 + 2 * 60 * 60 * 1000), // +2 hours
+    category: "Social",
+  },
+  club: {
+    name: "Santa Barbara Newcomers Club",
+    website: "https://sbnewcomers.org",
+    email: "info@sbnewcomers.org",
+  },
+};
+
+/**
+ * POST /api/v1/admin/comms/templates/:id/preview
+ *
+ * Preview a template with sample or custom data
+ *
+ * Body (optional):
+ * - context: Custom TokenContext to use instead of sample data
+ * - memberId: Fetch real member data for preview
+ * - eventId: Fetch real event data for preview
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const auth = await requireCapability(request, "comms:manage");
+  if (!auth.ok) return auth.response;
+
+  const { id } = await params;
+  const template = await prisma.messageTemplate.findUnique({
+    where: { id },
+  });
+
+  if (!template) {
+    return NextResponse.json(
+      { error: "Not found", message: "Template not found" },
+      { status: 404 }
+    );
+  }
+
+  let context: TokenContext = SAMPLE_CONTEXT;
+
+  // Parse body if present
+  try {
+    const body = await request.json();
+
+    // If custom context provided, use it
+    if (body.context) {
+      context = { ...SAMPLE_CONTEXT, ...body.context };
+    }
+
+    // If memberId provided, fetch real member data
+    if (body.memberId) {
+      const member = await prisma.member.findUnique({
+        where: { id: body.memberId },
+      });
+      if (member) {
+        context.member = {
+          id: member.id,
+          firstName: member.firstName,
+          lastName: member.lastName,
+          email: member.email,
+          phone: member.phone,
+        };
+      }
+    }
+
+    // If eventId provided, fetch real event data
+    if (body.eventId) {
+      const event = await prisma.event.findUnique({
+        where: { id: body.eventId },
+      });
+      if (event) {
+        context.event = {
+          id: event.id,
+          title: event.title,
+          description: event.description,
+          location: event.location,
+          startTime: event.startTime,
+          endTime: event.endTime,
+          category: event.category,
+        };
+      }
+    }
+
+    // Custom variables
+    if (body.custom) {
+      context.custom = body.custom;
+    }
+  } catch {
+    // No body or invalid JSON - use sample data
+  }
+
+  // Render template with context
+  const renderedSubject = replaceTokens(template.subject, context);
+  const renderedHtml = replaceTokens(template.bodyHtml, context);
+  const renderedText = template.bodyText ? replaceTokens(template.bodyText, context) : null;
+
+  return NextResponse.json({
+    template: {
+      id: template.id,
+      name: template.name,
+      slug: template.slug,
+    },
+    preview: {
+      subject: renderedSubject,
+      html: renderedHtml,
+      text: renderedText,
+    },
+    context: {
+      member: context.member ? { firstName: context.member.firstName, lastName: context.member.lastName } : null,
+      event: context.event ? { title: context.event.title } : null,
+    },
+  });
+}

--- a/src/app/api/v1/admin/comms/templates/[id]/route.ts
+++ b/src/app/api/v1/admin/comms/templates/[id]/route.ts
@@ -1,0 +1,117 @@
+// Copyright (c) Santa Barbara Newcomers Club
+// Individual Message Template API
+// Charter: P2, P5, N8 (template safety)
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireCapability } from "@/lib/auth";
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/**
+ * GET /api/v1/admin/comms/templates/:id
+ */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const auth = await requireCapability(request, "comms:manage");
+  if (!auth.ok) return auth.response;
+
+  const { id } = await params;
+  const template = await prisma.messageTemplate.findUnique({
+    where: { id },
+  });
+
+  if (!template) {
+    return NextResponse.json(
+      { error: "Not found", message: "Template not found" },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json(template);
+}
+
+/**
+ * PUT /api/v1/admin/comms/templates/:id
+ */
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+  const auth = await requireCapability(request, "comms:manage");
+  if (!auth.ok) return auth.response;
+
+  const { id } = await params;
+  const body = await request.json();
+  const { name, subject, bodyHtml, bodyText, tokens, providerOpts, isActive } = body;
+
+  const existing = await prisma.messageTemplate.findUnique({ where: { id } });
+  if (!existing) {
+    return NextResponse.json(
+      { error: "Not found", message: "Template not found" },
+      { status: 404 }
+    );
+  }
+
+  const updated = await prisma.messageTemplate.update({
+    where: { id },
+    data: {
+      name: name ?? existing.name,
+      subject: subject ?? existing.subject,
+      bodyHtml: bodyHtml ?? existing.bodyHtml,
+      bodyText: bodyText !== undefined ? bodyText : existing.bodyText,
+      tokens: tokens ?? existing.tokens,
+      providerOpts: providerOpts !== undefined ? providerOpts : existing.providerOpts,
+      isActive: isActive ?? existing.isActive,
+    },
+  });
+
+  // Audit log
+  await prisma.auditLog.create({
+    data: {
+      action: "UPDATE",
+      resourceType: "message_template",
+      resourceId: id,
+      memberId: auth.context.memberId === "e2e-admin" ? null : auth.context.memberId,
+      before: { name: existing.name, subject: existing.subject } as Record<string, unknown>,
+      after: { name: updated.name, subject: updated.subject } as Record<string, unknown>,
+    },
+  });
+
+  return NextResponse.json(updated);
+}
+
+/**
+ * DELETE /api/v1/admin/comms/templates/:id
+ *
+ * Soft delete - sets isActive to false
+ */
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  const auth = await requireCapability(request, "comms:manage");
+  if (!auth.ok) return auth.response;
+
+  const { id } = await params;
+  const existing = await prisma.messageTemplate.findUnique({ where: { id } });
+
+  if (!existing) {
+    return NextResponse.json(
+      { error: "Not found", message: "Template not found" },
+      { status: 404 }
+    );
+  }
+
+  const updated = await prisma.messageTemplate.update({
+    where: { id },
+    data: { isActive: false },
+  });
+
+  // Audit log
+  await prisma.auditLog.create({
+    data: {
+      action: "DELETE",
+      resourceType: "message_template",
+      resourceId: id,
+      memberId: auth.context.memberId === "e2e-admin" ? null : auth.context.memberId,
+      before: { isActive: true } as Record<string, unknown>,
+      after: { isActive: false } as Record<string, unknown>,
+    },
+  });
+
+  return NextResponse.json({ success: true, message: "Template deactivated" });
+}

--- a/src/app/api/v1/admin/comms/templates/[id]/test-send/route.ts
+++ b/src/app/api/v1/admin/comms/templates/[id]/test-send/route.ts
@@ -1,0 +1,172 @@
+// Copyright (c) Santa Barbara Newcomers Club
+// Template Test Send API - sends test email to specified address
+// Charter: P1 (provable identity), P2 (capability check), N8 (preview before commit)
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireCapability } from "@/lib/auth";
+import { replaceTokens, getEmailProvider, type TokenContext } from "@/lib/publishing/email";
+import { canUseIdentity } from "../../identities/route";
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+// Sample data for test send
+const SAMPLE_CONTEXT: TokenContext = {
+  member: {
+    id: "test-member-id",
+    firstName: "Test",
+    lastName: "Recipient",
+    email: "test@example.com",
+    phone: "(805) 555-0000",
+  },
+  event: {
+    id: "test-event-id",
+    title: "Sample Event",
+    description: "This is a test email preview.",
+    location: "Test Location",
+    startTime: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    endTime: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000 + 2 * 60 * 60 * 1000),
+    category: "Test",
+  },
+};
+
+/**
+ * POST /api/v1/admin/comms/templates/:id/test-send
+ *
+ * Send a test email using this template
+ *
+ * Body:
+ * - to: Email address to send test to (required)
+ * - identityId: Email identity to send from (required)
+ * - context: Custom TokenContext (optional)
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  // Require comms:send capability for test sends
+  const auth = await requireCapability(request, "comms:send");
+  if (!auth.ok) return auth.response;
+
+  const { id } = await params;
+  const template = await prisma.messageTemplate.findUnique({
+    where: { id },
+  });
+
+  if (!template) {
+    return NextResponse.json(
+      { error: "Not found", message: "Template not found" },
+      { status: 404 }
+    );
+  }
+
+  const body = await request.json();
+  const { to, identityId, context: customContext } = body;
+
+  // Validate required fields
+  if (!to || !identityId) {
+    return NextResponse.json(
+      { error: "Missing required fields", message: "to and identityId are required" },
+      { status: 400 }
+    );
+  }
+
+  // Validate email format
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(to)) {
+    return NextResponse.json(
+      { error: "Invalid email", message: "Invalid recipient email address" },
+      { status: 400 }
+    );
+  }
+
+  // Get and validate identity
+  const identity = await prisma.emailIdentity.findUnique({
+    where: { id: identityId },
+  });
+
+  if (!identity || !identity.isActive) {
+    return NextResponse.json(
+      { error: "Invalid identity", message: "Email identity not found or inactive" },
+      { status: 400 }
+    );
+  }
+
+  // Check if user can use this identity
+  if (!canUseIdentity(auth.context.globalRole, identity.allowedRoles as string[])) {
+    return NextResponse.json(
+      { error: "Access denied", message: "You are not authorized to send from this identity" },
+      { status: 403 }
+    );
+  }
+
+  // Build context
+  const context: TokenContext = {
+    ...SAMPLE_CONTEXT,
+    ...customContext,
+    member: {
+      ...SAMPLE_CONTEXT.member!,
+      email: to,
+      ...(customContext?.member || {}),
+    },
+  };
+
+  // Render template
+  const renderedSubject = `[TEST] ${replaceTokens(template.subject, context)}`;
+  const renderedHtml = replaceTokens(template.bodyHtml, context);
+  const renderedText = template.bodyText ? replaceTokens(template.bodyText, context) : undefined;
+
+  // Send via provider
+  const provider = getEmailProvider();
+  const result = await provider.send({
+    to,
+    subject: renderedSubject,
+    html: renderedHtml,
+    text: renderedText,
+    from: `${identity.displayName} <${identity.email}>`,
+    replyTo: identity.replyTo || undefined,
+  });
+
+  if (!result.success) {
+    return NextResponse.json(
+      { error: "Send failed", message: result.error || "Failed to send test email" },
+      { status: 500 }
+    );
+  }
+
+  // Log the test send in outbox
+  await prisma.emailOutbox.create({
+    data: {
+      identityId: identity.id,
+      recipientEmail: to,
+      subject: renderedSubject,
+      bodyHtml: renderedHtml,
+      bodyText: renderedText || null,
+      templateId: template.id,
+      templateData: context as unknown as Record<string, unknown>,
+      status: "SENT",
+      sentAt: new Date(),
+      providerMsgId: result.messageId,
+      createdById: auth.context.memberId === "e2e-admin" ? null : auth.context.memberId,
+    },
+  });
+
+  // Audit log
+  await prisma.auditLog.create({
+    data: {
+      action: "SEND",
+      resourceType: "message_template",
+      resourceId: template.id,
+      memberId: auth.context.memberId === "e2e-admin" ? null : auth.context.memberId,
+      metadata: {
+        type: "test_send",
+        to,
+        identityId,
+        messageId: result.messageId,
+      },
+    },
+  });
+
+  return NextResponse.json({
+    success: true,
+    messageId: result.messageId,
+    to,
+    subject: renderedSubject,
+  });
+}

--- a/src/app/api/v1/admin/comms/templates/route.ts
+++ b/src/app/api/v1/admin/comms/templates/route.ts
@@ -1,0 +1,109 @@
+// Copyright (c) Santa Barbara Newcomers Club
+// Message Templates API - CRUD with variable support
+// Charter: P2 (default deny), N8 (template safety - variables validated)
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { requireCapability } from "@/lib/auth";
+import { getAvailableTokens } from "@/lib/publishing/email";
+
+/**
+ * GET /api/v1/admin/comms/templates
+ *
+ * List all message templates with pagination
+ */
+export async function GET(request: NextRequest) {
+  const auth = await requireCapability(request, "comms:manage");
+  if (!auth.ok) return auth.response;
+
+  const { searchParams } = new URL(request.url);
+  const page = Math.max(1, parseInt(searchParams.get("page") || "1", 10));
+  const pageSize = Math.min(100, Math.max(1, parseInt(searchParams.get("pageSize") || "20", 10)));
+  const includeInactive = searchParams.get("includeInactive") === "true";
+
+  const where: Record<string, unknown> = {};
+  if (!includeInactive) {
+    where.isActive = true;
+  }
+
+  const [items, totalItems] = await Promise.all([
+    prisma.messageTemplate.findMany({
+      where,
+      orderBy: { updatedAt: "desc" },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+    }),
+    prisma.messageTemplate.count({ where }),
+  ]);
+
+  return NextResponse.json({
+    items,
+    page,
+    pageSize,
+    totalItems,
+    totalPages: Math.ceil(totalItems / pageSize),
+  });
+}
+
+/**
+ * POST /api/v1/admin/comms/templates
+ *
+ * Create a new message template
+ */
+export async function POST(request: NextRequest) {
+  const auth = await requireCapability(request, "comms:manage");
+  if (!auth.ok) return auth.response;
+
+  const body = await request.json();
+  const { name, slug, subject, bodyHtml, bodyText, tokens, providerOpts } = body;
+
+  // Validate required fields
+  if (!name || !slug || !subject || !bodyHtml) {
+    return NextResponse.json(
+      { error: "Missing required fields", message: "name, slug, subject, and bodyHtml are required" },
+      { status: 400 }
+    );
+  }
+
+  // Validate slug format
+  if (!/^[a-z0-9-]+$/.test(slug)) {
+    return NextResponse.json(
+      { error: "Invalid slug", message: "Slug must contain only lowercase letters, numbers, and hyphens" },
+      { status: 400 }
+    );
+  }
+
+  // Check for duplicate slug
+  const existing = await prisma.messageTemplate.findUnique({ where: { slug } });
+  if (existing) {
+    return NextResponse.json(
+      { error: "Duplicate slug", message: "A template with this slug already exists" },
+      { status: 409 }
+    );
+  }
+
+  const template = await prisma.messageTemplate.create({
+    data: {
+      name,
+      slug,
+      subject,
+      bodyHtml,
+      bodyText: bodyText || null,
+      tokens: tokens || getAvailableTokens(),
+      providerOpts: providerOpts || null,
+    },
+  });
+
+  // Audit log
+  await prisma.auditLog.create({
+    data: {
+      action: "CREATE",
+      resourceType: "message_template",
+      resourceId: template.id,
+      memberId: auth.context.memberId === "e2e-admin" ? null : auth.context.memberId,
+      after: { name, slug, subject } as Record<string, unknown>,
+    },
+  });
+
+  return NextResponse.json(template, { status: 201 });
+}

--- a/src/app/api/v1/admin/comms/templates/tokens/route.ts
+++ b/src/app/api/v1/admin/comms/templates/tokens/route.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Santa Barbara Newcomers Club
+// Available Template Tokens API
+// Charter: P4 (no hidden rules - tokens are documented)
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireCapability } from "@/lib/auth";
+import { getAvailableTokens } from "@/lib/publishing/email";
+
+/**
+ * GET /api/v1/admin/comms/templates/tokens
+ *
+ * Get all available template tokens with documentation
+ */
+export async function GET(request: NextRequest) {
+  const auth = await requireCapability(request, "comms:manage");
+  if (!auth.ok) return auth.response;
+
+  const tokens = getAvailableTokens();
+
+  return NextResponse.json({
+    tokens,
+    usage: "Tokens use {{category.field}} syntax. Example: {{member.firstName}}",
+    notes: [
+      "All token values are HTML-escaped for safety",
+      "Missing values render as empty strings",
+      "Custom tokens can be added via the custom.* namespace",
+    ],
+  });
+}


### PR DESCRIPTION
## Summary

- Add email identity management for sbnewcomers.org from-addresses
- Add role-based control for sender identities
- Add template preview and test-send functionality
- Add email composer UI with recipient management
- Add outbox tracking for email delivery status

## Charter Compliance

| Principle | Implementation |
|-----------|----------------|
| P1 (Provable Identity) | All sends attributed to authenticated users |
| P2 (Default Deny) | Role-based identity access, capability checks on all endpoints |
| P3 (State Machine) | OutboxStatus enum: DRAFT → QUEUED → SENDING → SENT → DELIVERED |
| P4 (No Hidden Rules) | Token documentation available via `/api/v1/admin/comms/templates/tokens` |
| P5 (Reversible) | Soft delete for identities and templates |
| N5 (Idempotent) | Idempotency keys prevent duplicate sends |
| N8 (Template Safety) | HTML escaping, preview before send |

## Template Variables Supported

- **Member**: `{{member.firstName}}`, `{{member.lastName}}`, `{{member.fullName}}`, `{{member.email}}`, `{{member.phone}}`
- **Event**: `{{event.title}}`, `{{event.description}}`, `{{event.location}}`, `{{event.startDate}}`, `{{event.startTime}}`
- **Club**: `{{club.name}}`, `{{club.website}}`, `{{club.email}}`
- **System**: `{{currentYear}}`, `{{currentDate}}`

## How From-Addresses Are Controlled

EmailIdentity records have an `allowedRoles` field (JSON array of role slugs). Only users with matching roles can send from that identity. Admin role can always use any identity.

## Test Plan

- [ ] Visit `/admin/comms/identities` and create a new identity
- [ ] Verify role-based access: non-admin users cannot create identities
- [ ] Visit `/admin/comms/templates` and create a template with variables
- [ ] Use preview to verify variable substitution
- [ ] Use test-send to receive a test email
- [ ] Visit `/admin/comms/compose` and send an email
- [ ] Verify outbox tracking at `/api/v1/admin/comms/outbox`

🤖 Generated with [Claude Code](https://claude.com/claude-code)