### PR TITLE
chore(ui): mechanical rename stripes imports to sections

### DIFF
--- a/src/app/events/EventsDiscovery.tsx
+++ b/src/app/events/EventsDiscovery.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
-import { ContentStripe } from "@/components/stripes";
+import { ContentStripe } from "@/components/sections";
 import { formatClubDate, formatClubTime } from "@/lib/timezone";
 
 interface EventSummary {

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -11,7 +11,7 @@
  */
 
 import Link from "next/link";
-import { HeroStripe } from "@/components/stripes";
+import { HeroStripe } from "@/components/sections";
 import { getCurrentSession } from "@/lib/passkey";
 import { GIFT_CERTIFICATE_URL } from "@/lib/config/externalLinks";
 import EventsDiscovery from "./EventsDiscovery";

--- a/src/app/gift/page.tsx
+++ b/src/app/gift/page.tsx
@@ -10,7 +10,7 @@
  */
 
 import Link from "next/link";
-import { HeroStripe, ContentStripe } from "@/components/stripes";
+import { HeroStripe, ContentStripe } from "@/components/sections";
 
 export default function GiftCertificatePage() {
   return (

--- a/src/app/my/page.tsx
+++ b/src/app/my/page.tsx
@@ -13,7 +13,7 @@
  */
 
 import Link from "next/link";
-import { Stripe } from "@/components/stripes";
+import { Stripe } from "@/components/sections";
 import { ViewAsControl } from "@/components/view-as";
 import { getViewContext } from "@/lib/view-context";
 import { getCurrentSession } from "@/lib/passkey";

--- a/src/app/my/payment-methods/page.tsx
+++ b/src/app/my/payment-methods/page.tsx
@@ -18,7 +18,7 @@
 
 import { useState, useEffect, FormEvent } from "react";
 import Link from "next/link";
-import { Stripe } from "@/components/stripes";
+import { Stripe } from "@/components/sections";
 
 // ============================================================================
 // Types

--- a/src/app/my/profile/page.tsx
+++ b/src/app/my/profile/page.tsx
@@ -25,7 +25,7 @@
 
 import { useState, useEffect, FormEvent, useMemo } from "react";
 import Link from "next/link";
-import { Stripe } from "@/components/stripes";
+import { Stripe } from "@/components/sections";
 import { ViewAsControl } from "@/components/view-as";
 import { formatClubDate } from "@/lib/timezone";
 import type { ProfileResponse } from "@/lib/profile";

--- a/src/components/sections/index.ts
+++ b/src/components/sections/index.ts
@@ -1,5 +1,10 @@
 export { Section } from "./Section";
 export type { SectionProps } from "./Section";
 
-// Aliases so app code can adopt "Section" language without moving files yet.
-export { HeroStripe as HeroSection, ContentStripe as ContentSection } from "../stripes";
+export { Stripe, default as StripeDefault } from "../stripes/Stripe";
+export { default as HeroStripe } from "../stripes/HeroStripe";
+export { default as ContentStripe } from "../stripes/ContentStripe";
+export { default as TwoColumnStripe } from "../stripes/TwoColumnStripe";
+
+export { default as HeroSection } from "../stripes/HeroStripe";
+export { default as ContentSection } from "../stripes/ContentStripe";


### PR DESCRIPTION
## Summary

- Mechanical-only rename of imports from `@/components/stripes` to `@/components/sections`
- No behavior changes
- Supports the Stripe→Section deprecation plan

## Changes

6 files updated to import from `@/components/sections` instead of `@/components/stripes`:
- `src/app/events/page.tsx`
- `src/app/events/EventsDiscovery.tsx`
- `src/app/gift/page.tsx`
- `src/app/my/page.tsx`
- `src/app/my/payment-methods/page.tsx`
- `src/app/my/profile/page.tsx`

## Test plan

- [x] `npm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)