### PR TITLE
feat(importing): add MembershipTier and map WA membership levels

### DIFF
--- a/docs/IMPORTING/MEMBERSHIP_TIER_MAPPING.md
+++ b/docs/IMPORTING/MEMBERSHIP_TIER_MAPPING.md
@@ -1,0 +1,161 @@
+# Membership Tier Mapping
+
+This document describes how Wild Apricot (WA) membership levels are mapped to ClubOS `MembershipTier` records during import.
+
+## Overview
+
+ClubOS maintains a canonical `MembershipTier` model that represents membership progression levels. During WA import, contacts' membership levels are resolved to the appropriate ClubOS tier using a best-effort mapping strategy.
+
+## Canonical Membership Tiers
+
+The following tiers are seeded into ClubOS:
+
+| Code            | Name            | Sort Order | Description                                      |
+|-----------------|-----------------|------------|--------------------------------------------------|
+| `unknown`       | Unknown         | 0          | Fallback for unmapped or missing WA levels       |
+| `extended_member` | Extended Member | 10         | Extended newcomer period (6-24 months)           |
+| `newbie_member` | Newbie Member   | 20         | Initial newcomer period (0-6 months)             |
+| `member`        | Member          | 30         | Full member status                               |
+
+## WA Level to ClubOS Tier Mapping
+
+The following Wild Apricot membership level names map to ClubOS tiers:
+
+| WA Level Name       | ClubOS Tier Code   | Notes                                |
+|---------------------|--------------------|--------------------------------------|
+| `ExtendedNewcomer`  | `extended_member`  | Exact string match                   |
+| `NewbieNewcomer`    | `newbie_member`    | Exact string match                   |
+| `NewcomerMember`    | `member`           | Exact string match                   |
+| `Admins`            | `unknown`          | Known non-tier (role, not membership)|
+| (any other value)   | `unknown`          | Unmapped value preserved in rawValue |
+| (null/missing)      | `unknown`          | Missing level data                   |
+
+## Resolution Logic
+
+The `resolveMembershipTier()` function in `src/lib/importing/wildapricot/transformers.ts` implements the mapping:
+
+1. **Missing Level**: If `MembershipLevel` is null or has no Name, returns `unknown` with confidence `"missing"`
+
+2. **Known Non-Tier**: If level name matches a known non-tier (e.g., "Admins"), returns `unknown` with confidence `"unmapped"`
+
+3. **Exact Match**: If level name matches one of the known WA levels, returns the corresponding tier code with confidence `"exact"`
+
+4. **Unknown Level**: Any unrecognized level name returns `unknown` with confidence `"unmapped"`
+
+### Resolution Result Structure
+
+```typescript
+interface MembershipTierResolution {
+  tierCode: string;          // ClubOS tier code
+  rawValue: string | null;   // Original WA value for traceability
+  confidence: "exact" | "unmapped" | "missing";
+}
+```
+
+## Data Flow During Import
+
+1. **Preflight Check**: The importer verifies all required tier codes exist in the database before starting
+
+2. **Tier Resolution**: For each WA contact, `resolveMembershipTier()` determines the appropriate tier
+
+3. **Warning Logging**: Non-exact mappings log warnings with:
+   - WA contact ID and email
+   - Raw WA value
+   - Confidence level
+
+4. **Member Update**: The member record is updated with:
+   - `membershipTierId`: Link to the resolved `MembershipTier`
+   - `waMembershipLevelRaw`: Original WA value for audit trail
+
+## Database Schema
+
+### MembershipTier Model
+
+```prisma
+model MembershipTier {
+  id        String   @id @default(uuid()) @db.Uuid
+  code      String   @unique
+  name      String
+  sortOrder Int      @default(0)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  members   Member[]
+}
+```
+
+### Member Model (relevant fields)
+
+```prisma
+model Member {
+  // ... other fields
+  membershipTierId      String?  @db.Uuid
+  waMembershipLevelRaw  String?
+  membershipTier        MembershipTier? @relation(...)
+}
+```
+
+## Seeding
+
+Run the seeder script to initialize membership tiers:
+
+```bash
+# Dry run (safe, no changes)
+DRY_RUN=1 npx tsx scripts/importing/seed_membership_tiers.ts
+
+# Production seeding (requires explicit opt-in)
+ALLOW_PROD_SEED=1 npx tsx scripts/importing/seed_membership_tiers.ts
+```
+
+The seeder is idempotent and uses upsert operations.
+
+## Admin Status Endpoint
+
+The `/api/v1/admin/import/status` endpoint reports:
+
+- **membershipTierCounts**: Array of `{ code, name, count }` showing member distribution by tier
+- **membersMissingTierCount**: Number of members with no tier assigned
+
+Example response:
+
+```json
+{
+  "membershipTierCounts": [
+    { "code": "unknown", "name": "Unknown", "count": 5 },
+    { "code": "extended_member", "name": "Extended Member", "count": 42 },
+    { "code": "newbie_member", "name": "Newbie Member", "count": 28 },
+    { "code": "member", "name": "Member", "count": 156 }
+  ],
+  "membersMissingTierCount": 3
+}
+```
+
+## Troubleshooting
+
+### Members assigned to "Unknown" tier
+
+Check the import logs for warning messages containing:
+- "Non-exact tier mapping" - indicates an unmapped WA level
+- Review `waMembershipLevelRaw` field on affected members
+
+### New WA membership levels
+
+If SBNC adds new membership levels in Wild Apricot:
+
+1. Add the mapping to `WA_LEVEL_TO_TIER_CODE` in `transformers.ts`
+2. Optionally create a new tier in `seed_membership_tiers.ts`
+3. Re-run the seeder if adding a new tier
+4. Re-import affected members
+
+### Preflight failures
+
+If preflight reports missing tiers:
+
+1. Run the seeder script
+2. Verify database connectivity
+3. Check for migration issues
+
+## Related Documentation
+
+- [WA Field Mapping](./WA_FIELD_MAPPING.md) - Full field mapping specification
+- [Importer System Spec](./IMPORTER_SYSTEM_SPEC.md) - Import system architecture
+- [Importer Runbook](./IMPORTER_RUNBOOK.md) - Operational procedures

