### PR TITLE
feat(governance): board decisions register + policy runtime + status page

### DIFF
--- a/docs/policies/sbnc/BOARD_DECISIONS.yaml
+++ b/docs/policies/sbnc/BOARD_DECISIONS.yaml
@@ -1,0 +1,46 @@
+meta:
+  description: >
+    Authoritative register of SBNC Board decisions affecting bylaws,
+    policies, eligibility, visibility, and enforcement.
+  maintained_by: Board of Directors
+  last_reviewed: null
+
+decisions:
+
+  bylaws_version:
+    title: Bylaws Version in Force
+    decision: pending
+    options:
+      - id: bylaws_2021_06_01
+        description: Bylaws adopted June 1, 2021
+      - id: bylaws_2024_07_29
+        description: Bylaws adopted July 29, 2024
+    decided_on: null
+
+  policy_visibility:
+    title: Policy Visibility Rules
+    decision: pending
+    policies:
+      privacy_policy: pending
+      social_media_policy: pending
+
+  guest_access:
+    title: Guest Eligibility for Events
+    decision: pending
+    options:
+      - members_only
+      - guests_allowed
+
+  membership_terms:
+    title: Membership Term Rules
+    decision: pending
+    options:
+      - fixed_term
+      - rolling_term
+
+  registration_eligibility:
+    title: Registration Eligibility Enforcement
+    decision: pending
+    options:
+      - strict_enforcement
+      - permissive_with_logging

--- a/src/app/admin/policies/status/page.tsx
+++ b/src/app/admin/policies/status/page.tsx
@@ -1,0 +1,27 @@
+export default function PolicyStatusPage() {
+  return (
+    <main style={{ padding: "2rem", maxWidth: "900px" }}>
+      <h1>Policy & Governance Status</h1>
+
+      <p>
+        This page reflects current Board decisions and provisional system behavior.
+        Pending decisions operate in a permissive, non-enforcing mode.
+      </p>
+
+      <h2>Decisions Requiring Board Action</h2>
+      <ul>
+        <li>Bylaws version in force</li>
+        <li>Policy visibility rules</li>
+        <li>Guest access for events</li>
+        <li>Membership term definition</li>
+        <li>Registration eligibility enforcement</li>
+      </ul>
+
+      <h2>System Behavior</h2>
+      <p>
+        While decisions are pending, the system allows access and logs activity.
+        No member is blocked due to unresolved policy direction.
+      </p>
+    </main>
+  );
+}

--- a/src/lib/policies/runtime.ts
+++ b/src/lib/policies/runtime.ts
@@ -1,0 +1,24 @@
+export type DecisionState = "approved" | "pending";
+
+export interface PolicyRuntime {
+  bylawsVersion: string | "pending";
+
+  policyVisibility: Record<string, "public" | "members" | "admins" | "pending">;
+
+  guestAccessMode: "members_only" | "guests_allowed" | "pending";
+
+  membershipTermMode: "fixed" | "rolling" | "pending";
+
+  registrationEligibilityMode:
+    | "strict_enforcement"
+    | "permissive_with_logging"
+    | "pending";
+}
+
+export const defaultPolicyRuntime: PolicyRuntime = {
+  bylawsVersion: "pending",
+  policyVisibility: {},
+  guestAccessMode: "pending",
+  membershipTermMode: "pending",
+  registrationEligibilityMode: "pending",
+};


### PR DESCRIPTION
Adds BOARD_DECISIONS.yaml as the board-controlled decision register, a minimal policy runtime contract (pending = permissive), and an admin status page stub for transparency.