### PR TITLE
chore(style): chip down style-guard baseline (member slug page)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "test:unit": "vitest run",
     "test:unit:coverage": "vitest run --coverage",
     "green": "npm run typecheck && npm run lint && npm run test:unit && npm run db:seed && npm run test-admin:stable && npm run test-api:stable",
-    "ci:style-guard": "node --no-warnings --loader tsx scripts/ci/check-style-guard.ts"
+    "ci:style-guard": "node --no-warnings --loader tsx scripts/ci/check-style-guard.ts",
+    "ci:style-guard:count": "npx -y tsx scripts/ci/check-style-guard.ts 2>&1 | rg -c ' HEX_COLOR | INLINE_STYLE ' || true",
+    "ci:style-guard:baseline": "STYLE_GUARD_FINDINGS_COUNT=$(npm run -s ci:style-guard:count) npx -y tsx scripts/ci/check-style-guard-baseline.ts"
   },
   "prisma": {
     "seed": "npx tsx prisma/seed.ts"

--- a/scripts/ci/check-style-guard-baseline.ts
+++ b/scripts/ci/check-style-guard-baseline.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import path from "node:path";
+
+function readJson(p: string): any {
+  return JSON.parse(fs.readFileSync(p, "utf8"));
+}
+
+function main() {
+  const baselinePath = path.join(process.cwd(), "scripts/ci/style-guard-baseline.json");
+  if (!fs.existsSync(baselinePath)) {
+    console.error("FAIL: missing baseline file:", baselinePath);
+    process.exit(1);
+  }
+
+  const baseline = readJson(baselinePath);
+  const max = Number(baseline?.max_findings ?? 0);
+  const count = Number(process.env.STYLE_GUARD_FINDINGS_COUNT ?? 0);
+
+  console.log(`STYLE_GUARD_BASELINE_MAX=${max}`);
+  console.log(`STYLE_GUARD_FINDINGS_COUNT=${count}`);
+
+  if (!Number.isFinite(max) || !Number.isFinite(count)) {
+    console.error("FAIL: baseline max/findings must be numbers.");
+    process.exit(1);
+  }
+
+  if (count > max) {
+    console.error("");
+    console.error("FAIL: style-guard baseline regression detected.");
+    console.error(`Expected <= ${max} findings but got ${count}.`);
+    console.error("Fix: convert new inline styles / hex colors to tokens.");
+    process.exit(1);
+  }
+
+  console.log("OK: no regression vs baseline.");
+}
+
+main();

--- a/src/app/(member)/member/[slug]/page.tsx
+++ b/src/app/(member)/member/[slug]/page.tsx
@@ -82,12 +82,12 @@ export default async function MemberPage({ params }: RouteParams) {
   if (!canView) {
     // User doesn't have permission to view this page
     return (
-      <main data-test-id="member-page-forbidden" style={{ padding: "40px", textAlign: "center" }}>
-        <h1 style={{ fontSize: "24px", marginBottom: "16px" }}>Access Restricted</h1>
-        <p style={{ color: "#666" }}>
+      <main data-test-id="member-page-forbidden" className="py-10 text-center">
+        <h1 className="text-2xl mb-4">Access Restricted</h1>
+        <p className="text-[var(--token-color-text-muted)]">
           You don&apos;t have permission to view this page.
         </p>
-        <Link href="/member" style={{ color: "#0066cc", marginTop: "16px", display: "inline-block" }}>
+        <Link href="/member" className="mt-4 inline-block text-[var(--token-color-primary)] hover:underline">
           Return to member dashboard
         </Link>
       </main>


### PR DESCRIPTION
candidate

Removes inline styles + hex colors from member slug page.

Also includes the missing baseline checker + npm scripts so ci:style-guard:baseline runs.

After the baseline PR merges to main, retarget this PR to main with no content change.