### PR TITLE
feat: Add WYSIWYG drag-and-drop page editor

### DIFF
--- a/docs/WYSIWYG_PAGE_EDITOR.md
+++ b/docs/WYSIWYG_PAGE_EDITOR.md
@@ -1,0 +1,203 @@
+# WYSIWYG Page Editor
+
+## Overview
+
+The WYSIWYG Page Editor provides a drag-and-drop interface for creating and editing pages in ClubOS. It supports SBNC's publishing needs including public and member-only pages while maintaining compatibility with themes and templates.
+
+## Architecture
+
+### Technology Stack
+
+- **Drag-and-Drop:** @dnd-kit (core, sortable, utilities)
+- **Rich Text Editing:** Tiptap (React-based ProseMirror wrapper)
+- **Framework:** React 19 with Next.js 16 App Router
+
+### Component Structure
+
+```
+src/components/editor/
+├── PageEditor.tsx         # Main editor orchestrator
+├── BlockPalette.tsx       # Block type selection panel
+├── SortableBlockList.tsx  # Drag-drop block list with @dnd-kit
+├── BlockEditors.tsx       # Individual block type editors
+└── RichTextEditor.tsx     # Tiptap-based rich text for text blocks
+```
+
+### Routes
+
+- `/admin/content/pages` - Page list (existing)
+- `/admin/content/pages/new` - Create new page
+- `/admin/content/pages/[id]` - Edit existing page
+
+## Block Types
+
+The editor supports 11 block types organized by category:
+
+### Content
+
+- **Hero** - Full-width header with background image, title, subtitle, CTA
+- **Text** - Rich text content with formatting (bold, italic, lists, headings)
+- **Cards** - Grid of content cards (2-4 columns)
+- **FAQ** - Accordion-style Q&A sections
+
+### Media
+
+- **Image** - Single image with alt text, caption, optional link
+- **Gallery** - Image grid with optional lightbox
+
+### Interactive
+
+- **Event List** - Dynamic list of upcoming events (widget)
+- **Contact** - Contact form with configurable fields
+- **CTA** - Call-to-action button with customizable style
+
+### Layout
+
+- **Divider** - Horizontal line separator
+- **Spacer** - Vertical spacing control
+
+## Features
+
+### Drag-and-Drop Reordering
+
+Blocks can be reordered by dragging the handle on the left side. Uses @dnd-kit for accessible, keyboard-navigable drag-and-drop.
+
+### Rich Text Editing
+
+Text blocks use Tiptap editor with toolbar for:
+
+- Bold, italic, strikethrough
+- Headings (H2, H3)
+- Bullet and numbered lists
+- Blockquotes
+- Undo/redo
+
+### Page Lifecycle
+
+Pages follow the status workflow:
+
+- **DRAFT** - Initial state, not visible to public
+- **PUBLISHED** - Visible according to visibility settings
+- **ARCHIVED** - Hidden from all users
+
+### Visibility Settings
+
+- **PUBLIC** - Visible to everyone
+- **MEMBERS_ONLY** - Requires authentication
+- **ROLE_RESTRICTED** - Requires specific role (with audience rules)
+
+### Auto-Save Warning
+
+The editor warns users before navigating away with unsaved changes via `beforeunload` event.
+
+### Preview
+
+Inline preview iframe shows live changes (requires page to be saved first).
+
+## Permissions
+
+The editor requires `publishing:manage` capability, which is granted to:
+
+- webmaster
+- admin
+
+The webmaster role can create, edit, and publish pages but cannot delete published pages (requires `admin:full`).
+
+## API Endpoints
+
+All endpoints require `publishing:manage` capability.
+
+### List Pages
+
+```
+GET /api/admin/content/pages
+Query: page, pageSize, status, visibility, search
+```
+
+### Create Page
+
+```
+POST /api/admin/content/pages
+Body: { slug, title, description?, visibility?, content? }
+```
+
+### Get Page
+
+```
+GET /api/admin/content/pages/[id]
+```
+
+### Update Page
+
+```
+PUT /api/admin/content/pages/[id]
+Body: { title?, slug?, description?, visibility?, content?, seoTitle?, seoDescription? }
+```
+
+### Delete Page
+
+```
+DELETE /api/admin/content/pages/[id]
+Note: Deleting PUBLISHED pages requires admin:full
+```
+
+### Publish/Unpublish/Archive
+
+```
+POST /api/admin/content/pages/[id]?action=publish
+POST /api/admin/content/pages/[id]?action=unpublish
+POST /api/admin/content/pages/[id]?action=archive
+```
+
+## Future Enhancements
+
+### Planned Widget Blocks
+
+- Event list (implemented)
+- Mentorship card
+- Member directory
+- Photo gallery from events
+
+### Advanced Features
+
+- Custom CSS per page (Tech Chair role only)
+- Template-based page creation
+- Scheduled publishing
+- Page versioning/history
+- Asset manager integration
+
+## Testing
+
+E2E tests in `tests/admin/admin-content-page-editor.spec.ts` cover:
+
+- Creating new pages with blocks
+- Adding and reordering blocks
+- Editing block content
+- Publish/unpublish workflow
+- Unsaved changes warning
+- Deleting blocks
+- Block palette completeness
+
+Run tests:
+
+```bash
+npx playwright test tests/admin/admin-content-page-editor.spec.ts
+```
+
+## Configuration
+
+No additional configuration required. The editor uses existing theme system for styling previews.
+
+## Troubleshooting
+
+### Blocks Not Saving
+
+Ensure you click "Save" before publishing. Unsaved changes prevent publishing.
+
+### Preview Not Updating
+
+The preview iframe loads the public page URL. Save changes first, then refresh preview.
+
+### Rich Text Formatting Lost
+
+Content is stored as HTML. Ensure the BlockRenderer component handles all formatting tags.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,15 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@prisma/adapter-pg": "^7.1.0",
         "@prisma/client": "^7.1.0",
+        "@tiptap/extension-placeholder": "^3.13.0",
+        "@tiptap/pm": "^3.13.0",
+        "@tiptap/react": "^3.13.0",
+        "@tiptap/starter-kit": "^3.13.0",
         "next": "^16.0.10",
         "pg": "^8.16.3",
         "react": "^19.2.3",
@@ -322,6 +329,59 @@
       "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==",
       "devOptional": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@electric-sql/pglite": {
       "version": "0.3.2",
@@ -971,6 +1031,34 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.6",
@@ -1972,6 +2060,12 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@remirror/core-constants": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
+      "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -2266,6 +2360,453 @@
         "tailwindcss": "4.1.17"
       }
     },
