### PR TITLE
[P1][Feature Flags] Kill-switch model + flag registry

### DIFF
--- a/docs/reliability/FEATURE_FLAGS.md
+++ b/docs/reliability/FEATURE_FLAGS.md
@@ -1,0 +1,364 @@
+# Feature Flags and Kill Switches
+
+**Status:** Normative
+**Last Updated:** 2025-12-21
+
+---
+
+## Purpose
+
+This document describes ClubOS's feature flag system, which provides:
+
+- **Gradual rollout** of new features
+- **Kill switches** for instant feature disable in production
+- **Environment-driven configuration** without code changes
+- **Type-safe flag evaluation** in application code
+
+---
+
+## Quick Reference
+
+### Check if a flag is enabled
+
+```typescript
+import { isEnabled } from "@/lib/flags";
+
+if (isEnabled("event_postmortem_enabled")) {
+  // Show postmortem UI
+}
+```
+
+### Check kill switch status
+
+```typescript
+import { isKillSwitchActive } from "@/lib/flags";
+
+if (!isKillSwitchActive("email_sending_enabled")) {
+  console.warn("Email sending disabled via kill switch");
+  return mockSendEmail(payload);
+}
+```
+
+### Set flag via environment
+
+```bash
+# Enable a flag
+CLUBOS_FLAG_EVENT_POSTMORTEM_ENABLED=1
+
+# Disable a flag (kill switch)
+CLUBOS_FLAG_EMAIL_SENDING_ENABLED=0
+```
+
+---
+
+## Concepts
+
+### Feature Flags vs Kill Switches
+
+| Aspect | Feature Flag | Kill Switch |
+|--------|--------------|-------------|
+| Default | Off (false) | On (true) |
+| Purpose | Gradual rollout of new features | Instant disable in emergency |
+| Use case | "Show new UI to 10% of users" | "Disable payments if gateway down" |
+| Registry field | `killSwitchEligible: false` | `killSwitchEligible: true` |
+
+### Kill Switch Requirements
+
+A flag can be marked as `killSwitchEligible: true` only if:
+
+1. **Graceful degradation**: Feature degrades safely when disabled
+2. **No data corruption**: Disabling does not corrupt or lose data
+3. **Immediate effect**: No cache invalidation or restart needed
+4. **Reversible**: Can be re-enabled without side effects
+
+---
+
+## How to Add a Flag
+
+### Step 1: Add to Registry
+
+Edit `src/lib/flags/registry.ts`:
+
+```typescript
+export const FLAG_REGISTRY: readonly FlagDefinition[] = [
+  // ... existing flags ...
+
+  {
+    key: "my_new_feature",
+    description: "Enable the new feature for all users",
+    defaultValue: false,           // Off by default for new features
+    killSwitchEligible: false,     // true if can be used as kill switch
+    surface: "ui",                 // Where it applies: api, ui, worker, migration, all
+    owner: "platform",             // Team responsible
+    notes: "Expected cleanup: 2025-Q2",
+    addedAt: "2025-12-21",
+  },
+];
+```
+
+### Step 2: Use in Code
+
+```typescript
+import { isEnabled } from "@/lib/flags";
+
+export function MyComponent() {
+  if (!isEnabled("my_new_feature")) {
+    return <LegacyComponent />;
+  }
+  return <NewComponent />;
+}
+```
+
+### Step 3: Set Environment Variable (Optional)
+
+If the default isn't what you want:
+
+```bash
+# In .env or Netlify environment
+CLUBOS_FLAG_MY_NEW_FEATURE=1
+```
+
+---
+
+## Environment Variable Convention
+
+Flags are controlled via environment variables with this naming:
+
+```
+CLUBOS_FLAG_{UPPERCASE_KEY}
+```
+
+| Flag Key | Environment Variable |
+|----------|---------------------|
+| `event_postmortem_enabled` | `CLUBOS_FLAG_EVENT_POSTMORTEM_ENABLED` |
+| `email_sending_enabled` | `CLUBOS_FLAG_EMAIL_SENDING_ENABLED` |
+| `migration_mode_enabled` | `CLUBOS_FLAG_MIGRATION_MODE_ENABLED` |
+
+**Values:**
+
+- `1` or `true` = enabled
+- `0` or `false` = disabled
+- Not set = use default from registry
+
+---
+
+## Setting Flags in Netlify
+
+### For All Deploys
+
+1. Go to **Site settings** > **Environment variables**
+2. Add the variable with the appropriate value
+3. Trigger a new deploy (or wait for next deploy)
+
+### For Preview Deploys
+
+1. Use branch-specific environment variables in Netlify
+2. Or add to `netlify.toml`:
+
+```toml
+[context.deploy-preview.environment]
+CLUBOS_FLAG_DEBUG_MODE_UI = "1"
+```
+
+### For Production Emergencies (Kill Switch)
+
+1. Go to Netlify dashboard
+2. Site settings > Environment variables
+3. Change the kill switch variable (e.g., `CLUBOS_FLAG_EMAIL_SENDING_ENABLED=0`)
+4. Trigger immediate redeploy or wait for next request (env vars are read per-request)
+
+---
+
+## API Reference
+
+### `isEnabled(key: string, ctx?: FlagContext): boolean`
+
+Check if a flag is enabled.
+
+```typescript
+import { isEnabled } from "@/lib/flags";
+
+// Simple check
+if (isEnabled("my_feature")) {
+  // Feature is enabled
+}
+
+// With test override
+const result = isEnabled("my_feature", {
+  overrides: { my_feature: true }
+});
+```
+
+### `isKillSwitchActive(key: string): boolean`
+
+Semantic alias for `isEnabled()`. Use for kill switches to make intent clear.
+
+```typescript
+import { isKillSwitchActive } from "@/lib/flags";
+
+if (!isKillSwitchActive("email_sending_enabled")) {
+  console.warn("[kill-switch] Email sending disabled");
+  return mockSend();
+}
+```
+
+### `evaluateFlag(key: string, ctx?: FlagContext): FlagEvaluationResult`
+
+Get detailed evaluation result for debugging.
+
+```typescript
+import { evaluateFlag } from "@/lib/flags";
+
+const result = evaluateFlag("my_feature");
+// {
+//   key: "my_feature",
+//   enabled: false,
+//   source: "default",      // "override" | "env" | "default"
+//   envVar: "CLUBOS_FLAG_MY_FEATURE",
+//   envValue: undefined,
+//   defaultValue: false
+// }
+```
+
+### `getAllFlagStatus(): FlagEvaluationResult[]`
+
+Get status of all flags. Useful for admin dashboards.
+
+```typescript
+import { getAllFlagStatus } from "@/lib/flags";
+
+const status = getAllFlagStatus();
+// Array of evaluation results for all registered flags
+```
+
+### `getKillSwitchStatus(): FlagEvaluationResult[]`
+
+Get status of kill switches only. Useful for incident response.
+
+```typescript
+import { getKillSwitchStatus } from "@/lib/flags";
+
+const switches = getKillSwitchStatus();
+// Only flags with killSwitchEligible: true
+```
+
+---
+
+## Testing with Flags
+
+### Override in Tests
+
+Use the `overrides` context to control flags in tests:
+
+```typescript
+import { isEnabled } from "@/lib/flags";
+
+describe("MyFeature", () => {
+  it("shows new UI when flag enabled", () => {
+    const enabled = isEnabled("my_feature", {
+      overrides: { my_feature: true }
+    });
+    expect(enabled).toBe(true);
+  });
+
+  it("shows legacy UI when flag disabled", () => {
+    const enabled = isEnabled("my_feature", {
+      overrides: { my_feature: false }
+    });
+    expect(enabled).toBe(false);
+  });
+});
+```
+
+### Reset Logging
+
+The flag system logs first evaluation of each flag. Reset for clean test output:
+
+```typescript
+import { resetFlagLogging } from "@/lib/flags";
+
+beforeEach(() => {
+  resetFlagLogging();
+});
+```
+
+---
+
+## Flag Lifecycle
+
+### Adding a Flag
+
+1. Add to registry with `addedAt` date
+2. Default to `false` for new features
+3. Document expected cleanup timeline in `notes`
+
+### Rolling Out
+
+1. Deploy with flag off (default)
+2. Enable for preview/staging: set env var to `1`
+3. Enable for production when ready
+4. Monitor for issues
+
+### Cleaning Up
+
+1. Once feature is stable and flag is always-on:
+2. Remove flag checks from code
+3. Remove from registry
+4. Remove environment variable
+
+**Target timeline:** Flags should be cleaned up within 90 days of full rollout.
+
+---
+
+## Current Flags
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `event_postmortem_enabled` | Kill switch | true | Event postmortem UI |
+| `transition_widget_enabled` | Kill switch | true | Leadership transition widget |
+| `email_sending_enabled` | Kill switch | true | Actual email sending |
+| `governance_annotations_ui` | Feature | false | Governance annotations panel |
+| `debug_mode_ui` | Feature | false | Debug info in admin UI |
+| `migration_mode_enabled` | Kill switch | false | Migration Mode master switch |
+
+---
+
+## Troubleshooting
+
+### Flag not taking effect
+
+1. Check environment variable name matches convention:
+   `CLUBOS_FLAG_{UPPERCASE_KEY}`
+
+2. Check value is `1` or `0` (not `true`/`false` string unless intentional)
+
+3. Check for typos in flag key
+
+4. Check logs for flag evaluation on first access
+
+### Unknown flag key warning
+
+If using a flag key not in registry:
+
+- Flag will evaluate to `false` (fail closed)
+- Warning logged to console
+- Add flag to registry to fix
+
+### Flag logged multiple times
+
+Flags are only logged on first evaluation per process. If seeing multiple logs:
+
+- You may be running multiple processes
+- Call `resetFlagLogging()` if intentional (e.g., in tests)
+
+---
+
+## See Also
+
+- [MULTITENANT_RELEASE_READINESS.md](./MULTITENANT_RELEASE_READINESS.md) - Kill switch requirements for releases
+- [WA_FUTURE_FAILURE_IMMUNITY.md](../architecture/WA_FUTURE_FAILURE_IMMUNITY.md) - MF-7 pattern
+- [FEATURE_RISK_AND_FIELD_TESTING_MODEL.md](../ops/FEATURE_RISK_AND_FIELD_TESTING_MODEL.md) - Feature rollout stages
+
+---
+
+*This document is normative for feature flag usage.*

