### PR TITLE
chore: tighten green script for fast safety net

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test-contracts:unit": "vitest run tests/contracts --reporter=verbose",
     "test-contracts:api": "playwright test tests/contracts --grep-invert @quarantine --workers=2",
     "test:guardrails": "npx tsx scripts/ci/check-auth-guardrails.ts",
-    "green": "npm run typecheck && npm run lint && npm run test:guardrails && npm run test:unit && npm run db:seed && npm run test-admin:stable && npm run test-api:stable"
+    "green": "npm run typecheck && npm run lint && npm run test:guardrails && npm run test-contracts:unit",
+    "green:full": "npm run green && npm run test:unit && npm run db:seed && npm run test-admin:stable && npm run test-api:stable"
   },
   "prisma": {
     "seed": "npx tsx prisma/seed.ts"


### PR DESCRIPTION
## Summary

Split `green` into fast and full variants for better developer experience.

### Changes

| Script | Contents | Runtime |
|--------|----------|---------|
| `green` | typecheck + lint + guardrails + contracts:unit | ~18s |
| `green:full` | green + test:unit + db:seed + Playwright | ~5min |

### Why

The fast `green` script enables developers to run a quick safety check before pushing without waiting for the full test suite. The `green:full` script provides the complete CI-equivalent check when needed.

### CI Verification

Current CI workflows already run components individually:
- `ci-prisma-build.yml`: typecheck + build on PRs
- `security-guardrails.yml`: test:guardrails on PRs

### Test Results

```
npm run green

> typecheck ✓
> lint ✓ (47 warnings, 0 errors)
> test:guardrails ✓ (28 known gaps tracked)
> test-contracts:unit ✓ (40 tests passed)

Total time: 18.4s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)