+    "node_modules/@tiptap/core": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.13.0.tgz",
+      "integrity": "sha512-iUelgiTMgPVMpY5ZqASUpk8mC8HuR9FWKaDzK27w9oWip9tuB54Z8mePTxNcQaSPb6ErzEaC8x8egrRt7OsdGQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.13.0.tgz",
+      "integrity": "sha512-K1z/PAIIwEmiWbzrP//4cC7iG1TZknDlF1yb42G7qkx2S2X4P0NiqX7sKOej3yqrPjKjGwPujLMSuDnCF87QkQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.13.0.tgz",
+      "integrity": "sha512-VYiDN9EEwR6ShaDLclG8mphkb/wlIzqfk7hxaKboq1G+NSDj8PcaSI9hldKKtTCLeaSNu6UR5nkdu/YHdzYWTw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bubble-menu": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.13.0.tgz",
+      "integrity": "sha512-qZ3j2DBsqP9DjG2UlExQ+tHMRhAnWlCKNreKddKocb/nAFrPdBCtvkqIEu+68zPlbLD4ukpoyjUklRJg+NipFg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.13.0",
+        "@tiptap/pm": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.13.0.tgz",
+      "integrity": "sha512-fFQmmEUoPzRGiQJ/KKutG35ZX21GE+1UCDo8Q6PoWH7Al9lex47nvyeU1BiDYOhcTKgIaJRtEH5lInsOsRJcSA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.13.0.tgz",
+      "integrity": "sha512-sF5raBni6iSVpXWvwJCAcOXw5/kZ+djDHx1YSGWhopm4+fsj0xW7GvVO+VTwiFjZGKSw+K5NeAxzcQTJZd3Vhw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.13.0.tgz",
+      "integrity": "sha512-kIwfQ4iqootsWg9e74iYJK54/YMIj6ahUxEltjZRML5z/h4gTDcQt2eTpnEC8yjDjHeUVOR94zH9auCySyk9CQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.13.0",
+        "@tiptap/pm": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.13.0.tgz",
+      "integrity": "sha512-RjU7hTJwjKXIdY57o/Pc+Yr8swLkrwT7PBQ/m+LCX5oO/V2wYoWCjoBYnK5KSHrWlNy/aLzC33BvLeqZZ9nzlQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.13.0.tgz",
+      "integrity": "sha512-m7GPT3c/83ni+bbU8c+3dpNa8ug+aQ4phNB1Q52VQG3oTonDJnZS7WCtn3lB/Hi1LqoqMtEHwhepU2eD+JeXqQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-floating-menu": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.13.0.tgz",
+      "integrity": "sha512-OsezV2cMofZM4c13gvgi93IEYBUzZgnu8BXTYZQiQYekz4bX4uulBmLa1KOA9EN71FzS+SoLkXHU0YzlbLjlxA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "^3.13.0",
+        "@tiptap/pm": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.13.0.tgz",
+      "integrity": "sha512-KVxjQKkd964nin+1IdM2Dvej/Jy4JTMcMgq5seusUhJ9T9P8F9s2D5Iefwgkps3OCzub/aF+eAsZe+1P5KSIgA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.13.0.tgz",
+      "integrity": "sha512-nH1OBaO+/pakhu+P1jF208mPgB70IKlrR/9d46RMYoYbqJTNf4KVLx5lHAOHytIhjcNg+MjyTfJWfkK+dyCCyg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.13.0.tgz",
+      "integrity": "sha512-8VKWX8waYPtUWN97J89em9fOtxNteh6pvUEd0htcOAtoxjt2uZjbW5N4lKyWhNKifZBrVhH2Cc2NUPuftCVgxw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.13.0.tgz",
+      "integrity": "sha512-ZUFyORtjj22ib8ykbxRhWFQOTZjNKqOsMQjaAGof30cuD2DN5J5pMz7Haj2fFRtLpugWYH+f0Mi+WumQXC3hCw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.13.0",
+        "@tiptap/pm": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.13.0.tgz",
+      "integrity": "sha512-XbVTgmzk1kgUMTirA6AGdLTcKHUvEJoh3R4qMdPtwwygEOe7sBuvKuLtF6AwUtpnOM+Y3tfWUTNEDWv9AcEdww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.13.0.tgz",
+      "integrity": "sha512-LuFPJ5GoL12GHW4A+USsj60O90pLcwUPdvEUSWewl9USyG6gnLnY/j5ZOXPYH7LiwYW8+lhq7ABwrDF2PKyBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.13.0",
+        "@tiptap/pm": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.13.0.tgz",
+      "integrity": "sha512-MMFH0jQ4LeCPkJJFyZ77kt6eM/vcKujvTbMzW1xSHCIEA6s4lEcx9QdZMPpfmnOvTzeoVKR4nsu2t2qT9ZXzAw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.13.0",
+        "@tiptap/pm": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.13.0.tgz",
+      "integrity": "sha512-63NbcS/XeQP2jcdDEnEAE3rjJICDj8y1SN1h/MsJmSt1LusnEo8WQ2ub86QELO6XnD3M04V03cY6Knf6I5mTkw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.13.0.tgz",
+      "integrity": "sha512-P+HtIa1iwosb1feFc8B/9MN5EAwzS+/dZ0UH0CTF2E4wnp5Z9OMxKl1IYjfiCwHzZrU5Let+S/maOvJR/EmV0g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.13.0.tgz",
+      "integrity": "sha512-QuDyLzuK/3vCvx9GeKhgvHWrGECBzmJyAx6gli2HY+Iil7XicbfltV4nvhIxgxzpx3LDHLKzJN9pBi+2MzX60g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.13.0.tgz",
+      "integrity": "sha512-9csQde1i0yeZI5oQQ9e1GYNtGL2JcC2d8Fwtw9FsGC8yz2W0h+Fmk+3bc2kobbtO5LGqupSc1fKM8fAg5rSRDg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-placeholder": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.13.0.tgz",
+      "integrity": "sha512-Au4ktRBraQktX9gjSzGWyJV6kPof7+kOhzE8ej+rOMjIrHbx3DCHy1CJWftSO9BbqIyonjsFmm4nE+vjzZ3Z5Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.13.0.tgz",
+      "integrity": "sha512-VHhWNqTAMOfrC48m2FcPIZB0nhl6XHQviAV16SBc+EFznKNv9tQUsqQrnuQ2y6ZVfqq5UxvZ3hKF/JlN/Ff7xw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.13.0.tgz",
+      "integrity": "sha512-VcZIna93rixw7hRkHGCxDbL3kvJWi80vIT25a2pXg0WP1e7Pi3nBYvZIL4SQtkbBCji9EHrbZx3p8nNPzfazYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.13.0.tgz",
+      "integrity": "sha512-VDQi+UYw0tFnfghpthJTFmtJ3yx90kXeDwFvhmT8G+O+si5VmP05xYDBYBmYCix5jqKigJxEASiBL0gYOgMDEg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.13.0.tgz",
+      "integrity": "sha512-i7O0ptSibEtTy+2PIPsNKEvhTvMaFJg1W4Oxfnbuxvaigs7cJV9Q0lwDUcc7CPsNw2T1+44wcxg431CzTvdYoA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.13.0",
+        "@tiptap/pm": "^3.13.0"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.13.0.tgz",
+      "integrity": "sha512-WKR4ucALq+lwx0WJZW17CspeTpXorbIOpvKv5mulZica6QxqfMhn8n1IXCkDws/mCoLRx4Drk5d377tIjFNsvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-collab": "^1.3.1",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-inputrules": "^1.4.0",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-markdown": "^1.13.1",
+        "prosemirror-menu": "^1.2.4",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-schema-basic": "^1.2.3",
+        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-trailing-node": "^3.0.0",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.38.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/react": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.13.0.tgz",
+      "integrity": "sha512-VqpqNZ9qtPr3pWK4NsZYxXgLSEiAnzl6oS7tEGmkkvJbcGSC+F7R13Xc9twv/zT5QCLxaHdEbmxHbuAIkrMgJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "fast-equals": "^5.3.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "optionalDependencies": {
+        "@tiptap/extension-bubble-menu": "^3.13.0",
+        "@tiptap/extension-floating-menu": "^3.13.0"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.13.0",
+        "@tiptap/pm": "^3.13.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.13.0.tgz",
+      "integrity": "sha512-Ojn6sRub04CRuyQ+9wqN62JUOMv+rG1vXhc2s6DCBCpu28lkCMMW+vTe7kXJcEdbot82+5swPbERw9vohswFzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^3.13.0",
+        "@tiptap/extension-blockquote": "^3.13.0",
+        "@tiptap/extension-bold": "^3.13.0",
+        "@tiptap/extension-bullet-list": "^3.13.0",
+        "@tiptap/extension-code": "^3.13.0",
+        "@tiptap/extension-code-block": "^3.13.0",
+        "@tiptap/extension-document": "^3.13.0",
+        "@tiptap/extension-dropcursor": "^3.13.0",
+        "@tiptap/extension-gapcursor": "^3.13.0",
+        "@tiptap/extension-hard-break": "^3.13.0",
+        "@tiptap/extension-heading": "^3.13.0",
+        "@tiptap/extension-horizontal-rule": "^3.13.0",
+        "@tiptap/extension-italic": "^3.13.0",
+        "@tiptap/extension-link": "^3.13.0",
+        "@tiptap/extension-list": "^3.13.0",
+        "@tiptap/extension-list-item": "^3.13.0",
+        "@tiptap/extension-list-keymap": "^3.13.0",
+        "@tiptap/extension-ordered-list": "^3.13.0",
+        "@tiptap/extension-paragraph": "^3.13.0",
+        "@tiptap/extension-strike": "^3.13.0",
+        "@tiptap/extension-text": "^3.13.0",
+        "@tiptap/extension-underline": "^3.13.0",
+        "@tiptap/extensions": "^3.13.0",
+        "@tiptap/pm": "^3.13.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2298,6 +2839,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.26",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.26.tgz",
@@ -2324,7 +2887,6 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2334,11 +2896,16 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.49.0",
@@ -2938,7 +3505,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -3496,6 +4062,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3515,7 +4087,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -3774,6 +4345,18 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-abstract": {
       "version": "1.24.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
@@ -4007,7 +4590,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4476,6 +5058,15 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -5938,6 +6529,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
+      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "license": "MIT"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -6024,6 +6630,23 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6033,6 +6656,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -6424,6 +7053,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
@@ -6857,11 +7492,215 @@
       "devOptional": true,
       "license": "ISC"
     },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.3.1.tgz",
+      "integrity": "sha512-j0kORIBm8ayJNl3zQvD1TTPHJX3g042et6y/KQhZhnPrruO8exkTgG8X+NRpj7kIyMMEx74Xb3DyMIBtO0IKkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-collab": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
+      "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.0.tgz",
+      "integrity": "sha512-z00qvurSdCEWUIulij/isHaqu4uLS8r/Fi61IbjdIPJEonQgggbJsLnstW7Lgdk4zQ68/yr6B6bf7sJXowIgdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-markdown": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.2.tgz",
+      "integrity": "sha512-FPD9rHPdA9fqzNmIIDhhnYQ6WgNoSWX9StUZ8LEKapaXU9i6XgykaHKhp6XMyXlOWetmaFgGDS/nu/w9/vUc5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "^14.0.0",
+        "markdown-it": "^14.0.0",
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-menu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.2.5.tgz",
+      "integrity": "sha512-qwXzynnpBIeg1D7BAtjOusR+81xCp53j7iWu/IargiRZqRjGIlQuu1f3jFi+ehrHhWMLoyOQTSRx/IWZJqOYtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "crelt": "^1.0.0",
+        "prosemirror-commands": "^1.0.0",
+        "prosemirror-history": "^1.0.0",
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-basic": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
+      "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.3.tgz",
+      "integrity": "sha512-wbqCR/RlRPRe41a4LFtmhKElzBEfBTdtAYWNIGHM6X2e24NN/MTNUKyXjjphfAfdQce37Kh/5yf765mLPYDe7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-trailing-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
+      "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remirror/core-constants": "3.0.0",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-state": "^1.4.2",
+        "prosemirror-view": "^1.33.8"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.10.5.tgz",
+      "integrity": "sha512-RPDQCxIDhIBb1o36xxwsaeAvivO8VLJcgBtzmOwQ64bMtsVFh5SSuJ6dWSxO1UsHTiTXPCgQm3PDJt7p6IOLbw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.4.tgz",
+      "integrity": "sha512-WkKgnyjNncri03Gjaz3IFWvCAE94XoiEgvtr0/r2Xw7R8/IjK3sKLSiDoCHWcsXSAinVaKlGRZDvMCsF1kbzjA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7080,6 +7919,12 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -7963,6 +8808,12 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -8065,6 +8916,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/valibot": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
@@ -8079,6 +8939,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,15 @@
     "seed": "npx tsx prisma/seed.ts"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@prisma/adapter-pg": "^7.1.0",
     "@prisma/client": "^7.1.0",
+    "@tiptap/extension-placeholder": "^3.13.0",
+    "@tiptap/pm": "^3.13.0",
+    "@tiptap/react": "^3.13.0",
+    "@tiptap/starter-kit": "^3.13.0",
     "next": "^16.0.10",
     "pg": "^8.16.3",
     "react": "^19.2.3",

