### PR TITLE
feat(migration): add WA to ClubOS data migration pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ playwright-report/
 test-results/
 playwright/.cache/
 
+# Migration reports
+scripts/migration/reports/*.json
+
 # Misc
 tmp/mock-email-log.json
 tsconfig.tsbuildinfo

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "next": "^16.0.10",
         "pg": "^8.16.3",
         "react": "^19.2.3",
-        "react-dom": "^19.2.3"
+        "react-dom": "^19.2.3",
+        "yaml": "^2.7.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.57.0",
@@ -9684,6 +9685,21 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "prisma:migrate": "prisma migrate dev",
     "prisma:check-migrations": "bash scripts/ci/check-migration-safety.sh",
     "db:seed": "npx tsx prisma/seed.ts",
+    "migrate:dry-run": "npx tsx scripts/migration/migrate.ts --dry-run",
+    "migrate:live": "npx tsx scripts/migration/migrate.ts --live",
+    "migrate:reset": "npx tsx scripts/migration/reset-sandbox.ts",
     "postinstall": "prisma generate",
     "test:unit": "vitest run",
     "test:unit:coverage": "vitest run --coverage",
@@ -32,7 +35,8 @@
     "next": "^16.0.10",
     "pg": "^8.16.3",
     "react": "^19.2.3",
-    "react-dom": "^19.2.3"
+    "react-dom": "^19.2.3",
+    "yaml": "^2.7.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.57.0",

--- a/scripts/migration/README.md
+++ b/scripts/migration/README.md
@@ -1,0 +1,50 @@
+# ClubOS Data Migration Pipeline
+
+Wild Apricot (WA) → ClubOS data migration tool.
+
+## Quick Start
+
+```bash
+# Dry run with sample data
+npm run migrate:dry-run
+
+# Dry run with real WA exports
+npm run migrate:dry-run -- --data-dir ./wa-export
+
+# Live import
+npm run migrate:live -- --yes --data-dir ./wa-export
+```
+
+## Required WA Exports
+
+### Members (Contacts → Export → CSV)
+- Contact ID, First name, Last name, Email, Phone, Member since, Membership level
+
+### Events (Events → Export)
+- Event ID, Event name, Start date, End date, Location, Registration limit, Tags
+
+### Registrations
+- Registration ID, Contact ID, Event ID, Registration status, Registration date
+
+## ID Reconciliation
+
+- **Members**: Matched by email
+- **Events**: Matched by title + start time (±1 hour)
+- **Registrations**: Matched by member + event
+
+Imports are **idempotent** - safe to re-run.
+
+## Reset Tool
+
+```bash
+npm run migrate:reset                # Preview
+npx tsx scripts/migration/reset-sandbox.ts --confirm "I understand this deletes data"
+```
+
+## Configuration
+
+Edit `config/migration-config.yaml` for field mappings and status translations.
+
+## Reports
+
+Each run generates JSON reports in `scripts/migration/reports/`.

--- a/scripts/migration/config/migration-config.yaml
+++ b/scripts/migration/config/migration-config.yaml
@@ -1,0 +1,91 @@
+# ClubOS Migration Configuration - WA -> ClubOS
+version: "1.0"
+source: "wild-apricot"
+target: "clubos"
+
+membership_status_mapping:
+  "New Member": "NEWCOMER"
+  "Newcomer": "NEWCOMER"
+  "1st Year": "NEWCOMER"
+  "2nd Year": "NEWCOMER"
+  "Third Year": "EXTENDED"
+  "3rd Year": "EXTENDED"
+  "Alumni": "ALUMNI"
+  "Lapsed": "LAPSED"
+  "Prospect": "PROSPECT"
+  _default: "PROSPECT"
+
+member_fields:
+  firstName: "First name"
+  lastName: "Last name"
+  email: "Email"
+  phone: "Phone"
+  joinedAt: "Member since"
+  membershipStatusId:
+    source: "Membership level"
+    transform: "membership_status_lookup"
+  _wa_contact_id: "Contact ID"
+
+event_fields:
+  title: "Event name"
+  description: "Description"
+  category: "Tags"
+  location: "Location"
+  startTime: "Start date"
+  endTime: "End date"
+  capacity: "Registration limit"
+  isPublished: true
+  _wa_event_id: "Event ID"
+
+event_category_mapping:
+  "Social": "Social"
+  "Outdoor": "Outdoor Activities"
+  "Cultural": "Cultural"
+  "Dining": "Dining Out"
+  _default: "General"
+
+registration_fields:
+  memberId:
+    source: "Contact ID"
+    transform: "member_id_lookup"
+  eventId:
+    source: "Event ID"
+    transform: "event_id_lookup"
+  status:
+    source: "Registration status"
+    transform: "registration_status_lookup"
+  registeredAt: "Registration date"
+  cancelledAt: "Cancellation date"
+  _wa_registration_id: "Registration ID"
+
+registration_status_mapping:
+  "Confirmed": "CONFIRMED"
+  "Registered": "CONFIRMED"
+  "Cancelled": "CANCELLED"
+  "Waitlisted": "WAITLISTED"
+  "No show": "NO_SHOW"
+  _default: "CONFIRMED"
+
+id_reconciliation:
+  members:
+    primary_key: "email"
+    on_conflict: "update"
+  events:
+    composite_key: ["title", "startTime"]
+    time_tolerance_minutes: 60
+    on_conflict: "skip"
+  registrations:
+    composite_key: ["memberId", "eventId"]
+    on_conflict: "update"
+
+import_options:
+  batch_size: 100
+  continue_on_error: true
+  date_format: "MM/DD/YYYY"
+  datetime_format: "MM/DD/YYYY HH:mm"
+  source_timezone: "America/Los_Angeles"
+  skip_incomplete: true
+  required_fields:
+    members: ["email", "firstName", "lastName"]
+    events: ["title", "startTime"]
+    registrations: ["memberId", "eventId"]

--- a/scripts/migration/lib/config.ts
+++ b/scripts/migration/lib/config.ts
@@ -1,0 +1,17 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'yaml';
+import type { MigrationConfig } from './types';
+
+export function loadConfig(configPath: string): MigrationConfig {
+  const absolutePath = path.resolve(configPath);
+  if (!fs.existsSync(absolutePath)) throw new Error(`Config not found: ${absolutePath}`);
+  const config = yaml.parse(fs.readFileSync(absolutePath, 'utf-8')) as MigrationConfig;
+  const required = ['version', 'membership_status_mapping', 'member_fields', 'event_fields', 'registration_fields', 'id_reconciliation', 'import_options'];
+  for (const s of required) if (!(s in config)) throw new Error(`Missing section: ${s}`);
+  return config;
+}
+
+export function getDefaultConfigPath(): string {
+  return path.join(__dirname, '..', 'config', 'migration-config.yaml');
+}

--- a/scripts/migration/lib/csv-parser.ts
+++ b/scripts/migration/lib/csv-parser.ts
@@ -1,0 +1,92 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { MigrationConfig, MemberImport, EventImport, RegistrationImport, FieldTransform } from './types';
+
+export function parseCSV(content: string): Array<Record<string, string>> {
+  const lines: string[] = []; let current = '', inQuotes = false;
+  for (let i = 0; i < content.length; i++) {
+    const c = content[i], n = content[i + 1];
+    if (c === '"') { if (inQuotes && n === '"') { current += '"'; i++; } else inQuotes = !inQuotes; }
+    else if ((c === '\n' || (c === '\r' && n === '\n')) && !inQuotes) { if (current.trim()) lines.push(current); current = ''; if (c === '\r') i++; }
+    else if (c !== '\r') current += c;
+  }
+  if (current.trim()) lines.push(current);
+  if (!lines.length) return [];
+  const headers = parseLine(lines[0]);
+  return lines.slice(1).map(line => { const vals = parseLine(line), rec: Record<string, string> = {}; headers.forEach((h, j) => rec[h] = vals[j] || ''); return rec; });
+}
+
+function parseLine(line: string): string[] {
+  const vals: string[] = []; let cur = '', inQ = false;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i], n = line[i + 1];
+    if (c === '"') { if (inQ && n === '"') { cur += '"'; i++; } else inQ = !inQ; }
+    else if (c === ',' && !inQ) { vals.push(cur.trim()); cur = ''; } else cur += c;
+  }
+  vals.push(cur.trim()); return vals;
+}
+
+export function loadCSVFile(filePath: string): Array<Record<string, string>> {
+  const p = path.resolve(filePath);
+  if (!fs.existsSync(p)) throw new Error(`CSV not found: ${p}`);
+  return parseCSV(fs.readFileSync(p, 'utf-8'));
+}
+
+export function mapMemberRecord(row: Record<string, string>, rowIndex: number, config: MigrationConfig): MemberImport {
+  const r: MemberImport = { _sourceRow: rowIndex, firstName: '', lastName: '', email: '', joinedAt: new Date(), membershipStatusCode: 'PROSPECT' };
+  const errs: string[] = [];
+  for (const [tf, ss] of Object.entries(config.member_fields)) {
+    if (tf.startsWith('_')) { if (tf === '_wa_contact_id') r._waId = row[ss as string]; continue; }
+    const v = extractValue(row, ss, config);
+    if (tf === 'joinedAt') r.joinedAt = parseDate(v as string) || new Date();
+    else if (tf === 'membershipStatusId') r.membershipStatusCode = v as string;
+    else (r as Record<string, unknown>)[tf] = v;
+  }
+  if (!r.email) errs.push('Missing email'); if (!r.firstName) errs.push('Missing firstName'); if (!r.lastName) errs.push('Missing lastName');
+  r._errors = errs.length ? errs : undefined; return r;
+}
+
+export function mapEventRecord(row: Record<string, string>, rowIndex: number, config: MigrationConfig): EventImport {
+  const r: EventImport = { _sourceRow: rowIndex, title: '', startTime: new Date(), isPublished: true };
+  const errs: string[] = [];
+  for (const [tf, ss] of Object.entries(config.event_fields)) {
+    if (tf.startsWith('_')) { if (tf === '_wa_event_id') r._waId = row[ss as string]; continue; }
+    const v = extractValue(row, ss, config);
+    if (tf === 'startTime' || tf === 'endTime') { const d = parseDate(v as string); if (d) (r as Record<string, unknown>)[tf] = d; }
+    else if (tf === 'capacity') { const n = parseInt(v as string, 10); if (!isNaN(n) && n > 0) r.capacity = n; }
+    else if (tf === 'category') r.category = config.event_category_mapping[v as string] || config.event_category_mapping._default || v as string;
+    else if (typeof v === 'boolean') (r as Record<string, unknown>)[tf] = v;
+    else (r as Record<string, unknown>)[tf] = v;
+  }
+  if (!r.title) errs.push('Missing title'); if (!r.startTime) errs.push('Missing startTime');
+  r._errors = errs.length ? errs : undefined; return r;
+}
+
+export function mapRegistrationRecord(row: Record<string, string>, rowIndex: number, config: MigrationConfig): RegistrationImport {
+  const r: RegistrationImport = { _sourceRow: rowIndex, memberId: '', eventId: '', status: 'CONFIRMED', registeredAt: new Date() };
+  for (const [tf, ss] of Object.entries(config.registration_fields)) {
+    if (tf.startsWith('_')) { if (tf === '_wa_registration_id') r._waId = row[ss as string]; continue; }
+    const v = extractValue(row, ss, config);
+    if (tf === 'registeredAt' || tf === 'cancelledAt') { const d = parseDate(v as string); if (d) (r as Record<string, unknown>)[tf] = d; }
+    else (r as Record<string, unknown>)[tf] = v;
+  }
+  return r;
+}
+
+function extractValue(row: Record<string, string>, spec: string | boolean | FieldTransform, config: MigrationConfig): string | boolean {
+  if (typeof spec === 'boolean') return spec;
+  if (typeof spec === 'string') return row[spec] || '';
+  const t = spec as FieldTransform, raw = row[t.source] || '';
+  if (t.transform === 'membership_status_lookup') return config.membership_status_mapping[raw] || config.membership_status_mapping._default || 'PROSPECT';
+  if (t.transform === 'registration_status_lookup') return config.registration_status_mapping[raw] || config.registration_status_mapping._default || 'CONFIRMED';
+  return raw;
+}
+
+function parseDate(v: string): Date | null {
+  if (!v?.trim()) return null;
+  const c = v.trim();
+  if (c.includes('T') || c.match(/^\d{4}-\d{2}-\d{2}/)) { const d = new Date(c); if (!isNaN(d.getTime())) return d; }
+  const m = c.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})(?:\s+(\d{1,2}):(\d{2}))?/);
+  if (m) { const d = new Date(+m[3], +m[1] - 1, +m[2], m[4] ? +m[4] : 0, m[5] ? +m[5] : 0); if (!isNaN(d.getTime())) return d; }
+  return null;
+}

--- a/scripts/migration/lib/migration-engine.ts
+++ b/scripts/migration/lib/migration-engine.ts
@@ -1,0 +1,177 @@
+import { PrismaClient } from '@prisma/client';
+import { randomUUID } from 'crypto';
+import * as path from 'path';
+import * as fs from 'fs';
+import type { MigrationConfig, MigrationRunOptions, MigrationReport, MemberImport, EventImport, RegistrationImport, EntityReport } from './types';
+import { loadConfig, getDefaultConfigPath } from './config';
+import { loadCSVFile, mapMemberRecord, mapEventRecord, mapRegistrationRecord } from './csv-parser';
+
+export class MigrationEngine {
+  private prisma: PrismaClient;
+  private config: MigrationConfig;
+  private options: MigrationRunOptions;
+  private report: MigrationReport;
+  private membershipStatuses: Record<string, string> = {};
+  private memberLookup = new Map<string, string>();
+  private eventLookup = new Map<string, string>();
+  private memberIdMap = new Map<string, string>();
+  private eventIdMap = new Map<string, string>();
+
+  constructor(options: MigrationRunOptions) {
+    this.options = options;
+    this.prisma = new PrismaClient();
+    this.config = loadConfig(options.configPath || getDefaultConfigPath());
+    this.report = { runId: randomUUID(), startedAt: new Date(), dryRun: options.dryRun, config: { source: this.config.source, target: this.config.target, version: this.config.version }, summary: { totalRecords: 0, created: 0, updated: 0, skipped: 0, errors: 0, duration_ms: 0 }, members: this.initEntity(), events: this.initEntity(), registrations: this.initEntity(), errors: [], idMapping: { members: [], events: [] } };
+  }
+
+  private initEntity(): EntityReport { return { totalRows: 0, parsed: 0, created: 0, updated: 0, skipped: 0, errors: 0, records: [] }; }
+
+  async run(): Promise<MigrationReport> {
+    const start = Date.now();
+    this.log(`\n${'='.repeat(60)}\nClubOS Migration - ${this.report.runId}\nMode: ${this.options.dryRun ? 'DRY RUN' : 'LIVE'}\n${'='.repeat(60)}\n`);
+    try {
+      await this.loadLookups();
+      if (this.options.membersFile) await this.processMembers();
+      if (this.options.eventsFile) await this.processEvents();
+      if (this.options.registrationsFile) await this.processRegistrations();
+      this.report.summary = { totalRecords: this.report.members.parsed + this.report.events.parsed + this.report.registrations.parsed, created: this.report.members.created + this.report.events.created + this.report.registrations.created, updated: this.report.members.updated + this.report.events.updated + this.report.registrations.updated, skipped: this.report.members.skipped + this.report.events.skipped + this.report.registrations.skipped, errors: this.report.members.errors + this.report.events.errors + this.report.registrations.errors, duration_ms: Date.now() - start };
+    } catch (e) { this.log(`FATAL: ${(e as Error).message}`, 'error'); this.report.errors.push({ entity: 'system', sourceRow: 0, message: (e as Error).message }); }
+    finally { await this.prisma.$disconnect(); }
+    this.report.completedAt = new Date();
+    this.writeReport();
+    this.printSummary();
+    return this.report;
+  }
+
+  private async loadLookups() {
+    this.log('Loading lookups...');
+    for (const s of await this.prisma.membershipStatus.findMany()) this.membershipStatuses[s.code] = s.id;
+    this.log(`  ${Object.keys(this.membershipStatuses).length} statuses`);
+    for (const m of await this.prisma.member.findMany({ select: { id: true, email: true } })) this.memberLookup.set(m.email.toLowerCase(), m.id);
+    this.log(`  ${this.memberLookup.size} members`);
+    for (const e of await this.prisma.event.findMany({ select: { id: true, title: true, startTime: true } })) this.eventLookup.set(this.eventKey(e.title, e.startTime), e.id);
+    this.log(`  ${this.eventLookup.size} events\n`);
+  }
+
+  private eventKey(title: string, time: Date): string { const t = new Date(time); t.setMinutes(0, 0, 0); return `${title.toLowerCase().trim()}|${t.toISOString()}`; }
+
+  private async processMembers() {
+    const file = path.resolve(this.options.dataDir, this.options.membersFile!);
+    this.log(`Members: ${file}`);
+    const rows = loadCSVFile(file);
+    this.report.members.file = file;
+    this.report.members.totalRows = rows.length;
+    for (let i = 0; i < rows.length; i++) {
+      const r = mapMemberRecord(rows[i], i + 2, this.config);
+      this.report.members.parsed++;
+      if (r._errors?.length) { this.report.members.errors++; for (const e of r._errors) this.report.errors.push({ entity: 'member', sourceRow: r._sourceRow, message: e, waId: r._waId }); }
+      await this.processMember(r);
+      this.report.members.records.push(r);
+    }
+    this.log(`  Done: ${this.report.members.created} created, ${this.report.members.updated} updated, ${this.report.members.skipped} skipped\n`);
+  }
+
+  private async processMember(r: MemberImport) {
+    if (r._errors?.length) { r._action = 'skip'; return; }
+    try {
+      const email = r.email.toLowerCase(), existing = this.memberLookup.get(email), statusId = this.membershipStatuses[r.membershipStatusCode];
+      if (!statusId) throw new Error(`Unknown status: ${r.membershipStatusCode}`);
+      if (existing) {
+        if (this.config.id_reconciliation.members.on_conflict === 'skip') { r._action = 'skip'; r._clubosId = existing; this.report.members.skipped++; }
+        else { r._action = 'update'; r._clubosId = existing; if (!this.options.dryRun) await this.prisma.member.update({ where: { id: existing }, data: { firstName: r.firstName, lastName: r.lastName, phone: r.phone || null, joinedAt: r.joinedAt, membershipStatusId: statusId } }); this.report.members.updated++; }
+      } else {
+        r._action = 'create';
+        if (!this.options.dryRun) { const c = await this.prisma.member.create({ data: { firstName: r.firstName, lastName: r.lastName, email: r.email, phone: r.phone || null, joinedAt: r.joinedAt, membershipStatusId: statusId } }); r._clubosId = c.id; this.memberLookup.set(email, c.id); }
+        else r._clubosId = `dry-${randomUUID()}`;
+        this.report.members.created++;
+      }
+      if (r._waId && r._clubosId) { this.memberIdMap.set(r._waId, r._clubosId); this.report.idMapping.members.push({ waId: r._waId, clubosId: r._clubosId, email: r.email }); }
+    } catch (e) { r._action = 'skip'; r._errors = [...(r._errors || []), (e as Error).message]; this.report.members.errors++; this.report.errors.push({ entity: 'member', sourceRow: r._sourceRow, message: (e as Error).message, waId: r._waId }); }
+  }
+
+  private async processEvents() {
+    const file = path.resolve(this.options.dataDir, this.options.eventsFile!);
+    this.log(`Events: ${file}`);
+    const rows = loadCSVFile(file);
+    this.report.events.file = file;
+    this.report.events.totalRows = rows.length;
+    for (let i = 0; i < rows.length; i++) {
+      const r = mapEventRecord(rows[i], i + 2, this.config);
+      this.report.events.parsed++;
+      if (r._errors?.length) { this.report.events.errors++; for (const e of r._errors) this.report.errors.push({ entity: 'event', sourceRow: r._sourceRow, message: e, waId: r._waId }); }
+      await this.processEvent(r);
+      this.report.events.records.push(r);
+    }
+    this.log(`  Done: ${this.report.events.created} created, ${this.report.events.updated} updated, ${this.report.events.skipped} skipped\n`);
+  }
+
+  private async processEvent(r: EventImport) {
+    if (r._errors?.length) { r._action = 'skip'; return; }
+    try {
+      const key = this.eventKey(r.title, r.startTime), existing = this.eventLookup.get(key);
+      if (existing) { r._action = 'skip'; r._clubosId = existing; this.report.events.skipped++; }
+      else {
+        r._action = 'create';
+        if (!this.options.dryRun) { const c = await this.prisma.event.create({ data: { title: r.title, description: r.description || null, category: r.category || null, location: r.location || null, startTime: r.startTime, endTime: r.endTime || null, capacity: r.capacity || null, isPublished: r.isPublished } }); r._clubosId = c.id; this.eventLookup.set(key, c.id); }
+        else r._clubosId = `dry-${randomUUID()}`;
+        this.report.events.created++;
+      }
+      if (r._waId && r._clubosId) { this.eventIdMap.set(r._waId, r._clubosId); this.report.idMapping.events.push({ waId: r._waId, clubosId: r._clubosId, title: r.title }); }
+    } catch (e) { r._action = 'skip'; r._errors = [...(r._errors || []), (e as Error).message]; this.report.events.errors++; this.report.errors.push({ entity: 'event', sourceRow: r._sourceRow, message: (e as Error).message, waId: r._waId }); }
+  }
+
+  private async processRegistrations() {
+    const file = path.resolve(this.options.dataDir, this.options.registrationsFile!);
+    this.log(`Registrations: ${file}`);
+    const rows = loadCSVFile(file);
+    this.report.registrations.file = file;
+    this.report.registrations.totalRows = rows.length;
+    for (let i = 0; i < rows.length; i++) {
+      const r = mapRegistrationRecord(rows[i], i + 2, this.config);
+      const waMember = r.memberId, waEvent = r.eventId;
+      r.memberId = this.memberIdMap.get(waMember) || '';
+      r.eventId = this.eventIdMap.get(waEvent) || '';
+      if (!r.memberId) { r._errors = [...(r._errors || []), `Member not found: ${waMember}`]; }
+      if (!r.eventId) { r._errors = [...(r._errors || []), `Event not found: ${waEvent}`]; }
+      this.report.registrations.parsed++;
+      if (r._errors?.length) { this.report.registrations.errors++; for (const e of r._errors) this.report.errors.push({ entity: 'registration', sourceRow: r._sourceRow, message: e, waId: r._waId }); }
+      await this.processRegistration(r);
+      this.report.registrations.records.push(r);
+    }
+    this.log(`  Done: ${this.report.registrations.created} created, ${this.report.registrations.updated} updated, ${this.report.registrations.skipped} skipped\n`);
+  }
+
+  private async processRegistration(r: RegistrationImport) {
+    if (r._errors?.length) { r._action = 'skip'; return; }
+    try {
+      const existing = this.options.dryRun ? null : await this.prisma.eventRegistration.findUnique({ where: { eventId_memberId: { eventId: r.eventId, memberId: r.memberId } } });
+      const status = r.status as 'CONFIRMED' | 'CANCELLED' | 'WAITLISTED' | 'PENDING' | 'NO_SHOW';
+      if (existing) {
+        if (this.config.id_reconciliation.registrations.on_conflict === 'skip') { r._action = 'skip'; r._clubosId = existing.id; this.report.registrations.skipped++; }
+        else { r._action = 'update'; r._clubosId = existing.id; if (!this.options.dryRun) await this.prisma.eventRegistration.update({ where: { id: existing.id }, data: { status, registeredAt: r.registeredAt, cancelledAt: r.cancelledAt || null } }); this.report.registrations.updated++; }
+      } else {
+        r._action = 'create';
+        if (!this.options.dryRun) { const c = await this.prisma.eventRegistration.create({ data: { eventId: r.eventId, memberId: r.memberId, status, registeredAt: r.registeredAt, cancelledAt: r.cancelledAt || null } }); r._clubosId = c.id; }
+        else r._clubosId = `dry-${randomUUID()}`;
+        this.report.registrations.created++;
+      }
+    } catch (e) { r._action = 'skip'; r._errors = [...(r._errors || []), (e as Error).message]; this.report.registrations.errors++; this.report.errors.push({ entity: 'registration', sourceRow: r._sourceRow, message: (e as Error).message, waId: r._waId }); }
+  }
+
+  private log(msg: string, level: 'info' | 'error' = 'info') { if (this.options.verbose || level === 'error') console.log(level === 'error' ? `[ERROR] ${msg}` : msg); }
+
+  private writeReport() {
+    const dir = path.resolve(this.options.outputDir);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    const ts = new Date().toISOString().replace(/[:.]/g, '-'), mode = this.options.dryRun ? 'dry-run' : 'live';
+    const summary = { ...this.report, members: { ...this.report.members, records: `[${this.report.members.records.length}]` }, events: { ...this.report.events, records: `[${this.report.events.records.length}]` }, registrations: { ...this.report.registrations, records: `[${this.report.registrations.records.length}]` } };
+    fs.writeFileSync(path.join(dir, `migration-${mode}-${ts}.json`), JSON.stringify(summary, null, 2));
+    fs.writeFileSync(path.join(dir, `migration-${mode}-${ts}-full.json`), JSON.stringify(this.report, null, 2));
+    this.log(`Reports written to ${dir}`);
+  }
+
+  private printSummary() {
+    const s = this.report.summary;
+    console.log(`\n${'='.repeat(60)}\nSUMMARY: ${s.totalRecords} total | ${s.created} created | ${s.updated} updated | ${s.skipped} skipped | ${s.errors} errors | ${s.duration_ms}ms\n${'='.repeat(60)}\n`);
+  }
+}

--- a/scripts/migration/lib/types.ts
+++ b/scripts/migration/lib/types.ts
@@ -1,0 +1,21 @@
+export interface MigrationConfig {
+  version: string; source: string; target: string;
+  membership_status_mapping: Record<string, string>;
+  member_fields: Record<string, string | FieldTransform>;
+  event_fields: Record<string, string | boolean | FieldTransform>;
+  event_category_mapping: Record<string, string>;
+  registration_fields: Record<string, string | FieldTransform>;
+  registration_status_mapping: Record<string, string>;
+  id_reconciliation: { members: ReconciliationRule; events: ReconciliationRule; registrations: ReconciliationRule };
+  import_options: ImportOptions;
+}
+export interface FieldTransform { source: string; transform: string; }
+export interface ReconciliationRule { primary_key?: string; composite_key?: string[]; time_tolerance_minutes?: number; on_conflict: 'update' | 'skip'; }
+export interface ImportOptions { batch_size: number; continue_on_error: boolean; date_format: string; datetime_format: string; source_timezone: string; skip_incomplete: boolean; required_fields: { members: string[]; events: string[]; registrations: string[] }; }
+export interface MigrationRecord { _sourceRow: number; _waId?: string; _clubosId?: string; _action?: 'create' | 'update' | 'skip'; _errors?: string[]; [key: string]: unknown; }
+export interface MemberImport extends MigrationRecord { firstName: string; lastName: string; email: string; phone?: string; joinedAt: Date; membershipStatusCode: string; }
+export interface EventImport extends MigrationRecord { title: string; description?: string; category?: string; location?: string; startTime: Date; endTime?: Date; capacity?: number; isPublished: boolean; }
+export interface RegistrationImport extends MigrationRecord { memberId: string; eventId: string; status: string; registeredAt: Date; cancelledAt?: Date; }
+export interface MigrationReport { runId: string; startedAt: Date; completedAt?: Date; dryRun: boolean; config: { source: string; target: string; version: string }; summary: { totalRecords: number; created: number; updated: number; skipped: number; errors: number; duration_ms: number }; members: EntityReport; events: EntityReport; registrations: EntityReport; errors: { entity: string; sourceRow: number; message: string; waId?: string }[]; idMapping: { members: { waId: string; clubosId: string; email?: string }[]; events: { waId: string; clubosId: string; title?: string }[] }; }
+export interface EntityReport { file?: string; totalRows: number; parsed: number; created: number; updated: number; skipped: number; errors: number; records: MigrationRecord[]; }
+export interface MigrationRunOptions { dryRun: boolean; configPath: string; dataDir: string; membersFile?: string; eventsFile?: string; registrationsFile?: string; outputDir: string; verbose: boolean; }

--- a/scripts/migration/migrate.ts
+++ b/scripts/migration/migrate.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env npx tsx
+import { MigrationEngine } from './lib/migration-engine';
+import { getDefaultConfigPath } from './lib/config';
+import * as path from 'path';
+import * as fs from 'fs';
+
+const args = process.argv.slice(2);
+let dryRun = true, dataDir = './scripts/migration/sample-pack', configPath = getDefaultConfigPath();
+let membersFile: string | undefined, eventsFile: string | undefined, registrationsFile: string | undefined;
+let outputDir = './scripts/migration/reports', verbose = true, confirmed = false;
+
+for (let i = 0; i < args.length; i++) {
+  const a = args[i], n = args[i + 1];
+  if (a === '--help' || a === '-h') { console.log(`
+ClubOS Migration - WA to ClubOS
+
+Usage: npx tsx scripts/migration/migrate.ts [OPTIONS]
+
+Options:
+  --dry-run         Preview (default)
+  --live            Write to DB (requires --yes)
+  --yes             Confirm live mode
+  --data-dir, -d    CSV directory
+  --members         Members file
+  --events          Events file
+  --registrations   Registrations file
+  --config, -c      Config path
+  --output, -o      Report directory
+  --quiet           Less output
+
+Examples:
+  npm run migrate:dry-run
+  npm run migrate:live -- --yes --data-dir ./wa-export
+`); process.exit(0); }
+  if (a === '--dry-run') dryRun = true;
+  if (a === '--live') dryRun = false;
+  if (a === '--yes' || a === '-y') confirmed = true;
+  if ((a === '--data-dir' || a === '-d') && n) { dataDir = n; i++; }
+  if ((a === '--config' || a === '-c') && n) { configPath = n; i++; }
+  if (a === '--members' && n) { membersFile = n; i++; }
+  if (a === '--events' && n) { eventsFile = n; i++; }
+  if (a === '--registrations' && n) { registrationsFile = n; i++; }
+  if ((a === '--output' || a === '-o') && n) { outputDir = n; i++; }
+  if (a === '--quiet' || a === '-q') verbose = false;
+}
+
+// Auto-detect
+if (!membersFile && !eventsFile && !registrationsFile) {
+  const dir = path.resolve(dataDir);
+  if (fs.existsSync(dir)) {
+    for (const sub of ['', 'members', 'events']) {
+      const check = path.join(dir, sub);
+      if (fs.existsSync(check) && fs.statSync(check).isDirectory()) {
+        for (const f of fs.readdirSync(check)) {
+          const l = f.toLowerCase();
+          if (l.includes('member') && l.endsWith('.csv') && !membersFile) membersFile = path.join(sub, f);
+          else if (l.includes('event') && !l.includes('registration') && l.endsWith('.csv') && !eventsFile) eventsFile = path.join(sub, f);
+          else if (l.includes('registration') && l.endsWith('.csv') && !registrationsFile) registrationsFile = path.join(sub, f);
+        }
+      }
+    }
+  }
+}
+
+if (!membersFile && !eventsFile && !registrationsFile) { console.error('No CSV files found.'); process.exit(1); }
+if (!dryRun && !confirmed) { console.log('\n⚠️ LIVE MODE requires --yes\n'); process.exit(1); }
+
+new MigrationEngine({ dryRun, configPath, dataDir, membersFile, eventsFile, registrationsFile, outputDir, verbose })
+  .run().then(r => process.exit(r.summary.errors > 0 ? 1 : 0)).catch(e => { console.error(e); process.exit(1); });

--- a/scripts/migration/reports/.gitkeep
+++ b/scripts/migration/reports/.gitkeep
@@ -1,0 +1,1 @@
+# Migration reports are generated here

--- a/scripts/migration/reset-sandbox.ts
+++ b/scripts/migration/reset-sandbox.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env npx tsx
+import { PrismaClient } from '@prisma/client';
+
+const args = process.argv.slice(2);
+let dryRun = true, confirmed = false;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--dry-run') dryRun = true;
+  if (args[i] === '--confirm' && args[i + 1] === 'I understand this deletes data') { confirmed = true; dryRun = false; i++; }
+  if (args[i] === '--help') { console.log(`
+Reset Sandbox - ⚠️ Deletes data!
+
+Usage: npx tsx scripts/migration/reset-sandbox.ts [OPTIONS]
+
+Options:
+  --dry-run                     Preview (default)
+  --confirm "I understand..."   Actually delete
+
+Deletes: registrations, events, members, user accounts, role assignments, service history
+Preserves: membership statuses, committees, terms
+`); process.exit(0); }
+}
+
+async function main() {
+  const prisma = new PrismaClient();
+  const dbUrl = process.env.DATABASE_URL || '';
+  if (dbUrl.includes('prod')) { console.error('❌ Production database!'); process.exit(1); }
+  console.log(`\n${'='.repeat(40)}\nReset Sandbox${dryRun ? ' (DRY RUN)' : ''}\n${'='.repeat(40)}`);
+  if (!dryRun && !confirmed) { console.error('Use: --confirm "I understand this deletes data"'); process.exit(1); }
+  try {
+    const counts = { payments: await prisma.paymentIntent.count(), regs: await prisma.eventRegistration.count(), events: await prisma.event.count(), roles: await prisma.roleAssignment.count(), history: await prisma.memberServiceHistory.count(), users: await prisma.userAccount.count(), members: await prisma.member.count() };
+    console.log('Counts:', counts);
+    if (dryRun) { console.log('\nUse --confirm "I understand this deletes data" to delete'); return; }
+    await prisma.paymentIntent.deleteMany();
+    await prisma.eventRegistration.deleteMany();
+    await prisma.transitionAssignment.deleteMany();
+    await prisma.memberServiceHistory.deleteMany();
+    await prisma.transitionPlan.deleteMany();
+    await prisma.roleAssignment.deleteMany();
+    await prisma.event.deleteMany();
+    await prisma.userAccount.deleteMany();
+    await prisma.member.deleteMany();
+    console.log('✅ Done');
+  } finally { await prisma.$disconnect(); }
+}
+main();

--- a/scripts/migration/sample-pack/events/wa-events-export.csv
+++ b/scripts/migration/sample-pack/events/wa-events-export.csv
@@ -1,0 +1,4 @@
+Event ID,Event name,Description,Tags,Location,Start date,End date,Registration limit
+EVT001,Welcome Coffee,Monthly new member welcome,Social,Handlebar Coffee,01/15/2024 09:00,01/15/2024 11:00,30
+EVT002,Wine Tasting,Local wineries visit,Dining,Foxen Winery,02/10/2024 13:00,02/10/2024 17:00,24
+EVT003,Hiking,Moderate 4-mile hike,Outdoor,Inspiration Point,02/24/2024 08:00,02/24/2024 12:00,20

--- a/scripts/migration/sample-pack/events/wa-registrations-export.csv
+++ b/scripts/migration/sample-pack/events/wa-registrations-export.csv
@@ -1,0 +1,6 @@
+Registration ID,Contact ID,Event ID,Registration status,Registration date,Cancellation date
+REG001,WA001,EVT001,Confirmed,01/10/2024,
+REG002,WA002,EVT001,Confirmed,01/11/2024,
+REG003,WA003,EVT002,Confirmed,02/01/2024,
+REG004,WA001,EVT003,Confirmed,02/15/2024,
+REG005,WA002,EVT002,Cancelled,02/03/2024,02/08/2024

--- a/scripts/migration/sample-pack/members/wa-members-export.csv
+++ b/scripts/migration/sample-pack/members/wa-members-export.csv
@@ -1,0 +1,6 @@
+Contact ID,Member ID,First name,Last name,Email,Phone,Member since,Membership level
+WA001,M001,Alice,Anderson,alice@example.com,805-555-0101,01/15/2024,Newcomer
+WA002,M002,Bob,Baker,bob@example.com,805-555-0102,06/01/2023,2nd Year
+WA003,M003,Carol,Chen,carol@example.com,805-555-0103,01/10/2022,Third Year
+WA004,M004,David,Davis,david@example.com,805-555-0104,03/20/2024,New Member
+WA005,M005,Eva,Edwards,eva@example.com,,08/15/2021,Alumni


### PR DESCRIPTION
## Summary

Adds repeatable, configurable migration pipeline for importing SBNC data from Wild Apricot.

- YAML config for field mappings and ID reconciliation rules
- CSV parser with dry-run mode and JSON reports  
- Idempotent imports: members by email, events by title+time
- Reset-sandbox tool with safety guards
- npm scripts: migrate:dry-run, migrate:live, migrate:reset

## Usage

```bash
npm run migrate:dry-run -- --data-dir ./wa-export
npm run migrate:live -- --yes --data-dir ./wa-export
```

## Assumptions

- WA exports use MM/DD/YYYY format
- Members have unique emails
- Membership statuses exist in ClubOS

## Required WA exports

1. Members: Contact ID, First name, Last name, Email, Phone, Member since, Membership level
2. Events: Event ID, Event name, Start date, End date, Location
3. Registrations: Registration ID, Contact ID, Event ID, Registration status, Registration date

🤖 Generated with [Claude Code](https://claude.com/claude-code)