### PR TITLE
chore: restore green baseline (lint + purity fixes)

### DIFF
--- a/src/app/account/security/page.tsx
+++ b/src/app/account/security/page.tsx
@@ -11,8 +11,10 @@
  */
 
 import { redirect } from "next/navigation";
+import Link from "next/link";
 import { getCurrentSession } from "@/lib/auth/session";
 import PasskeyManager from "@/components/auth/PasskeyManager";
+import { formatClubDateTime } from "@/lib/timezone";
 
 export const metadata = {
   title: "Security Settings - ClubOS",
@@ -50,12 +52,12 @@ export default async function SecurityPage() {
               color: "#6b7280",
             }}
           >
-            <a
+            <Link
               href="/account"
               style={{ color: "#2563eb", textDecoration: "none" }}
             >
               Account
-            </a>
+            </Link>
             {" / "}
             <span>Security</span>
           </nav>
@@ -145,11 +147,11 @@ export default async function SecurityPage() {
             </div>
             <div style={{ marginBottom: "8px" }}>
               <strong style={{ color: "#374151" }}>Session created:</strong>{" "}
-              {session.createdAt.toLocaleString()}
+              {formatClubDateTime(session.createdAt)}
             </div>
             <div>
               <strong style={{ color: "#374151" }}>Session expires:</strong>{" "}
-              {session.expiresAt.toLocaleString()}
+              {formatClubDateTime(session.expiresAt)}
             </div>
           </div>
         </div>

--- a/src/app/admin/content/pages/[id]/page.tsx
+++ b/src/app/admin/content/pages/[id]/page.tsx
@@ -3,6 +3,7 @@
 // A4: Lifecycle state passed to client for Draft/Published controls
 
 import { notFound } from "next/navigation";
+import Link from "next/link";
 import { prisma } from "@/lib/prisma";
 import { PageContent } from "@/lib/publishing/blocks";
 import {
@@ -52,12 +53,12 @@ export default async function PageEditorPage({ params }: RouteParams) {
   return (
     <div data-test-id="page-editor-root" style={{ padding: "20px" }}>
       <div style={{ marginBottom: "16px" }}>
-        <a
+        <Link
           href="/admin/content/pages"
           style={{ color: "#0066cc", textDecoration: "none", fontSize: "14px" }}
         >
           &larr; Back to Pages
-        </a>
+        </Link>
       </div>
 
       <h1 data-test-id="page-editor-title" style={{ fontSize: "24px", margin: "0 0 8px 0" }}>

--- a/src/app/admin/governance/annotations/[id]/page.tsx
+++ b/src/app/admin/governance/annotations/[id]/page.tsx
@@ -9,6 +9,7 @@
 
 import { useEffect, useState, useCallback, use } from "react";
 import Link from "next/link";
+import { formatClubDateTime } from "@/lib/timezone";
 
 type AnnotationTargetType = "motion" | "bylaw" | "policy" | "page" | "file" | "minutes";
 
@@ -157,13 +158,7 @@ export default function GovernanceAnnotationDetailPage({ params }: { params: Pro
   };
 
   const formatDate = (dateStr: string) => {
-    return new Date(dateStr).toLocaleString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    });
+    return formatClubDateTime(new Date(dateStr));
   };
 
   if (loading) {

--- a/src/app/admin/governance/flags/[id]/page.tsx
+++ b/src/app/admin/governance/flags/[id]/page.tsx
@@ -9,6 +9,7 @@
 
 import { useEffect, useState, useCallback, use } from "react";
 import Link from "next/link";
+import { formatClubDateTime } from "@/lib/timezone";
 
 type ReviewFlagType =
   | "INSURANCE_REVIEW"
@@ -116,13 +117,7 @@ export default function GovernanceFlagDetailPage({ params }: { params: Promise<{
   };
 
   const formatDate = (dateStr: string) => {
-    return new Date(dateStr).toLocaleString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-    });
+    return formatClubDateTime(new Date(dateStr));
   };
 
   const isOverdue = () => {

--- a/src/app/api/v1/officer/events/my-events/route.ts
+++ b/src/app/api/v1/officer/events/my-events/route.ts
@@ -223,7 +223,7 @@ export async function GET(request: NextRequest) {
     const transformedCommitteeEvents = committeeEvents.map((e) => transformEvent(e, false));
 
     // 4. Filter for needing wrap-up: completed events where postmortem is not complete
-    let needingWrapUp = transformedMyChairEvents.filter(
+    const needingWrapUp = transformedMyChairEvents.filter(
       (e) =>
         e.status === EventStatus.COMPLETED &&
         e.postmortemCompletionStatus !== "COMPLETE"

--- a/src/app/auth/verify/page.tsx
+++ b/src/app/auth/verify/page.tsx
@@ -19,6 +19,7 @@
  */
 
 import { redirect } from "next/navigation";
+import Link from "next/link";
 import { prisma } from "@/lib/prisma";
 import { verifyToken } from "@/lib/auth/tokens";
 import { loginUser } from "@/lib/auth/session";
@@ -207,12 +208,12 @@ export default async function VerifyPage({ searchParams }: VerifyPageProps) {
           <p className="text-gray-600 mb-4">
             No verification token provided. Please request a new sign-in link.
           </p>
-          <a
+          <Link
             href="/login"
             className="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
           >
             Go to Login
-          </a>
+          </Link>
         </div>
       </div>
     );
@@ -232,12 +233,12 @@ export default async function VerifyPage({ searchParams }: VerifyPageProps) {
             This sign-in link is invalid or has expired. Links are valid for 30 minutes
             and can only be used once.
           </p>
-          <a
+          <Link
             href="/login"
             className="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
           >
             Request New Link
-          </a>
+          </Link>
         </div>
       </div>
     );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -12,6 +12,7 @@
 
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import Link from "next/link";
 import { getSessionCookieName } from "@/lib/auth/cookies";
 import PasskeyLoginButton from "@/components/auth/PasskeyLoginButton";
 import MagicLinkForm from "@/components/auth/MagicLinkForm";
@@ -124,12 +125,12 @@ export default async function LoginPage() {
           </p>
           <p>
             Not a member?{" "}
-            <a
+            <Link
               href="/join"
               style={{ color: "#2563eb", textDecoration: "underline" }}
             >
               Join the club
-            </a>
+            </Link>
           </p>
         </div>
       </div>

--- a/src/app/my/MySBNCContent.tsx
+++ b/src/app/my/MySBNCContent.tsx
@@ -239,8 +239,9 @@ function EmptyEventsState() {
 }
 
 function EventCard({ registration }: { registration: Registration }) {
+  const [nowMs] = useState(() => Date.now());
   const eventDate = new Date(registration.eventDate);
-  const daysUntil = Math.ceil((eventDate.getTime() - Date.now()) / (1000 * 60 * 60 * 24));
+  const daysUntil = Math.ceil((eventDate.getTime() - nowMs) / (1000 * 60 * 60 * 24));
   const isWaitlisted = registration.status === "WAITLISTED";
   const isUrgent = daysUntil <= 2;
 

--- a/src/components/admin/events/EventForm.tsx
+++ b/src/components/admin/events/EventForm.tsx
@@ -13,7 +13,7 @@
 
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useMemo, useCallback } from "react";
 import {
   generateDerivedPreview,
   validateEventFields,
@@ -21,6 +21,7 @@ import {
   type UrgencyLevel,
   type EventValidationError,
 } from "@/lib/events";
+import { formatClubDateTime } from "@/lib/timezone";
 
 // ============================================================================
 // TYPES
@@ -307,13 +308,9 @@ function DerivationPreview({
   formData: EventFormData;
   registeredCount: number;
 }) {
-  const [preview, setPreview] = useState<ReturnType<typeof generateDerivedPreview> | null>(null);
-  const [inferredCategory, setInferredCategory] = useState<string | null>(null);
-
-  useEffect(() => {
+  const preview = useMemo(() => {
     if (!formData.title || !formData.startTime) {
-      setPreview(null);
-      return;
+      return null;
     }
 
     try {
@@ -321,7 +318,7 @@ function DerivationPreview({
       const endTime = formData.endTime ? new Date(formData.endTime) : null;
       const capacity = formData.capacity ? parseInt(formData.capacity, 10) : null;
 
-      const result = generateDerivedPreview({
+      return generateDerivedPreview({
         title: formData.title,
         startTime,
         endTime,
@@ -329,13 +326,12 @@ function DerivationPreview({
         isPublished: formData.isPublished,
         registeredCount,
       });
-
-      setPreview(result);
-      setInferredCategory(result.inferredCategory);
     } catch {
-      setPreview(null);
+      return null;
     }
   }, [formData, registeredCount]);
+
+  const inferredCategory = preview?.inferredCategory ?? null;
 
   if (!preview) {
     return (
@@ -461,7 +457,7 @@ function DerivationPreview({
             )}
           </div>
           <div style={{ fontWeight: 500, color: "#374151" }}>
-            {preview.effectiveEndTime.toLocaleString()}
+            {formatClubDateTime(preview.effectiveEndTime)}
           </div>
         </div>
 

--- a/src/components/auth/AccessDenied.tsx
+++ b/src/components/auth/AccessDenied.tsx
@@ -12,6 +12,7 @@
  */
 
 import { useCallback } from "react";
+import Link from "next/link";
 import { useCurrentUser, getRoleDisplayName } from "@/hooks/useCurrentUser";
 
 interface AccessDeniedProps {
@@ -149,7 +150,7 @@ export default function AccessDenied({
       >
         {/* Show login for unauthenticated users */}
         {showLogin && !isAuthenticated && (
-          <a
+          <Link
             href="/login"
             data-test-id="access-denied-login"
             style={{
@@ -178,7 +179,7 @@ export default function AccessDenied({
               <line x1="15" y1="12" x2="3" y2="12" />
             </svg>
             Sign In
-          </a>
+          </Link>
         )}
 
         {/* Go back button */}
@@ -217,7 +218,7 @@ export default function AccessDenied({
         )}
 
         {/* Home link */}
-        <a
+        <Link
           href="/"
           data-test-id="access-denied-home"
           style={{
@@ -246,7 +247,7 @@ export default function AccessDenied({
             <polyline points="9 22 9 12 15 12 15 22" />
           </svg>
           Go Home
-        </a>
+        </Link>
       </div>
 
       {/* Contact admin */}

--- a/src/components/auth/AccountIndicator.tsx
+++ b/src/components/auth/AccountIndicator.tsx
@@ -12,6 +12,7 @@
  */
 
 import { useState, useRef, useEffect, useCallback } from "react";
+import Link from "next/link";
 import { useCurrentUser, getRoleDisplayName } from "@/hooks/useCurrentUser";
 
 interface AccountIndicatorProps {
@@ -91,7 +92,7 @@ export default function AccountIndicator({ compact = false }: AccountIndicatorPr
   // Error state - show login link
   if (error || !isAuthenticated || !user) {
     return (
-      <a
+      <Link
         href="/login"
         data-test-id="account-indicator-login"
         style={{
@@ -120,7 +121,7 @@ export default function AccountIndicator({ compact = false }: AccountIndicatorPr
           <line x1="15" y1="12" x2="3" y2="12" />
         </svg>
         Sign In
-      </a>
+      </Link>
     );
   }
 
@@ -275,7 +276,7 @@ export default function AccountIndicator({ compact = false }: AccountIndicatorPr
 
           {/* Menu Items */}
           <div style={{ padding: "4px 0" }}>
-            <a
+            <Link
               href="/account/security"
               role="menuitem"
               data-test-id="account-menu-security"
@@ -304,7 +305,7 @@ export default function AccountIndicator({ compact = false }: AccountIndicatorPr
                 <path d="M7 11V7a5 5 0 0 1 10 0v4" />
               </svg>
               Security Settings
-            </a>
+            </Link>
 
             <button
               type="button"

--- a/src/components/auth/PasskeyLoginButton.tsx
+++ b/src/components/auth/PasskeyLoginButton.tsx
@@ -210,7 +210,7 @@ export default function PasskeyLoginButton({
             Passkeys not available
           </div>
           <div>
-            Your browser doesn't support passkeys. Please use the email sign-in option below.
+            Your browser doesn&apos;t support passkeys. Please use the email sign-in option below.
           </div>
         </div>
       )}

--- a/src/components/view-as/ImpersonationBanner.tsx
+++ b/src/components/view-as/ImpersonationBanner.tsx
@@ -23,6 +23,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
 
 interface ImpersonationState {
   isImpersonating: boolean;
@@ -289,7 +290,7 @@ export default function ImpersonationBanner() {
             <h4 style={styles.quickSwitchHeader}>Quick Switch to Demo Member</h4>
             <p style={styles.quickSwitchNote}>
               Switch to a different member type to test various user perspectives.
-              Go to <a href="/admin/demo" style={styles.linkStyle}>Admin Demo</a> for full member search.
+              Go to <Link href="/admin/demo" style={styles.linkStyle}>Admin Demo</Link> for full member search.
             </p>
             <div style={styles.personaGrid}>
               {QUICK_SWITCH_PERSONAS.map((persona) => (

--- a/src/lib/publishing/blockOrdering.ts
+++ b/src/lib/publishing/blockOrdering.ts
@@ -41,7 +41,7 @@ export function reorderBlocks<T extends OrderedBlock>(
   next.splice(clampedTo, 0, moved);
 
   // Renumber order field, returning new objects (do not mutate originals).
-  const renumbered = next.map((b, idx) => ({ ...(b as any), order: idx })) as T[];
+  const renumbered = next.map((b, idx) => ({ ...b, order: idx })) as T[];
   return renumbered;
 }
 

--- a/src/lib/view-context.ts
+++ b/src/lib/view-context.ts
@@ -25,9 +25,13 @@ const getNextCookies = () => {
   return getNextCookies();
 };
 
+type CookieStore = {
+  get?: (name: string) => string | { value?: string } | undefined;
+};
+
 function cookieGet(store: unknown, name: string): string | undefined {
-  const anyStore = store as any;
-  const v = anyStore?.get?.(name);
+  const typedStore = store as CookieStore;
+  const v = typedStore?.get?.(name);
   if (typeof v === "string") return v;
   if (v && typeof v.value === "string") return v.value;
   return undefined;

--- a/tests/unit/paramValidation.spec.ts
+++ b/tests/unit/paramValidation.spec.ts
@@ -1,8 +1,8 @@
-import { test, expect } from "@playwright/test";
+import { describe, it, expect } from "vitest";
 import { clampPageSize, validateTemplateParams } from "../../src/lib/query/paramValidation";
 
-test.describe("validateTemplateParams", () => {
-  test("denies unknown keys", async () => {
+describe("validateTemplateParams", () => {
+  it("denies unknown keys", () => {
     const spec = { allowedKeys: ["q"], maxPageSize: 10 };
     const res = validateTemplateParams(spec, { nope: 1 });
     expect(res.ok).toBe(false);
@@ -11,42 +11,42 @@ test.describe("validateTemplateParams", () => {
     }
   });
 
-  test("allows known keys", async () => {
+  it("allows known keys", () => {
     const spec = { allowedKeys: ["q"], maxPageSize: 10 };
     const res = validateTemplateParams(spec, { q: "hi" });
     expect(res.ok).toBe(true);
   });
 
-  test("allows empty params", async () => {
+  it("allows empty params", () => {
     const spec = { allowedKeys: ["q", "limit"], maxPageSize: 10 };
     const res = validateTemplateParams(spec, {});
     expect(res.ok).toBe(true);
   });
 });
 
-test.describe("clampPageSize", () => {
-  test("clamps above max", async () => {
+describe("clampPageSize", () => {
+  it("clamps above max", () => {
     const spec = { allowedKeys: [], maxPageSize: 10 };
     expect(clampPageSize(spec, 999)).toBe(10);
   });
 
-  test("clamps below minimum to 1", async () => {
+  it("clamps below minimum to 1", () => {
     const spec = { allowedKeys: [], maxPageSize: 10 };
     expect(clampPageSize(spec, 0)).toBe(1);
     expect(clampPageSize(spec, -5)).toBe(1);
   });
 
-  test("uses maxPageSize when undefined", async () => {
+  it("uses maxPageSize when undefined", () => {
     const spec = { allowedKeys: [], maxPageSize: 25 };
     expect(clampPageSize(spec, undefined)).toBe(25);
   });
 
-  test("uses maxPageSize when null", async () => {
+  it("uses maxPageSize when null", () => {
     const spec = { allowedKeys: [], maxPageSize: 25 };
     expect(clampPageSize(spec, null)).toBe(25);
   });
 
-  test("floors decimal values", async () => {
+  it("floors decimal values", () => {
     const spec = { allowedKeys: [], maxPageSize: 100 };
     expect(clampPageSize(spec, 5.9)).toBe(5);
   });

--- a/tests/unit/publishing/blockSchemas.spec.ts
+++ b/tests/unit/publishing/blockSchemas.spec.ts
@@ -250,7 +250,7 @@ describe("blockSchemas", () => {
 
     describe("unknown block type", () => {
       it("rejects unknown block type", () => {
-        const result = validateBlockData("unknown" as any, {});
+        const result = validateBlockData("unknown" as Parameters<typeof validateBlockData>[0], {});
         expect(result.ok).toBe(false);
         if (!result.ok) {
           expect(result.error).toContain("Unknown block type");


### PR DESCRIPTION
## Summary

This PR fixes lint errors that were blocking `npm run green`:

### Changes by Category

1. **Timezone helper** - Replace `toLocaleString()` with `formatClubDateTime()` in:
   - `src/app/admin/governance/annotations/[id]/page.tsx`
   - `src/app/admin/governance/flags/[id]/page.tsx`
   - `src/app/account/security/page.tsx`
   - `src/components/admin/events/EventForm.tsx`

2. **Date.now purity** - Fix react-hooks/purity in `MySBNCContent.tsx` using `useState(() => Date.now())`

3. **set-state-in-effect** - Convert useEffect+setState to useMemo in `EventForm.tsx`

4. **Link conversions** - Replace `<a>` with Next.js `<Link>` in 7 files (Next.js lint rule)

5. **no-explicit-any** - Remove in:
   - `blockOrdering.ts` (unnecessary cast)
   - `view-context.ts` (added CookieStore type)
   - `blockSchemas.spec.ts` (proper type assertion)

6. **prefer-const** - Fix in `my-events/route.ts`

7. **Test fix** - Convert Playwright imports to Vitest in `paramValidation.spec.ts`

### Test Evidence

| Check | Status |
|-------|--------|
| Typecheck | ✅ Pass |
| Lint | ✅ 0 errors (47 warnings acceptable) |
| Unit tests | ✅ 55 files, 1367 tests pass |
| Admin tests | ✅ 32 tests pass |
| API tests | ⚠️ Fail (pre-existing infra issue) |

### API Test Failure Evidence

**Same failure on origin/main:**
```
Error: apiRequestContext.get: connect ECONNREFUSED ::1:3000
→ GET http://localhost:3000/api/admin/demo/scenarios
```

This is a pre-existing infrastructure issue - tests require a running dev server on port 3000, but there's no `webServer` config in `playwright.config.ts`. The failure is identical on `origin/main`.

---

**Branch:** `chore/restore-green-20251223_142347`
**HEAD SHA:** `6341c21bd839388120df9df9abcde10fc1fd3de7`