--- a/src/app/admin/content/pages/[id]/PageEditorClient.tsx
+++ b/src/app/admin/content/pages/[id]/PageEditorClient.tsx
@@ -1,0 +1,353 @@
+"use client";
+
+// Copyright (c) Santa Barbara Newcomers Club
+// Page editor client component with full editing capabilities
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { PageContent, createDefaultPageContent } from "@/lib/publishing/blocks";
+import PageEditor from "@/components/editor/PageEditor";
+
+type PageData = {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  status: "DRAFT" | "PUBLISHED" | "ARCHIVED";
+  visibility: "PUBLIC" | "MEMBERS_ONLY" | "ROLE_RESTRICTED";
+  content: PageContent;
+  seoTitle: string | null;
+  seoDescription: string | null;
+  publishedAt: string | null;
+  updatedAt: string;
+  template: { id: string; name: string; slug: string } | null;
+  theme: { id: string; name: string; slug: string } | null;
+};
+
+type PageEditorClientProps = {
+  pageId: string;
+};
+
+export default function PageEditorClient({ pageId }: PageEditorClientProps) {
+  const [page, setPage] = useState<PageData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+
+  // Form state
+  const [title, setTitle] = useState("");
+  const [slug, setSlug] = useState("");
+  const [description, setDescription] = useState("");
+  const [visibility, setVisibility] = useState<"PUBLIC" | "MEMBERS_ONLY" | "ROLE_RESTRICTED">("PUBLIC");
+  const [content, setContent] = useState<PageContent>(createDefaultPageContent());
+
+  // Preview state
+  const [showPreview, setShowPreview] = useState(false);
+
+  // Load page data
+  useEffect(() => {
+    async function loadPage() {
+      try {
+        const res = await fetch(`/api/admin/content/pages/${pageId}`);
+        if (!res.ok) {
+          if (res.status === 404) {
+            setError("Page not found");
+          } else {
+            setError("Failed to load page");
+          }
+          return;
+        }
+        const data = await res.json();
+        const p = data.page as PageData;
+        setPage(p);
+        setTitle(p.title);
+        setSlug(p.slug);
+        setDescription(p.description || "");
+        setVisibility(p.visibility);
+        setContent(p.content || createDefaultPageContent());
+      } catch {
+        setError("Failed to load page");
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadPage();
+  }, [pageId]);
+
+  // Track unsaved changes
+  useEffect(() => {
+    if (!page) return;
+    const hasChanges =
+      title !== page.title ||
+      slug !== page.slug ||
+      description !== (page.description || "") ||
+      visibility !== page.visibility ||
+      JSON.stringify(content) !== JSON.stringify(page.content);
+    setHasUnsavedChanges(hasChanges);
+  }, [page, title, slug, description, visibility, content]);
+
+  // Warn before leaving with unsaved changes
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (hasUnsavedChanges) {
+        e.preventDefault();
+      }
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [hasUnsavedChanges]);
+
+  const handleSave = useCallback(async () => {
+    if (!page) return;
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/admin/content/pages/${pageId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title,
+          slug,
+          description: description || null,
+          visibility,
+          content,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.message || "Failed to save page");
+      }
+
+      const data = await res.json();
+      setPage((prev) =>
+        prev
+          ? {
+              ...prev,
+              title: data.page.title,
+              slug: data.page.slug,
+              description: data.page.description,
+              visibility: data.page.visibility,
+              content: content,
+              updatedAt: data.page.updatedAt,
+            }
+          : null
+      );
+      setHasUnsavedChanges(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save page");
+    } finally {
+      setSaving(false);
+    }
+  }, [page, pageId, title, slug, description, visibility, content]);
+
+  const handlePublish = useCallback(async () => {
+    if (!page || hasUnsavedChanges) return;
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/admin/content/pages/${pageId}?action=publish`, {
+        method: "POST",
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.message || "Failed to publish page");
+      }
+
+      const data = await res.json();
+      setPage((prev) => (prev ? { ...prev, status: "PUBLISHED", publishedAt: data.page.publishedAt } : null));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to publish page");
+    } finally {
+      setSaving(false);
+    }
+  }, [page, pageId, hasUnsavedChanges]);
+
+  const handleUnpublish = useCallback(async () => {
+    if (!page) return;
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/admin/content/pages/${pageId}?action=unpublish`, {
+        method: "POST",
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.message || "Failed to unpublish page");
+      }
+
+      setPage((prev) => (prev ? { ...prev, status: "DRAFT" } : null));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to unpublish page");
+    } finally {
+      setSaving(false);
+    }
+  }, [page, pageId]);
+
+  const handleArchive = useCallback(async () => {
+    if (!page) return;
+    if (!confirm("Are you sure you want to archive this page? It will no longer be visible.")) return;
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/admin/content/pages/${pageId}?action=archive`, {
+        method: "POST",
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.message || "Failed to archive page");
+      }
+
+      setPage((prev) => (prev ? { ...prev, status: "ARCHIVED" } : null));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to archive page");
+    } finally {
+      setSaving(false);
+    }
+  }, [page, pageId]);
+
+  const handleContentChange = useCallback((newContent: PageContent) => {
+    setContent(newContent);
+  }, []);
+
+  if (loading) {
+    return (
+      <div style={{ padding: "20px" }}>
+        <p>Loading page...</p>
+      </div>
+    );
+  }
+
+  if (error && !page) {
+    return (
+      <div style={{ padding: "20px" }}>
+        <p style={{ color: "#c00" }}>{error}</p>
+        <Link href="/admin/content/pages" style={{ color: "#0066cc" }}>
+          Back to pages
+        </Link>
+      </div>
+    );
+  }
+
+  if (!page) {
+    return null;
+  }
+
+  const statusBadgeStyle = {
+    DRAFT: { bg: "#fff3e0", text: "#995500" },
+    PUBLISHED: { bg: "#e6ffe6", text: "#006600" },
+    ARCHIVED: { bg: "#f0f0f0", text: "#666666" },
+  }[page.status];
+
+  return (
+    <div data-test-id="page-editor-root" style={{ padding: "20px", maxWidth: "1400px" }}>
+      {/* Header */}
+      <div style={{ marginBottom: "20px" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "12px", marginBottom: "8px" }}>
+          <Link href="/admin/content/pages" style={{ color: "#666", textDecoration: "none", fontSize: "14px" }}>
+            ← Pages
+          </Link>
+          <span style={{ padding: "2px 8px", borderRadius: "4px", fontSize: "12px", backgroundColor: statusBadgeStyle.bg, color: statusBadgeStyle.text }}>
+            {page.status}
+          </span>
+          {hasUnsavedChanges && (
+            <span style={{ fontSize: "12px", color: "#c60" }}>• Unsaved changes</span>
+          )}
+        </div>
+        <h1 style={{ margin: "0 0 4px 0", fontSize: "24px" }}>{page.title}</h1>
+        <p style={{ margin: 0, fontSize: "13px", color: "#666" }}>URL: /{page.slug}</p>
+      </div>
+
+      {/* Action bar */}
+      <div style={{ display: "flex", gap: "8px", marginBottom: "20px", padding: "12px 16px", backgroundColor: "#f5f5f5", borderRadius: "6px", alignItems: "center", flexWrap: "wrap" }}>
+        <button data-test-id="save-page-button" onClick={handleSave} disabled={saving || !hasUnsavedChanges} style={{ padding: "8px 16px", fontSize: "14px", fontWeight: 500, backgroundColor: hasUnsavedChanges ? "#0066cc" : "#ccc", color: "#fff", border: "none", borderRadius: "4px", cursor: saving || !hasUnsavedChanges ? "not-allowed" : "pointer" }}>
+          {saving ? "Saving..." : "Save"}
+        </button>
+
+        <button data-test-id="preview-page-button" onClick={() => setShowPreview(!showPreview)} style={{ padding: "8px 16px", fontSize: "14px", backgroundColor: "#fff", color: "#333", border: "1px solid #ddd", borderRadius: "4px", cursor: "pointer" }}>
+          {showPreview ? "Hide Preview" : "Preview"}
+        </button>
+
+        <div style={{ flex: 1 }} />
+
+        {page.status === "DRAFT" && (
+          <button data-test-id="publish-page-button" onClick={handlePublish} disabled={saving || hasUnsavedChanges} title={hasUnsavedChanges ? "Save changes first" : "Publish page"} style={{ padding: "8px 16px", fontSize: "14px", fontWeight: 500, backgroundColor: hasUnsavedChanges ? "#ccc" : "#060", color: "#fff", border: "none", borderRadius: "4px", cursor: saving || hasUnsavedChanges ? "not-allowed" : "pointer" }}>
+            Publish
+          </button>
+        )}
+
+        {page.status === "PUBLISHED" && (
+          <button data-test-id="unpublish-page-button" onClick={handleUnpublish} disabled={saving} style={{ padding: "8px 16px", fontSize: "14px", backgroundColor: "#fff", color: "#c60", border: "1px solid #c60", borderRadius: "4px", cursor: saving ? "not-allowed" : "pointer" }}>
+            Unpublish
+          </button>
+        )}
+
+        {page.status !== "ARCHIVED" && (
+          <button data-test-id="archive-page-button" onClick={handleArchive} disabled={saving} style={{ padding: "8px 16px", fontSize: "14px", backgroundColor: "#fff", color: "#666", border: "1px solid #ddd", borderRadius: "4px", cursor: saving ? "not-allowed" : "pointer" }}>
+            Archive
+          </button>
+        )}
+      </div>
+
+      {/* Error message */}
+      {error && (
+        <div style={{ padding: "12px 16px", backgroundColor: "#fee", color: "#c00", borderRadius: "4px", marginBottom: "16px", fontSize: "14px" }}>
+          {error}
+        </div>
+      )}
+
+      {/* Preview mode */}
+      {showPreview && (
+        <div data-test-id="page-preview" style={{ marginBottom: "24px", border: "1px solid #ddd", borderRadius: "8px", overflow: "hidden" }}>
+          <div style={{ padding: "8px 12px", backgroundColor: "#f5f5f5", borderBottom: "1px solid #ddd", fontSize: "12px", color: "#666" }}>
+            Preview (live changes) — <a href={`/${slug}`} target="_blank" rel="noopener noreferrer" style={{ color: "#0066cc" }}>Open in new tab</a>
+          </div>
+          <iframe src={`/${slug}?preview=true`} style={{ width: "100%", height: "500px", border: "none", backgroundColor: "#fff" }} title="Page preview" />
+        </div>
+      )}
+
+      {/* Page settings */}
+      <div style={{ display: "flex", gap: "24px", marginBottom: "24px" }}>
+        <div style={{ flex: "1 1 300px" }}>
+          <label style={{ display: "block", fontSize: "12px", fontWeight: 500, marginBottom: "4px", color: "#555" }}>Title</label>
+          <input type="text" value={title} onChange={(e) => setTitle(e.target.value)} data-test-id="page-title-input" style={{ width: "100%", padding: "8px 10px", fontSize: "14px", border: "1px solid #ddd", borderRadius: "4px", boxSizing: "border-box" }} />
+        </div>
+        <div style={{ flex: "1 1 200px" }}>
+          <label style={{ display: "block", fontSize: "12px", fontWeight: 500, marginBottom: "4px", color: "#555" }}>URL Slug</label>
+          <input type="text" value={slug} onChange={(e) => setSlug(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ""))} data-test-id="page-slug-input" style={{ width: "100%", padding: "8px 10px", fontSize: "14px", border: "1px solid #ddd", borderRadius: "4px", boxSizing: "border-box", fontFamily: "monospace" }} />
+        </div>
+        <div style={{ flex: "1 1 150px" }}>
+          <label style={{ display: "block", fontSize: "12px", fontWeight: 500, marginBottom: "4px", color: "#555" }}>Visibility</label>
+          <select value={visibility} onChange={(e) => setVisibility(e.target.value as "PUBLIC" | "MEMBERS_ONLY" | "ROLE_RESTRICTED")} data-test-id="page-visibility-select" style={{ width: "100%", padding: "8px 10px", fontSize: "14px", border: "1px solid #ddd", borderRadius: "4px", boxSizing: "border-box", backgroundColor: "#fff" }}>
+            <option value="PUBLIC">Public</option>
+            <option value="MEMBERS_ONLY">Members Only</option>
+            <option value="ROLE_RESTRICTED">Role Restricted</option>
+          </select>
+        </div>
+      </div>
+
+      <div style={{ marginBottom: "24px" }}>
+        <label style={{ display: "block", fontSize: "12px", fontWeight: 500, marginBottom: "4px", color: "#555" }}>Description (SEO)</label>
+        <textarea value={description} onChange={(e) => setDescription(e.target.value)} data-test-id="page-description-input" style={{ width: "100%", padding: "8px 10px", fontSize: "14px", border: "1px solid #ddd", borderRadius: "4px", boxSizing: "border-box", minHeight: "60px", resize: "vertical" }} placeholder="Brief description for search engines..." />
+      </div>
+
+      {/* Block editor */}
+      <div style={{ marginBottom: "24px" }}>
+        <h2 style={{ fontSize: "16px", fontWeight: 600, marginBottom: "12px" }}>Page Content</h2>
+        <PageEditor initialContent={content} onChange={handleContentChange} disabled={saving} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/content/pages/[id]/page.tsx
+++ b/src/app/admin/content/pages/[id]/page.tsx
@@ -1,0 +1,14 @@
+// Copyright (c) Santa Barbara Newcomers Club
+// Page editor route - Edit existing page
+
+import PageEditorClient from "./PageEditorClient";
+
+type PageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function AdminPageEditorPage({ params }: PageProps) {
+  const { id } = await params;
+
+  return <PageEditorClient pageId={id} />;
+}

--- a/src/app/admin/content/pages/new/page.tsx
+++ b/src/app/admin/content/pages/new/page.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+// Copyright (c) Santa Barbara Newcomers Club
+// Create new page route
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { PageContent, createDefaultPageContent } from "@/lib/publishing/blocks";
+import PageEditor from "@/components/editor/PageEditor";
+
+export default function AdminNewPagePage() {
+  const router = useRouter();
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Form state
+  const [title, setTitle] = useState("");
+  const [slug, setSlug] = useState("");
+  const [description, setDescription] = useState("");
+  const [visibility, setVisibility] = useState<"PUBLIC" | "MEMBERS_ONLY" | "ROLE_RESTRICTED">("PUBLIC");
+  const [content, setContent] = useState<PageContent>(createDefaultPageContent());
+
+  // Auto-generate slug from title
+  const handleTitleChange = (newTitle: string) => {
+    setTitle(newTitle);
+    // Only auto-generate if slug hasn't been manually edited
+    if (!slug || slug === generateSlug(title)) {
+      setSlug(generateSlug(newTitle));
+    }
+  };
+
+  const handleCreate = useCallback(async () => {
+    if (!title.trim()) {
+      setError("Title is required");
+      return;
+    }
+    if (!slug.trim()) {
+      setError("URL slug is required");
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/admin/content/pages", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: title.trim(),
+          slug: slug.trim(),
+          description: description.trim() || null,
+          visibility,
+          content,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.message || "Failed to create page");
+      }
+
+      const data = await res.json();
+      router.push(`/admin/content/pages/${data.page.id}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create page");
+      setSaving(false);
+    }
+  }, [title, slug, description, visibility, content, router]);
+
+  const handleContentChange = useCallback((newContent: PageContent) => {
+    setContent(newContent);
+  }, []);
+
+  return (
+    <div data-test-id="new-page-root" style={{ padding: "20px", maxWidth: "1400px" }}>
+      {/* Header */}
+      <div style={{ marginBottom: "20px" }}>
+        <Link href="/admin/content/pages" style={{ color: "#666", textDecoration: "none", fontSize: "14px" }}>
+          ← Pages
+        </Link>
+        <h1 style={{ margin: "8px 0 0 0", fontSize: "24px" }}>Create New Page</h1>
+      </div>
+
+      {/* Action bar */}
+      <div style={{ display: "flex", gap: "8px", marginBottom: "20px", padding: "12px 16px", backgroundColor: "#f5f5f5", borderRadius: "6px", alignItems: "center" }}>
+        <button data-test-id="create-page-button" onClick={handleCreate} disabled={saving || !title.trim() || !slug.trim()} style={{ padding: "8px 16px", fontSize: "14px", fontWeight: 500, backgroundColor: !title.trim() || !slug.trim() ? "#ccc" : "#0066cc", color: "#fff", border: "none", borderRadius: "4px", cursor: saving || !title.trim() || !slug.trim() ? "not-allowed" : "pointer" }}>
+          {saving ? "Creating..." : "Create Page"}
+        </button>
+        <span style={{ fontSize: "13px", color: "#666" }}>Page will be created as Draft</span>
+      </div>
+
+      {/* Error message */}
+      {error && (
+        <div style={{ padding: "12px 16px", backgroundColor: "#fee", color: "#c00", borderRadius: "4px", marginBottom: "16px", fontSize: "14px" }}>
+          {error}
+        </div>
+      )}
+
+      {/* Page settings */}
+      <div style={{ display: "flex", gap: "24px", marginBottom: "24px" }}>
+        <div style={{ flex: "1 1 300px" }}>
+          <label style={{ display: "block", fontSize: "12px", fontWeight: 500, marginBottom: "4px", color: "#555" }}>
+            Title <span style={{ color: "#c00" }}>*</span>
+          </label>
+          <input type="text" value={title} onChange={(e) => handleTitleChange(e.target.value)} data-test-id="new-page-title-input" placeholder="Page title" style={{ width: "100%", padding: "8px 10px", fontSize: "14px", border: "1px solid #ddd", borderRadius: "4px", boxSizing: "border-box" }} />
+        </div>
+        <div style={{ flex: "1 1 200px" }}>
+          <label style={{ display: "block", fontSize: "12px", fontWeight: 500, marginBottom: "4px", color: "#555" }}>
+            URL Slug <span style={{ color: "#c00" }}>*</span>
+          </label>
+          <input type="text" value={slug} onChange={(e) => setSlug(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ""))} data-test-id="new-page-slug-input" placeholder="page-url" style={{ width: "100%", padding: "8px 10px", fontSize: "14px", border: "1px solid #ddd", borderRadius: "4px", boxSizing: "border-box", fontFamily: "monospace" }} />
+        </div>
+        <div style={{ flex: "1 1 150px" }}>
+          <label style={{ display: "block", fontSize: "12px", fontWeight: 500, marginBottom: "4px", color: "#555" }}>Visibility</label>
+          <select value={visibility} onChange={(e) => setVisibility(e.target.value as "PUBLIC" | "MEMBERS_ONLY" | "ROLE_RESTRICTED")} data-test-id="new-page-visibility-select" style={{ width: "100%", padding: "8px 10px", fontSize: "14px", border: "1px solid #ddd", borderRadius: "4px", boxSizing: "border-box", backgroundColor: "#fff" }}>
+            <option value="PUBLIC">Public</option>
+            <option value="MEMBERS_ONLY">Members Only</option>
+            <option value="ROLE_RESTRICTED">Role Restricted</option>
+          </select>
+        </div>
+      </div>
+
+      <div style={{ marginBottom: "24px" }}>
+        <label style={{ display: "block", fontSize: "12px", fontWeight: 500, marginBottom: "4px", color: "#555" }}>Description (SEO)</label>
+        <textarea value={description} onChange={(e) => setDescription(e.target.value)} data-test-id="new-page-description-input" style={{ width: "100%", padding: "8px 10px", fontSize: "14px", border: "1px solid #ddd", borderRadius: "4px", boxSizing: "border-box", minHeight: "60px", resize: "vertical" }} placeholder="Brief description for search engines..." />
+      </div>
+
+      {/* Block editor */}
+      <div style={{ marginBottom: "24px" }}>
+        <h2 style={{ fontSize: "16px", fontWeight: 600, marginBottom: "12px" }}>Page Content</h2>
+        <PageEditor initialContent={content} onChange={handleContentChange} disabled={saving} />
+      </div>
+    </div>
+  );
+}
+
+function generateSlug(title: string): string {
+  return title.toLowerCase().replace(/[^a-z0-9\s-]/g, "").replace(/\s+/g, "-").replace(/-+/g, "-").slice(0, 50);
+}