--- a/src/lib/flags/index.ts
+++ b/src/lib/flags/index.ts
@@ -1,0 +1,188 @@
+/**
+ * Feature Flag Evaluation
+ *
+ * Type-safe feature flag system with environment variable overrides.
+ * See docs/reliability/FEATURE_FLAGS.md for documentation.
+ */
+
+import {
+  FLAG_REGISTRY,
+  FlagKey,
+  FlagDefinition,
+  getDefinition,
+  getKillSwitches,
+} from "./registry";
+
+export { FLAG_REGISTRY, getDefinition, getKillSwitches };
+export type { FlagKey, FlagDefinition };
+
+/**
+ * Context for flag evaluation (useful for testing)
+ */
+export interface FlagContext {
+  /** Override flag values (takes precedence over env vars) */
+  overrides?: Record<string, boolean>;
+}
+
+/**
+ * Result of evaluating a flag
+ */
+export interface FlagEvaluationResult {
+  key: string;
+  enabled: boolean;
+  source: "override" | "env" | "default";
+  envVar: string;
+  envValue: string | undefined;
+  defaultValue: boolean;
+}
+
+// Track which flags have been logged to avoid spam
+const loggedFlags = new Set<string>();
+
+/**
+ * Reset flag logging state (useful for tests)
+ */
+export function resetFlagLogging(): void {
+  loggedFlags.clear();
+}
+
+/**
+ * Convert a flag key to its environment variable name
+ * @example flagKeyToEnvVar("my_feature") => "CLUBOS_FLAG_MY_FEATURE"
+ */
+export function flagKeyToEnvVar(key: string): string {
+  return `CLUBOS_FLAG_${key.toUpperCase()}`;
+}
+
+/**
+ * Parse an environment variable value as boolean
+ */
+function parseEnvValue(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  const v = value.toLowerCase().trim();
+  if (v === "1" || v === "true") return true;
+  if (v === "0" || v === "false") return false;
+  // Unknown value - treat as undefined (use default)
+  return undefined;
+}
+
+/**
+ * Evaluate a flag and return detailed result
+ */
+export function evaluateFlag(
+  key: FlagKey | string,
+  ctx?: FlagContext
+): FlagEvaluationResult {
+  const definition = getDefinition(key);
+  const envVar = flagKeyToEnvVar(key);
+  const envValue = process.env[envVar];
+  const defaultValue = definition?.defaultValue ?? false;
+
+  // Check for override first
+  if (ctx?.overrides && key in ctx.overrides) {
+    return {
+      key,
+      enabled: ctx.overrides[key],
+      source: "override",
+      envVar,
+      envValue,
+      defaultValue,
+    };
+  }
+
+  // Check environment variable
+  const parsedEnv = parseEnvValue(envValue);
+  if (parsedEnv !== undefined) {
+    return {
+      key,
+      enabled: parsedEnv,
+      source: "env",
+      envVar,
+      envValue,
+      defaultValue,
+    };
+  }
+
+  // Fall back to default
+  return {
+    key,
+    enabled: defaultValue,
+    source: "default",
+    envVar,
+    envValue,
+    defaultValue,
+  };
+}
+
+/**
+ * Check if a feature flag is enabled
+ *
+ * @param key - The flag key from the registry
+ * @param ctx - Optional context for overrides (useful in tests)
+ * @returns true if the flag is enabled
+ *
+ * @example
+ * ```typescript
+ * if (isEnabled("event_postmortem_enabled")) {
+ *   // Show postmortem UI
+ * }
+ *
+ * // In tests
+ * isEnabled("my_feature", { overrides: { my_feature: true } })
+ * ```
+ */
+export function isEnabled(key: FlagKey | string, ctx?: FlagContext): boolean {
+  const definition = getDefinition(key);
+
+  // Warn on first use of unknown flag
+  if (!definition && !loggedFlags.has(key)) {
+    console.warn(`[flags] Unknown flag key: "${key}" - returning false (fail closed)`);
+    loggedFlags.add(key);
+  }
+
+  const result = evaluateFlag(key, ctx);
+
+  // Log first evaluation for debugging
+  if (!loggedFlags.has(key)) {
+    console.log(
+      `[flags] ${key} = ${result.enabled} (source: ${result.source})`
+    );
+    loggedFlags.add(key);
+  }
+
+  return result.enabled;
+}
+
+/**
+ * Semantic alias for isEnabled - use for kill switches
+ *
+ * @example
+ * ```typescript
+ * if (!isKillSwitchActive("email_sending_enabled")) {
+ *   console.warn("[kill-switch] Email sending disabled");
+ *   return mockSend();
+ * }
+ * ```
+ */
+export function isKillSwitchActive(
+  key: FlagKey | string,
+  ctx?: FlagContext
+): boolean {
+  return isEnabled(key, ctx);
+}
+
+/**
+ * Get evaluation results for all flags
+ * Useful for admin dashboards
+ */
+export function getAllFlagStatus(): FlagEvaluationResult[] {
+  return FLAG_REGISTRY.map((flag) => evaluateFlag(flag.key));
+}
+
+/**
+ * Get evaluation results for kill switches only
+ * Useful for incident response dashboards
+ */
+export function getKillSwitchStatus(): FlagEvaluationResult[] {
+  return getKillSwitches().map((flag) => evaluateFlag(flag.key));
+}