--- a/prisma/migrations/20251218064524_add_membership_tier/migration.sql
+++ b/prisma/migrations/20251218064524_add_membership_tier/migration.sql
@@ -1,0 +1,27 @@
+-- AlterTable
+ALTER TABLE "Member" ADD COLUMN     "membershipTierId" UUID,
+ADD COLUMN     "waMembershipLevelRaw" TEXT;
+
+-- CreateTable
+CREATE TABLE "MembershipTier" (
+    "id" UUID NOT NULL,
+    "code" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MembershipTier_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MembershipTier_code_key" ON "MembershipTier"("code");
+
+-- CreateIndex
+CREATE INDEX "MembershipTier_sortOrder_idx" ON "MembershipTier"("sortOrder");
+
+-- CreateIndex
+CREATE INDEX "Member_membershipTierId_idx" ON "Member"("membershipTierId");
+
+-- AddForeignKey
+ALTER TABLE "Member" ADD CONSTRAINT "Member_membershipTierId_fkey" FOREIGN KEY ("membershipTierId") REFERENCES "MembershipTier"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -120,17 +120,20 @@ enum TransitionStatus {
 // Core Models
 
 model Member {
-  id                 String   @id @default(uuid()) @db.Uuid
-  firstName          String
-  lastName           String
-  email              String   @unique
-  phone              String?
-  joinedAt           DateTime
-  membershipStatusId String   @db.Uuid
-  createdAt          DateTime @default(now())
-  updatedAt          DateTime @updatedAt
+  id                    String   @id @default(uuid()) @db.Uuid
+  firstName             String
+  lastName              String
+  email                 String   @unique
+  phone                 String?
+  joinedAt              DateTime
+  membershipStatusId    String   @db.Uuid
+  membershipTierId      String?  @db.Uuid // Nullable: canonical ClubOS tier (derived from WA membership level)
+  waMembershipLevelRaw  String?  // Raw WA membership level value for traceability
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
 
   membershipStatus   MembershipStatus    @relation(fields: [membershipStatusId], references: [id])
+  membershipTier     MembershipTier?     @relation(fields: [membershipTierId], references: [id])
   roleAssignments    RoleAssignment[]
   eventRegistrations EventRegistration[]
   userAccount        UserAccount?
@@ -180,6 +183,7 @@ model Member {
   fileAccessGrants FileAccess[]  @relation("FileAccessGrantedBy")
 
   @@index([membershipStatusId])
+  @@index([membershipTierId])
 }
 
 model MembershipStatus {
@@ -195,6 +199,21 @@ model MembershipStatus {
   updatedAt            DateTime @updatedAt
 
   members Member[]
+}
+
+// MembershipTier - Canonical membership tier/level in ClubOS
+// Maps from Wild Apricot membership levels to a stable ClubOS taxonomy
+model MembershipTier {
+  id        String   @id @default(uuid()) @db.Uuid
+  code      String   @unique // Stable key (lowercase, snake_case): unknown, extended_member, newbie_member, member
+  name      String // Human-readable: "Unknown", "Extended Member", "Newbie Member", "Member"
+  sortOrder Int      @default(0)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  members Member[]
+
+  @@index([sortOrder])
 }
 
 model Committee {

--- a/scripts/importing/seed_membership_tiers.ts
+++ b/scripts/importing/seed_membership_tiers.ts
@@ -1,0 +1,238 @@
+#!/usr/bin/env npx tsx
+/**
+ * Wild Apricot MembershipTier Seeder
+ *
+ * Seeds MembershipTier records required for WA import.
+ * This script is idempotent - running it multiple times is safe.
+ *
+ * Run with:
+ *   npx tsx scripts/importing/seed_membership_tiers.ts
+ *
+ * Environment variables:
+ *   ALLOW_PROD_SEED - Required in production: Set to "1" to allow
+ *   DRY_RUN         - Optional: Set to "1" for preview mode (no writes)
+ *
+ * Tier codes created:
+ *   - unknown: Unknown/unmapped tier (sortOrder 0)
+ *   - extended_member: Extended Member (WA: ExtendedNewcomer) (sortOrder 10)
+ *   - newbie_member: Newbie Member (WA: NewbieNewcomer) (sortOrder 20)
+ *   - member: Member (WA: NewcomerMember) (sortOrder 30)
+ *
+ * Note: "Admins" in WA is NOT a membership tier - it's modeled via roles/capabilities.
+ */
+
+import { PrismaClient } from "@prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+
+// Load .env manually
+import { config } from "dotenv";
+config();
+
+// ============================================================================
+// Safety Checks
+// ============================================================================
+
+function isProductionDatabase(): boolean {
+  const dbUrl = process.env.DATABASE_URL || "";
+  return (
+    process.env.NODE_ENV === "production" ||
+    dbUrl.includes("production") ||
+    dbUrl.includes("prod.") ||
+    dbUrl.includes("neon.tech") ||
+    dbUrl.includes("supabase.co") ||
+    (dbUrl.includes(".com") && !dbUrl.includes("localhost"))
+  );
+}
+
+function validateProductionSafety(): void {
+  if (isProductionDatabase() && process.env.ALLOW_PROD_SEED !== "1") {
+    throw new Error(
+      "Production database detected. Set ALLOW_PROD_SEED=1 to proceed."
+    );
+  }
+}
+
+function isDryRun(): boolean {
+  return process.env.DRY_RUN === "1";
+}
+
+// ============================================================================
+// Prisma Client
+// ============================================================================
+
+function createPrismaClient(): PrismaClient {
+  const connectionString = process.env.DATABASE_URL;
+
+  if (!connectionString) {
+    throw new Error("DATABASE_URL environment variable is not set");
+  }
+
+  const pool = new Pool({ connectionString });
+  const adapter = new PrismaPg(pool);
+
+  return new PrismaClient({ adapter });
+}
+
+// ============================================================================
+// Tier Definitions
+// ============================================================================
+
+/**
+ * MembershipTier records for ClubOS.
+ * These map from Wild Apricot membership levels.
+ *
+ * WA Level -> ClubOS MembershipTier.name
+ * - ExtendedNewcomer -> Extended Member
+ * - NewbieNewcomer   -> Newbie Member
+ * - NewcomerMember   -> Member
+ *
+ * "Admins" in WA is NOT a membership tier (it's modeled via roles/capabilities).
+ */
+const MEMBERSHIP_TIERS = [
+  {
+    code: "unknown",
+    name: "Unknown",
+    sortOrder: 0,
+  },
+  {
+    code: "extended_member",
+    name: "Extended Member",
+    sortOrder: 10,
+  },
+  {
+    code: "newbie_member",
+    name: "Newbie Member",
+    sortOrder: 20,
+  },
+  {
+    code: "member",
+    name: "Member",
+    sortOrder: 30,
+  },
+];
+
+// ============================================================================
+// Main
+// ============================================================================
+
+async function main(): Promise<void> {
+  console.log("");
+  console.log("=".repeat(60));
+  console.log("  WA MembershipTier Seeder");
+  console.log("=".repeat(60));
+  console.log("");
+
+  // Safety check
+  try {
+    validateProductionSafety();
+  } catch (error) {
+    console.error("");
+    console.error("ERROR:", error instanceof Error ? error.message : error);
+    console.error("");
+    console.error("To run against production, set:");
+    console.error(
+      "  ALLOW_PROD_SEED=1 npx tsx scripts/importing/seed_membership_tiers.ts"
+    );
+    console.error("");
+    process.exit(1);
+  }
+
+  // Show mode
+  if (isDryRun()) {
+    console.log("Mode: DRY RUN (no database writes)");
+    console.log("");
+  }
+
+  const prisma = createPrismaClient();
+
+  try {
+    // Check database connectivity
+    console.log("Checking database connection...");
+    await prisma.$queryRaw`SELECT 1`;
+    console.log("[OK] Database connection established");
+    console.log("");
+
+    // Check existing tiers
+    console.log("Checking existing MembershipTier records...");
+    const existingTiers = await prisma.membershipTier.findMany({
+      where: {
+        code: {
+          in: MEMBERSHIP_TIERS.map((t) => t.code),
+        },
+      },
+      select: { code: true },
+    });
+
+    const existingCodes = new Set(existingTiers.map((t) => t.code));
+    const missingCodes = MEMBERSHIP_TIERS.filter(
+      (t) => !existingCodes.has(t.code)
+    );
+
+    console.log(`  Found: ${existingCodes.size} existing tier codes`);
+    console.log(`  Missing: ${missingCodes.length} tier codes`);
+    console.log("");
+
+    if (missingCodes.length === 0) {
+      console.log("All MembershipTier codes already exist.");
+      console.log("");
+      console.log("=".repeat(60));
+      console.log("  No changes needed");
+      console.log("=".repeat(60));
+      console.log("");
+      process.exit(0);
+    }
+
+    // Seed missing tiers
+    console.log("Seeding MembershipTier records...");
+
+    for (const tier of MEMBERSHIP_TIERS) {
+      if (isDryRun()) {
+        if (existingCodes.has(tier.code)) {
+          console.log(`  [SKIP] ${tier.code} (already exists)`);
+        } else {
+          console.log(`  [DRY] Would create: ${tier.code} -> "${tier.name}"`);
+        }
+      } else {
+        const result = await prisma.membershipTier.upsert({
+          where: { code: tier.code },
+          update: {
+            name: tier.name,
+            sortOrder: tier.sortOrder,
+          },
+          create: tier,
+        });
+
+        if (existingCodes.has(tier.code)) {
+          console.log(`  [UPDATE] ${tier.code}`);
+        } else {
+          console.log(`  [CREATE] ${tier.code} -> "${tier.name}" (id: ${result.id})`);
+        }
+      }
+    }
+
+    console.log("");
+    console.log("=".repeat(60));
+    if (isDryRun()) {
+      console.log("  Dry run complete - no changes made");
+    } else {
+      console.log("  Seeding complete");
+    }
+    console.log("=".repeat(60));
+    console.log("");
+
+    process.exit(0);
+  } catch (error) {
+    console.error("");
+    console.error("ERROR:", error instanceof Error ? error.message : error);
+    console.error("");
+    process.exit(1);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error("Unhandled error:", error);
+  process.exit(2);
+});

--- a/src/lib/importing/wildapricot/index.ts
+++ b/src/lib/importing/wildapricot/index.ts
@@ -36,12 +36,14 @@ export {
   transformRegistration,
   mapContactStatusToCode,
   mapRegistrationStatus,
+  resolveMembershipTier,
   extractFieldValue,
   extractPhone,
   normalizeEmail,
   parseDate,
   deriveCategory,
 } from "./transformers";
+export type { MembershipTierResolution } from "./transformers";
 
 // Importer
 export {

--- a/tests/unit/publishing/audience.spec.ts
+++ b/tests/unit/publishing/audience.spec.ts
@@ -17,6 +17,8 @@ describe("Audience Rule System", () => {
     lastName: "Member",
     phone: null,
     membershipStatusId: "ms1",
+    membershipTierId: null,
+    waMembershipLevelRaw: null,
     membershipStatus: {
       id: "ms1",
       code: "active",


### PR DESCRIPTION
## Summary

- Add canonical `MembershipTier` model to ClubOS Prisma schema
- Implement mapping from Wild Apricot membership levels to ClubOS tiers during import
- Add tier distribution metrics to admin import status endpoint
- Include idempotent seeder script with production safety gates

## WA Level Mapping

| WA Level Name | ClubOS Tier Code | Notes |
|--------------|------------------|-------|
| ExtendedNewcomer | extended_member | Exact match |
| NewbieNewcomer | newbie_member | Exact match |
| NewcomerMember | member | Exact match |
| Admins | unknown | Known non-tier (role) |
| (missing/other) | unknown | Warning logged |

## Changes

**Schema:**
- Add `MembershipTier` model with id, code, name, sortOrder
- Add `membershipTierId` (nullable) and `waMembershipLevelRaw` to Member

**Importer:**
- `resolveMembershipTier()` function with confidence tracking (exact/unmapped/missing)
- Preflight checks verify required tier codes exist
- syncMember applies resolved tier to member records
- Warning logged for non-exact mappings

**Admin Status Endpoint:**
- `membershipTierCounts` array showing member distribution by tier
- `membersMissingTierCount` for members without tier assignment

## Test plan

- [x] Unit tests for `resolveMembershipTier` covering all mapping scenarios
- [x] TypeScript typecheck passes
- [x] Existing tests updated for new Member fields
- [ ] Run seeder in dev: `DRY_RUN=1 npx tsx scripts/importing/seed_membership_tiers.ts`
- [ ] Verify import status endpoint returns tier counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nRelease classification: experimental\n