--- a/src/components/editor/BlockEditors.tsx
+++ b/src/components/editor/BlockEditors.tsx
@@ -1,0 +1,439 @@
+"use client";
+
+// Copyright (c) Santa Barbara Newcomers Club
+// Block editor components for each block type
+
+import { Block, HeroBlock, TextBlock, ImageBlock, CardsBlock, EventListBlock, GalleryBlock, FaqBlock, ContactBlock, CtaBlock, DividerBlock, SpacerBlock } from "@/lib/publishing/blocks";
+import RichTextEditor from "./RichTextEditor";
+
+type BlockEditorProps<T extends Block> = {
+  block: T;
+  onChange: (block: T) => void;
+  disabled?: boolean;
+};
+
+// Form field component
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ marginBottom: "12px" }}>
+      <label style={{ display: "block", fontSize: "12px", fontWeight: 500, marginBottom: "4px", color: "#555" }}>
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+// Input styles
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "8px 10px",
+  fontSize: "14px",
+  border: "1px solid #ddd",
+  borderRadius: "4px",
+  boxSizing: "border-box",
+};
+
+const selectStyle: React.CSSProperties = {
+  ...inputStyle,
+  backgroundColor: "#fff",
+};
+
+// Hero Block Editor
+export function HeroBlockEditor({ block, onChange, disabled }: BlockEditorProps<HeroBlock>) {
+  const updateData = (updates: Partial<HeroBlock["data"]>) => {
+    onChange({ ...block, data: { ...block.data, ...updates } });
+  };
+
+  return (
+    <div data-test-id="hero-block-editor">
+      <Field label="Title">
+        <input type="text" value={block.data.title} onChange={(e) => updateData({ title: e.target.value })} disabled={disabled} style={inputStyle} data-test-id="hero-title-input" />
+      </Field>
+      <Field label="Subtitle">
+        <input type="text" value={block.data.subtitle || ""} onChange={(e) => updateData({ subtitle: e.target.value || undefined })} disabled={disabled} style={inputStyle} placeholder="Optional subtitle" />
+      </Field>
+      <Field label="Background Image URL">
+        <input type="text" value={block.data.backgroundImage || ""} onChange={(e) => updateData({ backgroundImage: e.target.value || undefined })} disabled={disabled} style={inputStyle} placeholder="https://example.com/image.jpg" />
+      </Field>
+      <Field label="Text Alignment">
+        <select value={block.data.alignment || "center"} onChange={(e) => updateData({ alignment: e.target.value as "left" | "center" | "right" })} disabled={disabled} style={selectStyle}>
+          <option value="left">Left</option>
+          <option value="center">Center</option>
+          <option value="right">Right</option>
+        </select>
+      </Field>
+      <Field label="CTA Button Text">
+        <input type="text" value={block.data.ctaText || ""} onChange={(e) => updateData({ ctaText: e.target.value || undefined })} disabled={disabled} style={inputStyle} placeholder="Learn More" />
+      </Field>
+      <Field label="CTA Button Link">
+        <input type="text" value={block.data.ctaLink || ""} onChange={(e) => updateData({ ctaLink: e.target.value || undefined })} disabled={disabled} style={inputStyle} placeholder="/about" />
+      </Field>
+    </div>
+  );
+}
+
+// Text Block Editor
+export function TextBlockEditor({ block, onChange, disabled }: BlockEditorProps<TextBlock>) {
+  const updateData = (updates: Partial<TextBlock["data"]>) => {
+    onChange({ ...block, data: { ...block.data, ...updates } });
+  };
+
+  return (
+    <div data-test-id="text-block-editor">
+      <Field label="Content">
+        <RichTextEditor content={block.data.content} onChange={(html) => updateData({ content: html })} disabled={disabled} placeholder="Enter your text content..." />
+      </Field>
+      <Field label="Alignment">
+        <select value={block.data.alignment || "left"} onChange={(e) => updateData({ alignment: e.target.value as "left" | "center" | "right" })} disabled={disabled} style={selectStyle}>
+          <option value="left">Left</option>
+          <option value="center">Center</option>
+          <option value="right">Right</option>
+        </select>
+      </Field>
+    </div>
+  );
+}
+
+// Image Block Editor
+export function ImageBlockEditor({ block, onChange, disabled }: BlockEditorProps<ImageBlock>) {
+  const updateData = (updates: Partial<ImageBlock["data"]>) => {
+    onChange({ ...block, data: { ...block.data, ...updates } });
+  };
+
+  return (
+    <div data-test-id="image-block-editor">
+      <Field label="Image URL">
+        <input type="text" value={block.data.src} onChange={(e) => updateData({ src: e.target.value })} disabled={disabled} style={inputStyle} placeholder="https://example.com/image.jpg" data-test-id="image-src-input" />
+      </Field>
+      <Field label="Alt Text (for accessibility)">
+        <input type="text" value={block.data.alt} onChange={(e) => updateData({ alt: e.target.value })} disabled={disabled} style={inputStyle} placeholder="Describe the image" data-test-id="image-alt-input" />
+      </Field>
+      <Field label="Caption">
+        <input type="text" value={block.data.caption || ""} onChange={(e) => updateData({ caption: e.target.value || undefined })} disabled={disabled} style={inputStyle} placeholder="Optional caption" />
+      </Field>
+      <Field label="Link URL">
+        <input type="text" value={block.data.linkUrl || ""} onChange={(e) => updateData({ linkUrl: e.target.value || undefined })} disabled={disabled} style={inputStyle} placeholder="Optional: make image clickable" />
+      </Field>
+      <Field label="Alignment">
+        <select value={block.data.alignment || "center"} onChange={(e) => updateData({ alignment: e.target.value as "left" | "center" | "right" })} disabled={disabled} style={selectStyle}>
+          <option value="left">Left</option>
+          <option value="center">Center</option>
+          <option value="right">Right</option>
+        </select>
+      </Field>
+    </div>
+  );
+}
+
+// Cards Block Editor
+export function CardsBlockEditor({ block, onChange, disabled }: BlockEditorProps<CardsBlock>) {
+  const updateData = (updates: Partial<CardsBlock["data"]>) => {
+    onChange({ ...block, data: { ...block.data, ...updates } });
+  };
+
+  const addCard = () => {
+    const newCard = { title: "New Card", description: "" };
+    updateData({ cards: [...block.data.cards, newCard] });
+  };
+
+  const updateCard = (index: number, updates: Partial<CardsBlock["data"]["cards"][0]>) => {
+    const newCards = [...block.data.cards];
+    newCards[index] = { ...newCards[index], ...updates };
+    updateData({ cards: newCards });
+  };
+
+  const removeCard = (index: number) => {
+    updateData({ cards: block.data.cards.filter((_, i) => i !== index) });
+  };
+
+  return (
+    <div data-test-id="cards-block-editor">
+      <Field label="Columns">
+        <select value={block.data.columns || 3} onChange={(e) => updateData({ columns: parseInt(e.target.value) as 2 | 3 | 4 })} disabled={disabled} style={selectStyle}>
+          <option value={2}>2 columns</option>
+          <option value={3}>3 columns</option>
+          <option value={4}>4 columns</option>
+        </select>
+      </Field>
+      <div style={{ marginTop: "16px" }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "8px" }}>
+          <span style={{ fontSize: "12px", fontWeight: 500, color: "#555" }}>Cards ({block.data.cards.length})</span>
+          <button type="button" onClick={addCard} disabled={disabled} style={{ padding: "4px 10px", fontSize: "12px", backgroundColor: "#0066cc", color: "#fff", border: "none", borderRadius: "4px", cursor: disabled ? "not-allowed" : "pointer" }}>+ Add Card</button>
+        </div>
+        {block.data.cards.map((card, index) => (
+          <div key={index} style={{ padding: "12px", backgroundColor: "#f9f9f9", borderRadius: "4px", marginBottom: "8px" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", marginBottom: "8px" }}>
+              <span style={{ fontSize: "11px", color: "#666" }}>Card {index + 1}</span>
+              <button type="button" onClick={() => removeCard(index)} disabled={disabled} style={{ padding: "2px 6px", fontSize: "11px", backgroundColor: "#fff", color: "#c00", border: "1px solid #ddd", borderRadius: "3px", cursor: disabled ? "not-allowed" : "pointer" }}>Remove</button>
+            </div>
+            <input type="text" value={card.title} onChange={(e) => updateCard(index, { title: e.target.value })} disabled={disabled} style={{ ...inputStyle, marginBottom: "6px" }} placeholder="Card title" />
+            <textarea value={card.description || ""} onChange={(e) => updateCard(index, { description: e.target.value || undefined })} disabled={disabled} style={{ ...inputStyle, minHeight: "60px", resize: "vertical" }} placeholder="Card description" />
+            <input type="text" value={card.image || ""} onChange={(e) => updateCard(index, { image: e.target.value || undefined })} disabled={disabled} style={{ ...inputStyle, marginTop: "6px" }} placeholder="Image URL (optional)" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// Event List Block Editor
+export function EventListBlockEditor({ block, onChange, disabled }: BlockEditorProps<EventListBlock>) {
+  const updateData = (updates: Partial<EventListBlock["data"]>) => {
+    onChange({ ...block, data: { ...block.data, ...updates } });
+  };
+
+  return (
+    <div data-test-id="event-list-block-editor">
+      <Field label="Section Title">
+        <input type="text" value={block.data.title || ""} onChange={(e) => updateData({ title: e.target.value || undefined })} disabled={disabled} style={inputStyle} placeholder="Upcoming Events" />
+      </Field>
+      <Field label="Number of Events">
+        <input type="number" value={block.data.limit || 5} onChange={(e) => updateData({ limit: parseInt(e.target.value) || 5 })} disabled={disabled} style={inputStyle} min={1} max={20} />
+      </Field>
+      <Field label="Layout">
+        <select value={block.data.layout || "list"} onChange={(e) => updateData({ layout: e.target.value as "list" | "cards" | "calendar" })} disabled={disabled} style={selectStyle}>
+          <option value="list">List</option>
+          <option value="cards">Cards</option>
+          <option value="calendar">Calendar</option>
+        </select>
+      </Field>
+      <Field label="Show Past Events">
+        <label style={{ display: "flex", alignItems: "center", gap: "8px", cursor: "pointer" }}>
+          <input type="checkbox" checked={block.data.showPastEvents || false} onChange={(e) => updateData({ showPastEvents: e.target.checked })} disabled={disabled} />
+          <span style={{ fontSize: "14px" }}>Include past events</span>
+        </label>
+      </Field>
+    </div>
+  );
+}
+
+// Gallery Block Editor
+export function GalleryBlockEditor({ block, onChange, disabled }: BlockEditorProps<GalleryBlock>) {
+  const updateData = (updates: Partial<GalleryBlock["data"]>) => {
+    onChange({ ...block, data: { ...block.data, ...updates } });
+  };
+
+  const addImage = () => {
+    const newImage = { src: "", alt: "Image" };
+    updateData({ images: [...block.data.images, newImage] });
+  };
+
+  const updateImage = (index: number, updates: Partial<GalleryBlock["data"]["images"][0]>) => {
+    const newImages = [...block.data.images];
+    newImages[index] = { ...newImages[index], ...updates };
+    updateData({ images: newImages });
+  };
+
+  const removeImage = (index: number) => {
+    updateData({ images: block.data.images.filter((_, i) => i !== index) });
+  };
+
+  return (
+    <div data-test-id="gallery-block-editor">
+      <Field label="Columns">
+        <select value={block.data.columns || 3} onChange={(e) => updateData({ columns: parseInt(e.target.value) as 2 | 3 | 4 })} disabled={disabled} style={selectStyle}>
+          <option value={2}>2 columns</option>
+          <option value={3}>3 columns</option>
+          <option value={4}>4 columns</option>
+        </select>
+      </Field>
+      <Field label="Enable Lightbox">
+        <label style={{ display: "flex", alignItems: "center", gap: "8px", cursor: "pointer" }}>
+          <input type="checkbox" checked={block.data.enableLightbox ?? true} onChange={(e) => updateData({ enableLightbox: e.target.checked })} disabled={disabled} />
+          <span style={{ fontSize: "14px" }}>Click to enlarge images</span>
+        </label>
+      </Field>
+      <div style={{ marginTop: "16px" }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "8px" }}>
+          <span style={{ fontSize: "12px", fontWeight: 500, color: "#555" }}>Images ({block.data.images.length})</span>
+          <button type="button" onClick={addImage} disabled={disabled} style={{ padding: "4px 10px", fontSize: "12px", backgroundColor: "#0066cc", color: "#fff", border: "none", borderRadius: "4px", cursor: disabled ? "not-allowed" : "pointer" }}>+ Add Image</button>
+        </div>
+        {block.data.images.map((image, index) => (
+          <div key={index} style={{ padding: "10px", backgroundColor: "#f9f9f9", borderRadius: "4px", marginBottom: "6px", display: "flex", gap: "8px", alignItems: "flex-start" }}>
+            <div style={{ flex: 1 }}>
+              <input type="text" value={image.src} onChange={(e) => updateImage(index, { src: e.target.value })} disabled={disabled} style={{ ...inputStyle, marginBottom: "4px" }} placeholder="Image URL" />
+              <input type="text" value={image.alt} onChange={(e) => updateImage(index, { alt: e.target.value })} disabled={disabled} style={inputStyle} placeholder="Alt text" />
+            </div>
+            <button type="button" onClick={() => removeImage(index)} disabled={disabled} style={{ padding: "4px 8px", fontSize: "14px", backgroundColor: "#fff", color: "#c00", border: "1px solid #ddd", borderRadius: "3px", cursor: disabled ? "not-allowed" : "pointer" }}>×</button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// FAQ Block Editor
+export function FaqBlockEditor({ block, onChange, disabled }: BlockEditorProps<FaqBlock>) {
+  const updateData = (updates: Partial<FaqBlock["data"]>) => {
+    onChange({ ...block, data: { ...block.data, ...updates } });
+  };
+
+  const addItem = () => {
+    const newItem = { question: "New Question", answer: "" };
+    updateData({ items: [...block.data.items, newItem] });
+  };
+
+  const updateItem = (index: number, updates: Partial<FaqBlock["data"]["items"][0]>) => {
+    const newItems = [...block.data.items];
+    newItems[index] = { ...newItems[index], ...updates };
+    updateData({ items: newItems });
+  };
+
+  const removeItem = (index: number) => {
+    updateData({ items: block.data.items.filter((_, i) => i !== index) });
+  };
+
+  return (
+    <div data-test-id="faq-block-editor">
+      <Field label="Section Title">
+        <input type="text" value={block.data.title || ""} onChange={(e) => updateData({ title: e.target.value || undefined })} disabled={disabled} style={inputStyle} placeholder="Frequently Asked Questions" />
+      </Field>
+      <div style={{ marginTop: "16px" }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "8px" }}>
+          <span style={{ fontSize: "12px", fontWeight: 500, color: "#555" }}>Questions ({block.data.items.length})</span>
+          <button type="button" onClick={addItem} disabled={disabled} style={{ padding: "4px 10px", fontSize: "12px", backgroundColor: "#0066cc", color: "#fff", border: "none", borderRadius: "4px", cursor: disabled ? "not-allowed" : "pointer" }}>+ Add Question</button>
+        </div>
+        {block.data.items.map((item, index) => (
+          <div key={index} style={{ padding: "12px", backgroundColor: "#f9f9f9", borderRadius: "4px", marginBottom: "8px" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", marginBottom: "8px" }}>
+              <span style={{ fontSize: "11px", color: "#666" }}>Q{index + 1}</span>
+              <button type="button" onClick={() => removeItem(index)} disabled={disabled} style={{ padding: "2px 6px", fontSize: "11px", backgroundColor: "#fff", color: "#c00", border: "1px solid #ddd", borderRadius: "3px", cursor: disabled ? "not-allowed" : "pointer" }}>Remove</button>
+            </div>
+            <input type="text" value={item.question} onChange={(e) => updateItem(index, { question: e.target.value })} disabled={disabled} style={{ ...inputStyle, marginBottom: "6px" }} placeholder="Question" />
+            <textarea value={item.answer} onChange={(e) => updateItem(index, { answer: e.target.value })} disabled={disabled} style={{ ...inputStyle, minHeight: "80px", resize: "vertical" }} placeholder="Answer" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// Contact Block Editor
+export function ContactBlockEditor({ block, onChange, disabled }: BlockEditorProps<ContactBlock>) {
+  const updateData = (updates: Partial<ContactBlock["data"]>) => {
+    onChange({ ...block, data: { ...block.data, ...updates } });
+  };
+
+  return (
+    <div data-test-id="contact-block-editor">
+      <Field label="Section Title">
+        <input type="text" value={block.data.title || ""} onChange={(e) => updateData({ title: e.target.value || undefined })} disabled={disabled} style={inputStyle} placeholder="Contact Us" />
+      </Field>
+      <Field label="Description">
+        <textarea value={block.data.description || ""} onChange={(e) => updateData({ description: e.target.value || undefined })} disabled={disabled} style={{ ...inputStyle, minHeight: "60px", resize: "vertical" }} placeholder="Optional description above the form" />
+      </Field>
+      <Field label="Recipient Email">
+        <input type="email" value={block.data.recipientEmail} onChange={(e) => updateData({ recipientEmail: e.target.value })} disabled={disabled} style={inputStyle} placeholder="info@example.com" data-test-id="contact-recipient-input" />
+      </Field>
+      <Field label="Submit Button Text">
+        <input type="text" value={block.data.submitText || ""} onChange={(e) => updateData({ submitText: e.target.value || undefined })} disabled={disabled} style={inputStyle} placeholder="Send Message" />
+      </Field>
+      <p style={{ fontSize: "11px", color: "#666", marginTop: "8px" }}>
+        Default form fields: Name, Email, Message. Custom field configuration coming soon.
+      </p>
+    </div>
+  );
+}
+
+// CTA Block Editor
+export function CtaBlockEditor({ block, onChange, disabled }: BlockEditorProps<CtaBlock>) {
+  const updateData = (updates: Partial<CtaBlock["data"]>) => {
+    onChange({ ...block, data: { ...block.data, ...updates } });
+  };
+
+  return (
+    <div data-test-id="cta-block-editor">
+      <Field label="Button Text">
+        <input type="text" value={block.data.text} onChange={(e) => updateData({ text: e.target.value })} disabled={disabled} style={inputStyle} placeholder="Click Here" data-test-id="cta-text-input" />
+      </Field>
+      <Field label="Link URL">
+        <input type="text" value={block.data.link} onChange={(e) => updateData({ link: e.target.value })} disabled={disabled} style={inputStyle} placeholder="/signup" data-test-id="cta-link-input" />
+      </Field>
+      <Field label="Style">
+        <select value={block.data.style || "primary"} onChange={(e) => updateData({ style: e.target.value as "primary" | "secondary" | "outline" })} disabled={disabled} style={selectStyle}>
+          <option value="primary">Primary (filled)</option>
+          <option value="secondary">Secondary</option>
+          <option value="outline">Outline</option>
+        </select>
+      </Field>
+      <Field label="Size">
+        <select value={block.data.size || "medium"} onChange={(e) => updateData({ size: e.target.value as "small" | "medium" | "large" })} disabled={disabled} style={selectStyle}>
+          <option value="small">Small</option>
+          <option value="medium">Medium</option>
+          <option value="large">Large</option>
+        </select>
+      </Field>
+      <Field label="Alignment">
+        <select value={block.data.alignment || "center"} onChange={(e) => updateData({ alignment: e.target.value as "left" | "center" | "right" })} disabled={disabled} style={selectStyle}>
+          <option value="left">Left</option>
+          <option value="center">Center</option>
+          <option value="right">Right</option>
+        </select>
+      </Field>
+    </div>
+  );
+}
+
+// Divider Block Editor
+export function DividerBlockEditor({ block, onChange, disabled }: BlockEditorProps<DividerBlock>) {
+  const updateData = (updates: Partial<DividerBlock["data"]>) => {
+    onChange({ ...block, data: { ...block.data, ...updates } });
+  };
+
+  return (
+    <div data-test-id="divider-block-editor">
+      <Field label="Style">
+        <select value={block.data.style || "solid"} onChange={(e) => updateData({ style: e.target.value as "solid" | "dashed" | "dotted" })} disabled={disabled} style={selectStyle}>
+          <option value="solid">Solid</option>
+          <option value="dashed">Dashed</option>
+          <option value="dotted">Dotted</option>
+        </select>
+      </Field>
+      <Field label="Width">
+        <select value={block.data.width || "full"} onChange={(e) => updateData({ width: e.target.value as "full" | "half" | "quarter" })} disabled={disabled} style={selectStyle}>
+          <option value="full">Full width</option>
+          <option value="half">Half width</option>
+          <option value="quarter">Quarter width</option>
+        </select>
+      </Field>
+    </div>
+  );
+}
+
+// Spacer Block Editor
+export function SpacerBlockEditor({ block, onChange, disabled }: BlockEditorProps<SpacerBlock>) {
+  const updateData = (updates: Partial<SpacerBlock["data"]>) => {
+    onChange({ ...block, data: { ...block.data, ...updates } });
+  };
+
+  return (
+    <div data-test-id="spacer-block-editor">
+      <Field label="Height">
+        <select value={block.data.height || "medium"} onChange={(e) => updateData({ height: e.target.value as "small" | "medium" | "large" })} disabled={disabled} style={selectStyle}>
+          <option value="small">Small (24px)</option>
+          <option value="medium">Medium (48px)</option>
+          <option value="large">Large (96px)</option>
+        </select>
+      </Field>
+    </div>
+  );
+}
+
+// Block editor selector
+export function BlockEditor({ block, onChange, disabled }: { block: Block; onChange: (block: Block) => void; disabled?: boolean }) {
+  switch (block.type) {
+    case "hero": return <HeroBlockEditor block={block} onChange={onChange as (b: HeroBlock) => void} disabled={disabled} />;
+    case "text": return <TextBlockEditor block={block} onChange={onChange as (b: TextBlock) => void} disabled={disabled} />;
+    case "image": return <ImageBlockEditor block={block} onChange={onChange as (b: ImageBlock) => void} disabled={disabled} />;
+    case "cards": return <CardsBlockEditor block={block} onChange={onChange as (b: CardsBlock) => void} disabled={disabled} />;
+    case "event-list": return <EventListBlockEditor block={block} onChange={onChange as (b: EventListBlock) => void} disabled={disabled} />;
+    case "gallery": return <GalleryBlockEditor block={block} onChange={onChange as (b: GalleryBlock) => void} disabled={disabled} />;
+    case "faq": return <FaqBlockEditor block={block} onChange={onChange as (b: FaqBlock) => void} disabled={disabled} />;
+    case "contact": return <ContactBlockEditor block={block} onChange={onChange as (b: ContactBlock) => void} disabled={disabled} />;
+    case "cta": return <CtaBlockEditor block={block} onChange={onChange as (b: CtaBlock) => void} disabled={disabled} />;
+    case "divider": return <DividerBlockEditor block={block} onChange={onChange as (b: DividerBlock) => void} disabled={disabled} />;
+    case "spacer": return <SpacerBlockEditor block={block} onChange={onChange as (b: SpacerBlock) => void} disabled={disabled} />;
+    default: return <div>Unknown block type</div>;
+  }
+}

--- a/src/components/editor/BlockPalette.tsx
+++ b/src/components/editor/BlockPalette.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+// Copyright (c) Santa Barbara Newcomers Club
+// Block palette component for adding new blocks to a page
+
+import { BlockType, BLOCK_METADATA } from "@/lib/publishing/blocks";
+
+type BlockPaletteProps = {
+  onAddBlock: (type: BlockType) => void;
+  disabled?: boolean;
+};
+
+const BLOCK_ICONS: Record<BlockType, string> = {
+  hero: "⬜",
+  text: "📝",
+  image: "🖼️",
+  cards: "🃏",
+  "event-list": "📅",
+  gallery: "🖼️",
+  faq: "❓",
+  contact: "✉️",
+  cta: "👆",
+  divider: "➖",
+  spacer: "↕️",
+};
+
+const CATEGORIES = ["content", "media", "interactive", "layout"] as const;
+const CATEGORY_LABELS: Record<string, string> = {
+  content: "Content",
+  media: "Media",
+  interactive: "Interactive",
+  layout: "Layout",
+};
+
+export default function BlockPalette({ onAddBlock, disabled }: BlockPaletteProps) {
+  const blocksByCategory = CATEGORIES.map((category) => ({
+    category,
+    label: CATEGORY_LABELS[category],
+    blocks: (Object.entries(BLOCK_METADATA) as [BlockType, typeof BLOCK_METADATA[BlockType]][])
+      .filter(([, meta]) => meta.category === category),
+  }));
+
+  return (
+    <div
+      data-test-id="block-palette"
+      style={{
+        backgroundColor: "#f9f9f9",
+        borderRadius: "8px",
+        padding: "16px",
+        marginBottom: "16px",
+      }}
+    >
+      <h3 style={{ margin: "0 0 12px 0", fontSize: "14px", fontWeight: 600, color: "#333" }}>
+        Add Block
+      </h3>
+      {blocksByCategory.map(({ category, label, blocks }) => (
+        <div key={category} style={{ marginBottom: "12px" }}>
+          <div style={{ fontSize: "11px", color: "#666", marginBottom: "6px", textTransform: "uppercase", letterSpacing: "0.5px" }}>
+            {label}
+          </div>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "6px" }}>
+            {blocks.map(([type, meta]) => (
+              <button
+                key={type}
+                data-test-id={`add-block-${type}`}
+                onClick={() => onAddBlock(type)}
+                disabled={disabled}
+                title={meta.description}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "4px",
+                  padding: "6px 10px",
+                  fontSize: "12px",
+                  backgroundColor: "#fff",
+                  border: "1px solid #ddd",
+                  borderRadius: "4px",
+                  cursor: disabled ? "not-allowed" : "pointer",
+                  opacity: disabled ? 0.5 : 1,
+                  transition: "all 0.15s ease",
+                }}
+                onMouseOver={(e) => {
+                  if (!disabled) {
+                    e.currentTarget.style.backgroundColor = "#f0f0f0";
+                    e.currentTarget.style.borderColor = "#bbb";
+                  }
+                }}
+                onMouseOut={(e) => {
+                  e.currentTarget.style.backgroundColor = "#fff";
+                  e.currentTarget.style.borderColor = "#ddd";
+                }}
+              >
+                <span>{BLOCK_ICONS[type]}</span>
+                <span>{meta.label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/editor/PageEditor.tsx
+++ b/src/components/editor/PageEditor.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+// Copyright (c) Santa Barbara Newcomers Club
+// Main page editor component with drag-drop blocks
+
+import { useState, useCallback, useEffect } from "react";
+import { Block, BlockType, PageContent, createEmptyBlock, BLOCK_METADATA } from "@/lib/publishing/blocks";
+import BlockPalette from "./BlockPalette";
+import SortableBlockList from "./SortableBlockList";
+import { BlockEditor } from "./BlockEditors";
+
+type PageEditorProps = {
+  initialContent: PageContent;
+  onChange: (content: PageContent) => void;
+  disabled?: boolean;
+};
+
+export default function PageEditor({ initialContent, onChange, disabled }: PageEditorProps) {
+  const [blocks, setBlocks] = useState<Block[]>(initialContent.blocks);
+  const [selectedBlockId, setSelectedBlockId] = useState<string | null>(null);
+
+  // Sync changes to parent
+  useEffect(() => {
+    onChange({
+      schemaVersion: initialContent.schemaVersion,
+      blocks,
+    });
+  }, [blocks, initialContent.schemaVersion, onChange]);
+
+  const selectedBlock = blocks.find((b) => b.id === selectedBlockId) || null;
+
+  const handleAddBlock = useCallback((type: BlockType) => {
+    const newBlock = createEmptyBlock(type, blocks.length);
+    setBlocks((prev) => [...prev, newBlock]);
+    setSelectedBlockId(newBlock.id);
+  }, [blocks.length]);
+
+  const handleReorder = useCallback((newBlocks: Block[]) => {
+    setBlocks(newBlocks);
+  }, []);
+
+  const handleSelectBlock = useCallback((blockId: string) => {
+    setSelectedBlockId(blockId);
+  }, []);
+
+  const handleDeleteBlock = useCallback((blockId: string) => {
+    setBlocks((prev) => {
+      const filtered = prev.filter((b) => b.id !== blockId);
+      // Reorder remaining blocks
+      return filtered.map((block, idx) => ({ ...block, order: idx }));
+    });
+    if (selectedBlockId === blockId) {
+      setSelectedBlockId(null);
+    }
+  }, [selectedBlockId]);
+
+  const handleBlockChange = useCallback((updatedBlock: Block) => {
+    setBlocks((prev) => prev.map((b) => (b.id === updatedBlock.id ? updatedBlock : b)));
+  }, []);
+
+  return (
+    <div data-test-id="page-editor" style={{ display: "flex", gap: "24px" }}>
+      {/* Left panel - Block list */}
+      <div style={{ flex: "1 1 400px", minWidth: "300px", maxWidth: "500px" }}>
+        <BlockPalette onAddBlock={handleAddBlock} disabled={disabled} />
+        <SortableBlockList
+          blocks={blocks}
+          onReorder={handleReorder}
+          onSelectBlock={handleSelectBlock}
+          onDeleteBlock={handleDeleteBlock}
+          selectedBlockId={selectedBlockId}
+          disabled={disabled}
+        />
+      </div>
+
+      {/* Right panel - Block editor */}
+      <div style={{ flex: "1 1 500px", minWidth: "400px" }}>
+        {selectedBlock ? (
+          <div
+            data-test-id="block-editor-panel"
+            style={{
+              backgroundColor: "#fff",
+              borderRadius: "8px",
+              border: "1px solid #ddd",
+              padding: "20px",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                marginBottom: "16px",
+                paddingBottom: "12px",
+                borderBottom: "1px solid #eee",
+              }}
+            >
+              <h3 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>
+                Edit {BLOCK_METADATA[selectedBlock.type].label}
+              </h3>
+              <button
+                type="button"
+                onClick={() => setSelectedBlockId(null)}
+                style={{
+                  padding: "4px 8px",
+                  fontSize: "12px",
+                  backgroundColor: "#f5f5f5",
+                  color: "#666",
+                  border: "1px solid #ddd",
+                  borderRadius: "4px",
+                  cursor: "pointer",
+                }}
+              >
+                Close
+              </button>
+            </div>
+            <BlockEditor
+              block={selectedBlock}
+              onChange={handleBlockChange}
+              disabled={disabled}
+            />
+          </div>
+        ) : (
+          <div
+            data-test-id="no-block-selected"
+            style={{
+              backgroundColor: "#f9f9f9",
+              borderRadius: "8px",
+              padding: "40px 20px",
+              textAlign: "center",
+              color: "#999",
+              border: "2px dashed #ddd",
+            }}
+          >
+            <p style={{ margin: 0, fontSize: "14px" }}>
+              {blocks.length === 0
+                ? "Add a block from the palette to get started."
+                : "Select a block from the list to edit it."}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/editor/RichTextEditor.tsx
+++ b/src/components/editor/RichTextEditor.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+// Copyright (c) Santa Barbara Newcomers Club
+// Rich text editor component using Tiptap
+
+import { useEditor, EditorContent } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import Placeholder from "@tiptap/extension-placeholder";
+import { useEffect } from "react";
+
+type RichTextEditorProps = {
+  content: string;
+  onChange: (html: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+};
+
+export default function RichTextEditor({
+  content,
+  onChange,
+  placeholder = "Start typing...",
+  disabled,
+}: RichTextEditorProps) {
+  const editor = useEditor({
+    extensions: [
+      StarterKit.configure({
+        heading: {
+          levels: [2, 3, 4],
+        },
+      }),
+      Placeholder.configure({
+        placeholder,
+      }),
+    ],
+    content,
+    editable: !disabled,
+    onUpdate: ({ editor }) => {
+      onChange(editor.getHTML());
+    },
+  });
+
+  // Update content when it changes externally
+  useEffect(() => {
+    if (editor && content !== editor.getHTML()) {
+      editor.commands.setContent(content, { emitUpdate: false });
+    }
+  }, [content, editor]);
+
+  // Update editable state
+  useEffect(() => {
+    if (editor) {
+      editor.setEditable(!disabled);
+    }
+  }, [disabled, editor]);
+
+  if (!editor) {
+    return null;
+  }
+
+  return (
+    <div data-test-id="rich-text-editor">
+      {/* Toolbar */}
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "4px",
+          padding: "8px",
+          backgroundColor: "#f5f5f5",
+          borderRadius: "4px 4px 0 0",
+          border: "1px solid #ddd",
+          borderBottom: "none",
+        }}
+      >
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleBold().run()}
+          active={editor.isActive("bold")}
+          disabled={disabled}
+          title="Bold"
+        >
+          <strong>B</strong>
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleItalic().run()}
+          active={editor.isActive("italic")}
+          disabled={disabled}
+          title="Italic"
+        >
+          <em>I</em>
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleStrike().run()}
+          active={editor.isActive("strike")}
+          disabled={disabled}
+          title="Strikethrough"
+        >
+          <s>S</s>
+        </ToolbarButton>
+        <div style={{ width: "1px", backgroundColor: "#ddd", margin: "0 4px" }} />
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+          active={editor.isActive("heading", { level: 2 })}
+          disabled={disabled}
+          title="Heading 2"
+        >
+          H2
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
+          active={editor.isActive("heading", { level: 3 })}
+          disabled={disabled}
+          title="Heading 3"
+        >
+          H3
+        </ToolbarButton>
+        <div style={{ width: "1px", backgroundColor: "#ddd", margin: "0 4px" }} />
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleBulletList().run()}
+          active={editor.isActive("bulletList")}
+          disabled={disabled}
+          title="Bullet List"
+        >
+          •
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleOrderedList().run()}
+          active={editor.isActive("orderedList")}
+          disabled={disabled}
+          title="Numbered List"
+        >
+          1.
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleBlockquote().run()}
+          active={editor.isActive("blockquote")}
+          disabled={disabled}
+          title="Quote"
+        >
+          &quot;
+        </ToolbarButton>
+        <div style={{ width: "1px", backgroundColor: "#ddd", margin: "0 4px" }} />
+        <ToolbarButton
+          onClick={() => editor.chain().focus().undo().run()}
+          disabled={disabled || !editor.can().undo()}
+          title="Undo"
+        >
+          ↩
+        </ToolbarButton>
+        <ToolbarButton
+          onClick={() => editor.chain().focus().redo().run()}
+          disabled={disabled || !editor.can().redo()}
+          title="Redo"
+        >
+          ↪
+        </ToolbarButton>
+      </div>
+
+      {/* Editor content */}
+      <div
+        style={{
+          border: "1px solid #ddd",
+          borderRadius: "0 0 4px 4px",
+          minHeight: "150px",
+          backgroundColor: disabled ? "#f9f9f9" : "#fff",
+        }}
+      >
+        <EditorContent
+          editor={editor}
+          style={{
+            padding: "12px",
+          }}
+        />
+      </div>
+
+      <style>{`
+        .tiptap {
+          outline: none;
+          min-height: 120px;
+        }
+        .tiptap p {
+          margin: 0 0 0.75em 0;
+        }
+        .tiptap p:last-child {
+          margin-bottom: 0;
+        }
+        .tiptap h2, .tiptap h3, .tiptap h4 {
+          margin: 1em 0 0.5em 0;
+        }
+        .tiptap h2:first-child, .tiptap h3:first-child, .tiptap h4:first-child {
+          margin-top: 0;
+        }
+        .tiptap ul, .tiptap ol {
+          margin: 0 0 0.75em 0;
+          padding-left: 1.5em;
+        }
+        .tiptap blockquote {
+          border-left: 3px solid #ddd;
+          margin: 0 0 0.75em 0;
+          padding-left: 1em;
+          color: #666;
+        }
+        .tiptap p.is-editor-empty:first-child::before {
+          color: #aaa;
+          content: attr(data-placeholder);
+          float: left;
+          height: 0;
+          pointer-events: none;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+type ToolbarButtonProps = {
+  onClick: () => void;
+  active?: boolean;
+  disabled?: boolean;
+  title: string;
+  children: React.ReactNode;
+};
+
+function ToolbarButton({ onClick, active, disabled, title, children }: ToolbarButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      style={{
+        padding: "4px 8px",
+        fontSize: "12px",
+        fontWeight: 500,
+        backgroundColor: active ? "#0066cc" : "#fff",
+        color: active ? "#fff" : "#333",
+        border: "1px solid #ddd",
+        borderRadius: "3px",
+        cursor: disabled ? "not-allowed" : "pointer",
+        opacity: disabled ? 0.5 : 1,
+        minWidth: "28px",
+      }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/editor/SortableBlockList.tsx
+++ b/src/components/editor/SortableBlockList.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+// Copyright (c) Santa Barbara Newcomers Club
+// Sortable block list with drag-drop reordering
+
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Block, BLOCK_METADATA } from "@/lib/publishing/blocks";
+
+type SortableBlockListProps = {
+  blocks: Block[];
+  onReorder: (blocks: Block[]) => void;
+  onSelectBlock: (blockId: string) => void;
+  onDeleteBlock: (blockId: string) => void;
+  selectedBlockId: string | null;
+  disabled?: boolean;
+};
+
+type SortableBlockItemProps = {
+  block: Block;
+  isSelected: boolean;
+  onSelect: () => void;
+  onDelete: () => void;
+  disabled?: boolean;
+};
+
+function SortableBlockItem({ block, isSelected, onSelect, onDelete, disabled }: SortableBlockItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: block.id, disabled });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  const meta = BLOCK_METADATA[block.type];
+  const blockPreview = getBlockPreview(block);
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      data-test-id={`block-item-${block.id}`}
+      onClick={onSelect}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "stretch",
+          backgroundColor: isSelected ? "#e8f4fc" : "#fff",
+          border: isSelected ? "2px solid #0066cc" : "1px solid #ddd",
+          borderRadius: "6px",
+          marginBottom: "8px",
+          overflow: "hidden",
+          cursor: "pointer",
+          transition: "all 0.15s ease",
+        }}
+      >
+        {/* Drag handle */}
+        <div
+          {...attributes}
+          {...listeners}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: "32px",
+            backgroundColor: "#f5f5f5",
+            borderRight: "1px solid #eee",
+            cursor: disabled ? "not-allowed" : "grab",
+            color: "#999",
+            fontSize: "14px",
+          }}
+          title="Drag to reorder"
+        >
+          ⋮⋮
+        </div>
+
+        {/* Block info */}
+        <div style={{ flex: 1, padding: "10px 12px" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: "4px" }}>
+            <span
+              style={{
+                fontSize: "11px",
+                backgroundColor: "#e0e0e0",
+                padding: "2px 6px",
+                borderRadius: "3px",
+                textTransform: "uppercase",
+                fontWeight: 500,
+              }}
+            >
+              {meta.label}
+            </span>
+          </div>
+          <div
+            style={{
+              fontSize: "13px",
+              color: "#666",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              maxWidth: "300px",
+            }}
+          >
+            {blockPreview}
+          </div>
+        </div>
+
+        {/* Delete button */}
+        <button
+          data-test-id={`delete-block-${block.id}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete();
+          }}
+          disabled={disabled}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: "36px",
+            backgroundColor: "transparent",
+            border: "none",
+            borderLeft: "1px solid #eee",
+            cursor: disabled ? "not-allowed" : "pointer",
+            color: "#999",
+            fontSize: "16px",
+            transition: "all 0.15s ease",
+          }}
+          title="Delete block"
+          onMouseOver={(e) => {
+            if (!disabled) {
+              e.currentTarget.style.backgroundColor = "#fee";
+              e.currentTarget.style.color = "#c00";
+            }
+          }}
+          onMouseOut={(e) => {
+            e.currentTarget.style.backgroundColor = "transparent";
+            e.currentTarget.style.color = "#999";
+          }}
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function getBlockPreview(block: Block): string {
+  switch (block.type) {
+    case "hero":
+      return block.data.title || "Untitled hero";
+    case "text": {
+      // Strip HTML and truncate
+      const text = block.data.content.replace(/<[^>]*>/g, "");
+      return text.slice(0, 60) + (text.length > 60 ? "..." : "") || "Empty text";
+    }
+    case "image":
+      return block.data.alt || block.data.src || "No image";
+    case "cards":
+      return `${block.data.cards.length} card(s)`;
+    case "event-list":
+      return block.data.title || `Showing ${block.data.limit || 5} events`;
+    case "gallery":
+      return `${block.data.images.length} image(s)`;
+    case "faq":
+      return block.data.title || `${block.data.items.length} question(s)`;
+    case "contact":
+      return block.data.title || "Contact form";
+    case "cta":
+      return block.data.text || "Button";
+    case "divider":
+      return `${block.data.style || "solid"} line`;
+    case "spacer":
+      return `${block.data.height || "medium"} space`;
+    default:
+      return "Block";
+  }
+}
+
+export default function SortableBlockList({
+  blocks,
+  onReorder,
+  onSelectBlock,
+  onDeleteBlock,
+  selectedBlockId,
+  disabled,
+}: SortableBlockListProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+
+    if (over && active.id !== over.id) {
+      const oldIndex = blocks.findIndex((b) => b.id === active.id);
+      const newIndex = blocks.findIndex((b) => b.id === over.id);
+
+      const newBlocks = arrayMove(blocks, oldIndex, newIndex).map((block, idx) => ({
+        ...block,
+        order: idx,
+      }));
+
+      onReorder(newBlocks);
+    }
+  }
+
+  if (blocks.length === 0) {
+    return (
+      <div
+        data-test-id="empty-blocks-state"
+        style={{
+          padding: "40px 20px",
+          textAlign: "center",
+          color: "#999",
+          backgroundColor: "#f9f9f9",
+          borderRadius: "8px",
+          border: "2px dashed #ddd",
+        }}
+      >
+        <p style={{ margin: 0, fontSize: "14px" }}>No blocks yet. Add a block from the palette above.</p>
+      </div>
+    );
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext items={blocks.map((b) => b.id)} strategy={verticalListSortingStrategy}>
+        <div data-test-id="sortable-block-list">
+          {blocks.map((block) => (
+            <SortableBlockItem
+              key={block.id}
+              block={block}
+              isSelected={selectedBlockId === block.id}
+              onSelect={() => onSelectBlock(block.id)}
+              onDelete={() => onDeleteBlock(block.id)}
+              disabled={disabled}
+            />
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
+  );
+}

--- a/tests/admin/admin-content-page-editor.spec.ts
+++ b/tests/admin/admin-content-page-editor.spec.ts
@@ -1,0 +1,208 @@
+// Copyright (c) Santa Barbara Newcomers Club
+// E2E tests for page editor WYSIWYG functionality
+
+import { test, expect } from "@playwright/test";
+
+test.describe("Admin Page Editor", () => {
+  test.beforeEach(async ({ request }) => {
+    // Clean up any test pages
+    const listRes = await request.get("/api/admin/content/pages?search=e2e-test");
+    if (listRes.ok()) {
+      const data = await listRes.json();
+      for (const page of data.items || []) {
+        await request.delete(`/api/admin/content/pages/${page.id}`);
+      }
+    }
+  });
+
+  test("can create a new page with blocks", async ({ page }) => {
+    // Navigate to new page form
+    await page.goto("/admin/content/pages/new");
+    await expect(page.locator("h1")).toContainText("Create New Page");
+
+    // Fill in page details
+    await page.locator('[data-test-id="new-page-title-input"]').fill("E2E Test Page");
+    await expect(page.locator('[data-test-id="new-page-slug-input"]')).toHaveValue("e2e-test-page");
+
+    // Add a text block
+    await page.locator('[data-test-id="add-block-text"]').click();
+    await expect(page.locator('[data-test-id="sortable-block-list"]')).toBeVisible();
+
+    // Create the page
+    await page.locator('[data-test-id="create-page-button"]').click();
+
+    // Should redirect to editor
+    await expect(page).toHaveURL(/\/admin\/content\/pages\/[a-f0-9-]+/);
+    await expect(page.locator("h1")).toContainText("E2E Test Page");
+  });
+
+  test("can add and reorder blocks via drag-drop", async ({ page, request }) => {
+    // Create a test page via API
+    const createRes = await request.post("/api/admin/content/pages", {
+      data: {
+        title: "E2E Test Blocks",
+        slug: "e2e-test-blocks",
+        content: { schemaVersion: 1, blocks: [] },
+      },
+    });
+    expect(createRes.ok()).toBeTruthy();
+    const { page: testPage } = await createRes.json();
+
+    // Navigate to editor
+    await page.goto(`/admin/content/pages/${testPage.id}`);
+    await expect(page.locator('[data-test-id="page-editor"]')).toBeVisible();
+
+    // Add hero block
+    await page.locator('[data-test-id="add-block-hero"]').click();
+    await expect(page.locator('[data-test-id="sortable-block-list"]')).toContainText("Hero");
+
+    // Add text block
+    await page.locator('[data-test-id="add-block-text"]').click();
+
+    // Add CTA block
+    await page.locator('[data-test-id="add-block-cta"]').click();
+
+    // Should have 3 blocks
+    const blockItems = page.locator('[data-test-id^="block-item-"]');
+    await expect(blockItems).toHaveCount(3);
+  });
+
+  test("can edit block content", async ({ page, request }) => {
+    // Create a test page with a hero block
+    const createRes = await request.post("/api/admin/content/pages", {
+      data: {
+        title: "E2E Test Edit",
+        slug: "e2e-test-edit",
+        content: {
+          schemaVersion: 1,
+          blocks: [{ id: "test-hero-1", type: "hero", order: 0, data: { title: "Original Title" } }],
+        },
+      },
+    });
+    expect(createRes.ok()).toBeTruthy();
+    const { page: testPage } = await createRes.json();
+
+    // Navigate to editor
+    await page.goto(`/admin/content/pages/${testPage.id}`);
+
+    // Click on the hero block to select it
+    await page.locator('[data-test-id="block-item-test-hero-1"]').click();
+
+    // Should show hero editor
+    await expect(page.locator('[data-test-id="hero-block-editor"]')).toBeVisible();
+
+    // Edit the title
+    await page.locator('[data-test-id="hero-title-input"]').fill("Updated Title");
+
+    // Save the page
+    await page.locator('[data-test-id="save-page-button"]').click();
+
+    // Wait for save to complete (button becomes disabled)
+    await expect(page.locator('[data-test-id="save-page-button"]')).toBeDisabled();
+  });
+
+  test("can publish and unpublish a page", async ({ page, request }) => {
+    // Create a draft page
+    const createRes = await request.post("/api/admin/content/pages", {
+      data: { title: "E2E Test Publish", slug: "e2e-test-publish" },
+    });
+    expect(createRes.ok()).toBeTruthy();
+    const { page: testPage } = await createRes.json();
+
+    // Navigate to editor
+    await page.goto(`/admin/content/pages/${testPage.id}`);
+
+    // Should show DRAFT status
+    await expect(page.locator("text=DRAFT")).toBeVisible();
+
+    // Publish button should be visible
+    await expect(page.locator('[data-test-id="publish-page-button"]')).toBeVisible();
+
+    // Click publish
+    await page.locator('[data-test-id="publish-page-button"]').click();
+
+    // Should show PUBLISHED status
+    await expect(page.locator("text=PUBLISHED")).toBeVisible();
+
+    // Unpublish button should now be visible
+    await expect(page.locator('[data-test-id="unpublish-page-button"]')).toBeVisible();
+
+    // Click unpublish
+    await page.locator('[data-test-id="unpublish-page-button"]').click();
+
+    // Should show DRAFT status again
+    await expect(page.locator("text=DRAFT")).toBeVisible();
+  });
+
+  test("warns about unsaved changes", async ({ page, request }) => {
+    // Create a test page
+    const createRes = await request.post("/api/admin/content/pages", {
+      data: { title: "E2E Test Unsaved", slug: "e2e-test-unsaved" },
+    });
+    expect(createRes.ok()).toBeTruthy();
+    const { page: testPage } = await createRes.json();
+
+    // Navigate to editor
+    await page.goto(`/admin/content/pages/${testPage.id}`);
+
+    // Make a change
+    await page.locator('[data-test-id="page-title-input"]').fill("Changed Title");
+
+    // Should show unsaved changes indicator
+    await expect(page.locator("text=Unsaved changes")).toBeVisible();
+
+    // Save button should be enabled
+    await expect(page.locator('[data-test-id="save-page-button"]')).toBeEnabled();
+
+    // Publish button should be disabled (need to save first)
+    await expect(page.locator('[data-test-id="publish-page-button"]')).toBeDisabled();
+  });
+
+  test("can delete blocks", async ({ page, request }) => {
+    // Create a page with blocks
+    const createRes = await request.post("/api/admin/content/pages", {
+      data: {
+        title: "E2E Test Delete Block",
+        slug: "e2e-test-delete-block",
+        content: {
+          schemaVersion: 1,
+          blocks: [
+            { id: "block-1", type: "hero", order: 0, data: { title: "Hero" } },
+            { id: "block-2", type: "text", order: 1, data: { content: "<p>Text</p>" } },
+          ],
+        },
+      },
+    });
+    expect(createRes.ok()).toBeTruthy();
+    const { page: testPage } = await createRes.json();
+
+    // Navigate to editor
+    await page.goto(`/admin/content/pages/${testPage.id}`);
+
+    // Should have 2 blocks
+    await expect(page.locator('[data-test-id^="block-item-"]')).toHaveCount(2);
+
+    // Delete the first block
+    await page.locator('[data-test-id="delete-block-block-1"]').click();
+
+    // Should have 1 block
+    await expect(page.locator('[data-test-id^="block-item-"]')).toHaveCount(1);
+  });
+
+  test("block palette shows all block types", async ({ page }) => {
+    await page.goto("/admin/content/pages/new");
+
+    // Should show all block type buttons
+    await expect(page.locator('[data-test-id="add-block-hero"]')).toBeVisible();
+    await expect(page.locator('[data-test-id="add-block-text"]')).toBeVisible();
+    await expect(page.locator('[data-test-id="add-block-image"]')).toBeVisible();
+    await expect(page.locator('[data-test-id="add-block-cards"]')).toBeVisible();
+    await expect(page.locator('[data-test-id="add-block-event-list"]')).toBeVisible();
+    await expect(page.locator('[data-test-id="add-block-gallery"]')).toBeVisible();
+    await expect(page.locator('[data-test-id="add-block-faq"]')).toBeVisible();
+    await expect(page.locator('[data-test-id="add-block-contact"]')).toBeVisible();
+    await expect(page.locator('[data-test-id="add-block-cta"]')).toBeVisible();
+    await expect(page.locator('[data-test-id="add-block-divider"]')).toBeVisible();
+    await expect(page.locator('[data-test-id="add-block-spacer"]')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Implements modern block-based WYSIWYG page editor for ClubOS
- Drag-and-drop block reordering using @dnd-kit
- Rich text editing with Tiptap (ProseMirror-based)
- Supports all 11 block types: hero, text, image, cards, event-list, gallery, faq, contact, cta, divider, spacer
- Page lifecycle: DRAFT → PUBLISHED → ARCHIVED
- Visibility settings: PUBLIC, MEMBERS_ONLY, ROLE_RESTRICTED
- E2E tests covering core editor workflows

## Test plan

- [ ] Run `npx playwright test tests/admin/admin-content-page-editor.spec.ts`
- [ ] Create new page at `/admin/content/pages/new`
- [ ] Add and reorder blocks using drag-and-drop
- [ ] Edit text block with rich text formatting
- [ ] Save, publish, unpublish workflow
- [ ] Verify unsaved changes warning on navigation

🤖 Generated with [Claude Code](https://claude.ai/claude-code)\n\nRelease classification: experimental\n