--- a/src/lib/flags/registry.ts
+++ b/src/lib/flags/registry.ts
@@ -1,0 +1,135 @@
+/**
+ * Feature Flag Registry
+ *
+ * Central registry of all feature flags and kill switches in ClubOS.
+ * Each flag must be defined here with its metadata before use.
+ *
+ * See docs/reliability/FEATURE_FLAGS.md for usage documentation.
+ */
+
+/**
+ * Surface where the flag applies
+ */
+export type FlagSurface = "api" | "ui" | "worker" | "migration" | "all";
+
+/**
+ * Flag definition with all required metadata
+ */
+export interface FlagDefinition {
+  /** Unique identifier for the flag (snake_case) */
+  key: string;
+  /** Human-readable description of what this flag controls */
+  description: string;
+  /** Default value when not set via environment */
+  defaultValue: boolean;
+  /** True if this can be used as a kill switch (defaults to ON, disables on failure) */
+  killSwitchEligible: boolean;
+  /** Where this flag applies */
+  surface: FlagSurface;
+  /** Team or person responsible for this flag */
+  owner: string;
+  /** Optional notes about the flag (e.g., cleanup timeline) */
+  notes?: string;
+  /** ISO date when this flag was added */
+  addedAt: string;
+}
+
+/**
+ * Central registry of all feature flags.
+ *
+ * Adding a flag:
+ * 1. Add entry here with all required fields
+ * 2. Use isEnabled("key") in code
+ * 3. Set CLUBOS_FLAG_KEY=1 or 0 in environment
+ *
+ * Conventions:
+ * - Kill switches: default to true (ON), set to false to disable
+ * - Feature flags: default to false (OFF), set to true to enable
+ */
+export const FLAG_REGISTRY: readonly FlagDefinition[] = [
+  // Kill Switches (default ON, can be disabled in emergency)
+  {
+    key: "event_postmortem_enabled",
+    description: "Enable event postmortem UI for completed/cancelled events",
+    defaultValue: true,
+    killSwitchEligible: true,
+    surface: "ui",
+    owner: "platform",
+    addedAt: "2025-12-21",
+  },
+  {
+    key: "transition_widget_enabled",
+    description: "Enable leadership transition widget in admin dashboard",
+    defaultValue: true,
+    killSwitchEligible: true,
+    surface: "ui",
+    owner: "platform",
+    addedAt: "2025-12-21",
+  },
+  {
+    key: "email_sending_enabled",
+    description: "Enable actual email sending (disable to use mock)",
+    defaultValue: true,
+    killSwitchEligible: true,
+    surface: "all",
+    owner: "platform",
+    addedAt: "2025-12-21",
+  },
+  {
+    key: "migration_mode_enabled",
+    description: "Master switch for Migration Mode (WA sync, event matching, etc.)",
+    defaultValue: false, // Opt-in behavior, defaults OFF
+    killSwitchEligible: true,
+    surface: "all",
+    owner: "platform",
+    notes: "Controls MF-1 through MF-9 migration features",
+    addedAt: "2025-12-21",
+  },
+
+  // Feature Flags (default OFF, gradually rolled out)
+  {
+    key: "governance_annotations_ui",
+    description: "Enable governance annotations panel in admin UI",
+    defaultValue: false,
+    killSwitchEligible: false,
+    surface: "ui",
+    owner: "platform",
+    notes: "Expected cleanup: 2025-Q1",
+    addedAt: "2025-12-21",
+  },
+  {
+    key: "debug_mode_ui",
+    description: "Show debug information panels in admin UI",
+    defaultValue: false,
+    killSwitchEligible: false,
+    surface: "ui",
+    owner: "platform",
+    addedAt: "2025-12-21",
+  },
+] as const;
+
+// Type for valid flag keys
+export type FlagKey = (typeof FLAG_REGISTRY)[number]["key"];
+
+// Build a lookup map for O(1) access
+const FLAG_MAP = new Map<string, FlagDefinition>();
+for (const flag of FLAG_REGISTRY) {
+  if (FLAG_MAP.has(flag.key)) {
+    throw new Error(`Duplicate flag key in registry: ${flag.key}`);
+  }
+  FLAG_MAP.set(flag.key, flag);
+}
+
+/**
+ * Get a flag definition by key
+ */
+export function getDefinition(key: string): FlagDefinition | undefined {
+  return FLAG_MAP.get(key);
+}
+
+/**
+ * Get all kill-switch-eligible flags
+ */
+export function getKillSwitches(): FlagDefinition[] {
+  return FLAG_REGISTRY.filter((f) => f.killSwitchEligible);
+}

