### PR TITLE
docs: charter refs + normalcy signals + governance roles specs

### DIFF
--- a/docs/ARCHITECTURAL_CHARTER.md
+++ b/docs/ARCHITECTURAL_CHARTER.md
@@ -1,6 +1,20 @@
 # ClubOS Non-Negotiable Architectural Charter
 Copyright (c) Santa Barbara Newcomers Club
 
+## Normative Reference Documents
+
+The following documents are authoritative inputs to ClubOS design decisions.
+They define expected operating norms, red flags, and sustainability constraints
+that the system must support, surface, or enforce.
+
+- docs/WHAT_IS_NORMAL.md
+  Defines normal vs abnormal operating patterns for members, volunteers, and leaders.
+  Used to guide UX affordances, guardrails, and alerting.
+
+- docs/ORG/SBNC_Business_Model_and_Sustainability.md
+  Defines the canonical business model, sustainability flywheel, and failure modes.
+  Used to evaluate feature priority, governance design, and operational risk.
+
 ## Purpose
 ClubOS is a club operating system designed for non-technical users and maintained primarily by chatbots. This charter defines the invariants that must hold across all code, schemas, APIs, UI workflows, and documentation.
 

--- a/docs/OPS/NORMALCY_SIGNALS_AND_RESPONSES.md
+++ b/docs/OPS/NORMALCY_SIGNALS_AND_RESPONSES.md
@@ -1,0 +1,23 @@
+# Normalcy Signals and Responses (Spec)
+Derived from: docs/WHAT_IS_NORMAL.md
+
+This document maps "not normal" red flags into enforceable or observable system signals
+and expected system responses. It is a design input for RBAC, audit, alerts, and UI.
+
+## Red flags -> signals -> system response
+
+| Red Flag (from WHAT_IS_NORMAL) | Detectable? | Required System Signal | Who Sees It | Expected System Response |
+|---|---|---|---|---|
+| Silent failures where actions appear to succeed but nothing changes | Yes | Action recorded with no state delta | Actor + Admin | Warning banner; audit annotation required |
+| Repeated manual work to fix the same issue without root cause review | Yes | Same override or correction repeated | Admin / Board | Escalation report; trend indicator |
+| Leaders avoiding actions due to fear of breaking the system | Indirect | High preview usage + low commit rate | Admin | Promote preview; provide rollback confidence |
+| Missing or inconsistent signals (status, roles, permissions) | Yes | Validation errors; missing joins; inconsistent status | Admin | Hard validation; blocking warnings where appropriate |
+| No audit trail for decisions that affect members | Yes | State change without audit entry | System | Block action (hard fail) |
+| Emergency access or workarounds becoming routine | Yes | Elevated role duration exceeds threshold | Board / Parliamentarian | Forced review; auto-expire elevation |
+
+## Design principles
+
+- Normal should feel easy and safe.
+- Abnormal should be visible, reviewable, and slightly uncomfortable.
+- Nothing bad should be silent.
+

--- a/docs/RBAC/GOVERNANCE_ROLES_SECRETARY_AND_PARLIAMENTARIAN.md
+++ b/docs/RBAC/GOVERNANCE_ROLES_SECRETARY_AND_PARLIAMENTARIAN.md
@@ -1,0 +1,60 @@
+# Governance Roles: Secretary and Parliamentarian (RBAC Spec)
+
+These are custodial governance roles. They protect record and process integrity.
+
+## Secretary (Custodian of Record Integrity)
+
+System responsibility:
+Ensure organizational records exist, are complete, preserved correctly, and discoverable by authorized roles.
+
+Core guarantees:
+- Required records exist for required events
+- Records progress through defined states
+- Approved records are immutable
+- Records are discoverable by authorized roles
+
+Illustrative capabilities:
+- records:read
+- records:certify
+- records:lock
+- records:metadata:update
+
+System enforcement:
+- Cannot certify incomplete records
+- Cannot modify locked records
+- Every certification action produces an audit entry
+- Missing required records surface as yellow/red signals
+
+Non-goals:
+- The Secretary is not an editor of policy content
+- The Secretary is not an approver of policy outcomes
+- The Secretary is not a gatekeeper for routine operations
+
+## Parliamentarian (Custodian of Process Integrity)
+
+System responsibility:
+Ensure actions followed defined process, or that deviations are explicitly recorded and reviewable.
+
+Core guarantees:
+- Rules exist and are visible
+- Exceptions are annotated, not hidden
+- Deviations are reviewable after the fact
+- Emergency powers are time-boxed
+
+Illustrative capabilities:
+- process:review
+- process:annotate-exception
+- process:certify-compliance
+- process:flag-deviation
+
+System enforcement:
+- Any rule bypass requires annotation
+- Time-limited powers auto-expire
+- Unreviewed deviations surface as warnings
+- Parliamentarian cannot change outcomes, only record compliance
+
+Non-goals:
+- The Parliamentarian is not an enforcer
+- The Parliamentarian is not an approver
+- The Parliamentarian is not an operator
+


### PR DESCRIPTION
Docs updates:
- Add Normative Reference Documents section to ARCHITECTURAL_CHARTER.md
- Add OPS spec: NORMALCY_SIGNALS_AND_RESPONSES.md
- Add RBAC spec: GOV. roles (Secretary + Parliamentarian)

No code/behavior changes.