### PR TITLE
ci(style): guardrails for token-first styling

### DIFF
--- a/docs/ui/STYLING_SYSTEM.md
+++ b/docs/ui/STYLING_SYSTEM.md
@@ -1,0 +1,28 @@
+ClubOS Styling System (v1)
+
+Goals
+- No CSS override soup.
+- Non-technical admins change "Appearance" via safe knobs, not selectors.
+- Components never invent colors; they consume tokens.
+
+Layers (in order)
+1) Theme values (src/styles/themes/*.css)
+   - --theme-* variables (the only place theme values live)
+
+2) Tokens (src/styles/tokens/tokens.css)
+   - --token-* variables map to --theme-*
+   - Components and utility classes use --token-*
+
+3) Presets/variants (code)
+   - Components expose variants: e.g. button: primary|secondary|quiet|danger
+   - Variants are implemented with class strings that reference tokens
+
+Rules
+- Do not add hex colors (e.g. #fff, #2563eb) in TS/TSX.
+- Do not add new inline style objects in TSX (style={{...}}), except for truly dynamic layout calculations.
+- If a component needs a color/state, add a token for it.
+
+Admin UX (future)
+- "Appearance" edits theme values and a small set of component defaults.
+- Draft/publish: preview theme changes before making active.
+

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "postinstall": "prisma generate",
     "test:unit": "vitest run",
     "test:unit:coverage": "vitest run --coverage",
-    "green": "npm run typecheck && npm run lint && npm run test:unit && npm run db:seed && npm run test-admin:stable && npm run test-api:stable"
+    "green": "npm run typecheck && npm run lint && npm run test:unit && npm run db:seed && npm run test-admin:stable && npm run test-api:stable",
+    "ci:style-guard": "node --no-warnings --loader tsx scripts/ci/check-style-guard.ts"
   },
   "prisma": {
     "seed": "npx tsx prisma/seed.ts"

--- a/scripts/ci/check-style-guard.ts
+++ b/scripts/ci/check-style-guard.ts
@@ -1,0 +1,96 @@
+type Finding = { file: string; line: number; kind: string; text: string };
+
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = process.cwd();
+
+const INCLUDE_DIRS = [
+  "src/app",
+  "src/components",
+];
+
+const EXCLUDE_DIRS = [
+  "node_modules",
+  ".next",
+  "dist",
+  "build",
+];
+
+const HEX_RE = /#[0-9a-fA-F]{3,8}\b/g;
+const INLINE_STYLE_RE = /\bstyle\s*=\s*\{\{/g;
+
+const ALLOWLIST_FILES: string[] = [
+  "src/app/globals.css",
+  "src/styles/tokens/tokens.css",
+  "src/styles/themes/base.css",
+  "src/styles/themes/sbnc.css",
+];
+
+function isExcluded(p: string) {
+  return EXCLUDE_DIRS.some((d) => p.includes(`${path.sep}${d}${path.sep}`));
+}
+
+function walk(dir: string, out: string[]) {
+  const full = path.join(ROOT, dir);
+  if (!fs.existsSync(full)) return;
+  const entries = fs.readdirSync(full, { withFileTypes: true });
+  for (const e of entries) {
+    const p = path.join(full, e.name);
+    if (isExcluded(p)) continue;
+    if (e.isDirectory()) walk(path.join(dir, e.name), out);
+    else out.push(path.join(dir, e.name));
+  }
+}
+
+function rel(p: string) {
+  return p.split(path.sep).join("/");
+}
+
+function main() {
+  const files: string[] = [];
+  for (const d of INCLUDE_DIRS) walk(d, files);
+
+  const findings: Finding[] = [];
+
+  for (const f of files) {
+    const rf = rel(f);
+
+    if (!rf.endsWith(".ts") && !rf.endsWith(".tsx")) continue;
+    if (ALLOWLIST_FILES.includes(rf)) continue;
+
+    const text = fs.readFileSync(path.join(ROOT, f), "utf8");
+    const lines = text.split("\n");
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+
+      const hex = line.match(HEX_RE);
+      if (hex) {
+        findings.push({ file: rf, line: i + 1, kind: "HEX_COLOR", text: line.trim() });
+      }
+
+      if (INLINE_STYLE_RE.test(line)) {
+        findings.push({ file: rf, line: i + 1, kind: "INLINE_STYLE", text: line.trim() });
+      }
+    }
+  }
+
+  if (findings.length === 0) {
+    console.log("OK: style guardrails passed (no hex colors or inline style={{}} found in TS/TSX).");
+    return;
+  }
+
+  console.error("FAIL: style guardrails found violations:");
+  for (const f of findings.slice(0, 200)) {
+    console.error(`${f.file}:${f.line} ${f.kind} ${f.text}`);
+  }
+  console.error("");
+  console.error("Fix:");
+  console.error("- Replace hex colors with tokens (var(--token-...)) via classNames or CSS.");
+  console.error("- Replace inline style={{}} with token-based classes or a small variant system.");
+  process.exit(1);
+}
+
+main();
+


### PR DESCRIPTION
Adds a style-guard CI script and docs.

- New script: scripts/ci/check-style-guard.ts
- New npm script: ci:style-guard
- New doc: docs/ui/STYLING_SYSTEM.md

Next: wire ci:style-guard into GitHub Actions and begin converting FilePicker + gadgets to tokens.