--- a/tests/unit/flags/flags.spec.ts
+++ b/tests/unit/flags/flags.spec.ts
@@ -1,0 +1,241 @@
+/**
+ * Unit tests for feature flag evaluation
+ *
+ * Tests the flag system defined in src/lib/flags/
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  isEnabled,
+  evaluateFlag,
+  flagKeyToEnvVar,
+  getDefinition,
+  isKillSwitchActive,
+  getAllFlagStatus,
+  getKillSwitchStatus,
+  resetFlagLogging,
+} from "@/lib/flags";
+import { FLAG_REGISTRY } from "@/lib/flags/registry";
+
+describe("flags", () => {
+  beforeEach(() => {
+    // Reset logging state between tests
+    resetFlagLogging();
+    // Clear any flag-related env vars
+    for (const flag of FLAG_REGISTRY) {
+      const envVar = flagKeyToEnvVar(flag.key);
+      delete process.env[envVar];
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("flagKeyToEnvVar", () => {
+    it("converts lowercase key to uppercase with prefix", () => {
+      expect(flagKeyToEnvVar("my_feature")).toBe("CLUBOS_FLAG_MY_FEATURE");
+    });
+
+    it("handles already uppercase keys", () => {
+      expect(flagKeyToEnvVar("MY_FEATURE")).toBe("CLUBOS_FLAG_MY_FEATURE");
+    });
+
+    it("handles mixed case keys", () => {
+      expect(flagKeyToEnvVar("myFeature")).toBe("CLUBOS_FLAG_MYFEATURE");
+    });
+  });
+
+  describe("getDefinition", () => {
+    it("returns definition for known flag", () => {
+      const def = getDefinition("event_postmortem_enabled");
+      expect(def).toBeDefined();
+      expect(def?.key).toBe("event_postmortem_enabled");
+      expect(def?.killSwitchEligible).toBe(true);
+    });
+
+    it("returns undefined for unknown flag", () => {
+      const def = getDefinition("nonexistent_flag");
+      expect(def).toBeUndefined();
+    });
+  });
+
+  describe("isEnabled", () => {
+    it("returns default value when no env var set", () => {
+      // event_postmortem_enabled defaults to true (kill switch)
+      expect(isEnabled("event_postmortem_enabled")).toBe(true);
+
+      // governance_annotations_ui defaults to false (feature flag)
+      expect(isEnabled("governance_annotations_ui")).toBe(false);
+    });
+
+    it("returns true when env var is '1'", () => {
+      process.env.CLUBOS_FLAG_GOVERNANCE_ANNOTATIONS_UI = "1";
+      expect(isEnabled("governance_annotations_ui")).toBe(true);
+    });
+
+    it("returns true when env var is 'true'", () => {
+      process.env.CLUBOS_FLAG_GOVERNANCE_ANNOTATIONS_UI = "true";
+      expect(isEnabled("governance_annotations_ui")).toBe(true);
+    });
+
+    it("returns false when env var is '0'", () => {
+      process.env.CLUBOS_FLAG_EVENT_POSTMORTEM_ENABLED = "0";
+      expect(isEnabled("event_postmortem_enabled")).toBe(false);
+    });
+
+    it("returns false when env var is 'false'", () => {
+      process.env.CLUBOS_FLAG_EVENT_POSTMORTEM_ENABLED = "false";
+      expect(isEnabled("event_postmortem_enabled")).toBe(false);
+    });
+
+    it("returns false for unknown flag (fail closed)", () => {
+      // Suppress console.warn for this test
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      expect(isEnabled("totally_unknown_flag")).toBe(false);
+    });
+
+    it("logs warning for unknown flag", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      isEnabled("totally_unknown_flag");
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[flags] Unknown flag key")
+      );
+    });
+
+    it("respects override context", () => {
+      // Default is false
+      expect(isEnabled("governance_annotations_ui")).toBe(false);
+
+      // Override to true
+      expect(
+        isEnabled("governance_annotations_ui", {
+          overrides: { governance_annotations_ui: true },
+        })
+      ).toBe(true);
+    });
+
+    it("override takes precedence over env var", () => {
+      process.env.CLUBOS_FLAG_GOVERNANCE_ANNOTATIONS_UI = "1";
+
+      // Env says true, but override says false
+      expect(
+        isEnabled("governance_annotations_ui", {
+          overrides: { governance_annotations_ui: false },
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("evaluateFlag", () => {
+    it("returns full evaluation result with source 'default'", () => {
+      const result = evaluateFlag("governance_annotations_ui");
+      expect(result).toEqual({
+        key: "governance_annotations_ui",
+        enabled: false,
+        source: "default",
+        envVar: "CLUBOS_FLAG_GOVERNANCE_ANNOTATIONS_UI",
+        envValue: undefined,
+        defaultValue: false,
+      });
+    });
+
+    it("returns source 'env' when env var is set", () => {
+      process.env.CLUBOS_FLAG_GOVERNANCE_ANNOTATIONS_UI = "1";
+      const result = evaluateFlag("governance_annotations_ui");
+      expect(result.source).toBe("env");
+      expect(result.enabled).toBe(true);
+      expect(result.envValue).toBe("1");
+    });
+
+    it("returns source 'override' when context override is set", () => {
+      const result = evaluateFlag("governance_annotations_ui", {
+        overrides: { governance_annotations_ui: true },
+      });
+      expect(result.source).toBe("override");
+      expect(result.enabled).toBe(true);
+    });
+
+    it("returns default false for unknown flag", () => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      const result = evaluateFlag("unknown_flag");
+      expect(result.enabled).toBe(false);
+      expect(result.source).toBe("default");
+      expect(result.defaultValue).toBe(false);
+    });
+  });
+
+  describe("isKillSwitchActive", () => {
+    it("is semantic alias for isEnabled", () => {
+      // email_sending_enabled is a kill switch, defaults to true
+      expect(isKillSwitchActive("email_sending_enabled")).toBe(true);
+
+      // Disable it
+      process.env.CLUBOS_FLAG_EMAIL_SENDING_ENABLED = "0";
+      expect(isKillSwitchActive("email_sending_enabled")).toBe(false);
+    });
+  });
+
+  describe("getAllFlagStatus", () => {
+    it("returns evaluation results for all registered flags", () => {
+      const status = getAllFlagStatus();
+      expect(status.length).toBe(FLAG_REGISTRY.length);
+
+      // Check structure
+      for (const result of status) {
+        expect(result).toHaveProperty("key");
+        expect(result).toHaveProperty("enabled");
+        expect(result).toHaveProperty("source");
+      }
+    });
+  });
+
+  describe("getKillSwitchStatus", () => {
+    it("returns only kill-switch-eligible flags", () => {
+      const status = getKillSwitchStatus();
+
+      // All returned flags should be kill switch eligible
+      for (const result of status) {
+        const def = getDefinition(result.key);
+        expect(def?.killSwitchEligible).toBe(true);
+      }
+
+      // Should not include non-kill-switch flags
+      const keys = status.map((s) => s.key);
+      expect(keys).not.toContain("governance_annotations_ui");
+      expect(keys).not.toContain("debug_mode_ui");
+    });
+  });
+
+  describe("registry validation", () => {
+    it("all flags have required fields", () => {
+      for (const flag of FLAG_REGISTRY) {
+        expect(flag.key).toBeTruthy();
+        expect(flag.description).toBeTruthy();
+        expect(typeof flag.defaultValue).toBe("boolean");
+        expect(typeof flag.killSwitchEligible).toBe("boolean");
+        expect(flag.surface).toBeTruthy();
+        expect(flag.owner).toBeTruthy();
+        expect(flag.addedAt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      }
+    });
+
+    it("kill switches default to true (convention)", () => {
+      const killSwitches = FLAG_REGISTRY.filter((f) => f.killSwitchEligible);
+      for (const ks of killSwitches) {
+        // Kill switches should generally default to true (enabled)
+        // Exception: migration_mode_enabled defaults to false (opt-in behavior)
+        if (ks.key !== "migration_mode_enabled") {
+          expect(ks.defaultValue).toBe(true);
+        }
+      }
+    });
+
+    it("feature flags default to false (convention)", () => {
+      const featureFlags = FLAG_REGISTRY.filter((f) => !f.killSwitchEligible);
+      for (const ff of featureFlags) {
+        expect(ff.defaultValue).toBe(false);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements typed feature flag infrastructure for ClubOS:

- **Central registry** (`src/lib/flags/registry.ts`): Type-safe flag definitions with metadata (key, description, defaultValue, killSwitchEligible, surface, owner)
- **Evaluation API** (`src/lib/flags/index.ts`): `isEnabled()`, `evaluateFlag()`, `isKillSwitchActive()` with environment variable support (`CLUBOS_FLAG_{KEY}`)
- **Documentation** (`docs/reliability/FEATURE_FLAGS.md`): Usage guide, API reference, lifecycle management
- **Unit tests**: 24 tests covering all flag evaluation scenarios

### Initial Flags

| Key | Type | Default | Description |
|-----|------|---------|-------------|
| `event_postmortem_enabled` | Kill switch | true | Event postmortem UI |
| `transition_widget_enabled` | Kill switch | true | Leadership transition widget |
| `email_sending_enabled` | Kill switch | true | Actual email sending |
| `migration_mode_enabled` | Kill switch | false | Migration Mode master switch |
| `governance_annotations_ui` | Feature | false | Governance annotations panel |
| `debug_mode_ui` | Feature | false | Debug info in admin UI |

### Charter Alignment

- **P7** (Observability): Flags log on first evaluation for debugging
- **MF-7** (Immunity gates): Kill switches enable instant feature disable

Closes #161

## Test plan

- [x] Unit tests pass (24 tests)
- [x] TypeScript compiles without errors
- [x] Pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)