### PR TITLE
docs(ci): hotspot map + editor wave merge addendum

### DIFF
--- a/docs/CI/HOTSPOT_MAP.md
+++ b/docs/CI/HOTSPOT_MAP.md
@@ -1,0 +1,20 @@
+# Hotspot Map (Quarantine Paths)
+
+Purpose: Identify paths that frequently conflict and should be treated as "hotspots".
+Rule: If a change must touch a hotspot, it becomes a dedicated themed wave owned by the merge captain.
+
+Hotspots (primary)
+- prisma/schema.prisma
+- package.json
+- package-lock.json
+- src/app/admin/** (core admin nav/search/layout surfaces)
+- src/app/admin/content/pages/** (publishing/editor surfaces)
+- src/lib/publishing/** (publishing runtime)
+
+Hotspots (secondary)
+- src/app/api/** (route contracts; frequently touched)
+- tests/** (broad surface; prefer micro-PRs)
+
+Guidance
+- Prefer docs-only work that avoids hotspots while waves are in flight.
+- For conflicting work, salvage via micro-PRs after the wave lands.

--- a/docs/CI/MERGE_POLICY_ADDENDUM_EDITOR_WAVE.md
+++ b/docs/CI/MERGE_POLICY_ADDENDUM_EDITOR_WAVE.md
@@ -1,0 +1,17 @@
+# Merge Policy Addendum: Editor/Publishing Wave
+
+Scope: Editor/publishing integration waves that touch hotspot paths.
+
+Rules
+- Do not rebase wave branches.
+- Do not cherry-pick commits out of wave branches into unrelated branches.
+- Follow-up fixes land on the wave branch while the PR is open, or as micro-PRs after merge.
+- Park conflicting PRs; label as parked + blocked-by-editor-wave; salvage later via micro-PRs.
+
+Micro-PR salvage template (post-wave)
+1. Create a fresh branch from main (post-wave merge)
+2. Identify the smallest coherent slice (one feature, one test set)
+3. Apply as manual edits or minimal clean cherry-picks
+4. Add/adjust tests
+5. Keep PR small (target < 300 net LOC; split if larger)
+6. Merge ASAP to reduce drift


### PR DESCRIPTION
## Release classification (required)
Select exactly one:

- [ ] experimental
- [x] candidate
- [ ] stable

## Summary

Docs-only CI/process guidance.

Adds:
- docs/CI/HOTSPOT_MAP.md
- docs/CI/MERGE_POLICY_ADDENDUM_EDITOR_WAVE.md

No hotspots touched.

## Checks
- [x] Local preflight passed: docs-only, no build needed