### PR TITLE
feat: add policy access layer with typed keys and defaults

### DIFF
--- a/src/lib/membership/lifecycle.ts
+++ b/src/lib/membership/lifecycle.ts
@@ -5,7 +5,14 @@
  * Based on docs/MEMBERSHIP/MEMBERSHIP_LIFECYCLE_STATE_MACHINE.md
  *
  * This module is READ-ONLY - it infers state but never writes.
+ *
+ * Policy Integration:
+ * - Thresholds (90-day newbie, 730-day extended) come from the policy layer
+ * - See: Issue #235 (Membership Lifecycle Thresholds Migration)
+ * - See: Issue #263 (Policy Configuration Layer)
  */
+
+import { getPolicyDefault } from "@/lib/policy/getPolicy";
 
 // ============================================================================
 // Types
@@ -91,11 +98,18 @@ export interface LifecycleExplanation {
 }
 
 // ============================================================================
-// Constants
+// Policy-Derived Constants
 // ============================================================================
 
-const NEWBIE_PERIOD_DAYS = 90;
-const TWO_YEAR_DAYS = 730;
+/**
+ * Lifecycle thresholds from the policy layer.
+ * These values are configurable per-organization in the future.
+ *
+ * See: Issue #235 (Membership Lifecycle Thresholds Migration)
+ * See: Issue #263 (Policy Configuration Layer)
+ */
+const NEWBIE_PERIOD_DAYS = getPolicyDefault("membership.newbieDays");
+const TWO_YEAR_DAYS = getPolicyDefault("membership.extendedDays");
 
 const STATE_LABELS: Record<LifecycleState, string> = {
   not_a_member: "Not a Member",

--- a/src/lib/policy/getPolicy.ts
+++ b/src/lib/policy/getPolicy.ts
@@ -1,0 +1,210 @@
+/**
+ * Policy Access Layer - getPolicy
+ *
+ * Single entry point for accessing organization-configurable policies.
+ * All code that needs policy values MUST use this function.
+ *
+ * Current implementation: Returns hard-coded defaults (SBNC values)
+ * Future implementation: Database lookup with caching
+ *
+ * See: docs/ARCH/PLATFORM_VS_POLICY.md
+ * Related: Issue #263 (Policy Configuration Layer)
+ */
+
+import type {
+  PolicyKey,
+  PolicyValue,
+  PolicyValueMap,
+  GetPolicyOptions,
+} from "./types";
+
+// =============================================================================
+// Default Values (SBNC as Tenant Zero)
+// =============================================================================
+
+/**
+ * Default policy values based on SBNC configuration.
+ * These serve as fallbacks and initial values for new organizations.
+ *
+ * IMPORTANT: These are DEFAULTS, not requirements.
+ * Other organizations may configure different values.
+ */
+const POLICY_DEFAULTS: PolicyValueMap = {
+  // Membership lifecycle
+  "membership.newbieDays": 90,
+  "membership.extendedDays": 730,
+  "membership.gracePeriodDays": 30,
+  "membership.renewalReminderDays": 30,
+
+  // Event scheduling (SBNC: Pacific time, Tuesday 8 AM opens, Sunday announcements)
+  "scheduling.timezone": "America/Los_Angeles",
+  "scheduling.registrationOpenDay": 2, // Tuesday (0 = Sunday)
+  "scheduling.registrationOpenHour": 8, // 8 AM
+  "scheduling.eventArchiveDays": 30,
+  "scheduling.announcementDay": 0, // Sunday
+  "scheduling.announcementHour": 8, // 8 AM
+
+  // Governance
+  "governance.minutesReviewDays": 7,
+  "governance.boardEligibilityDays": 730, // 2 years
+  "governance.quorumPercentage": 50,
+
+  // KPI thresholds
+  "kpi.membershipWarningThreshold": 200,
+  "kpi.membershipDangerThreshold": 150,
+  "kpi.eventAttendanceWarningPercent": 50,
+  "kpi.eventAttendanceDangerPercent": 25,
+
+  // Display
+  "display.organizationName": "Organization",
+  "display.memberTermSingular": "member",
+  "display.memberTermPlural": "members",
+};
+
+// =============================================================================
+// Validation
+// =============================================================================
+
+/**
+ * Set of all valid policy keys for runtime validation
+ */
+const VALID_KEYS = new Set<string>(Object.keys(POLICY_DEFAULTS));
+
+/**
+ * Type guard to check if a string is a valid PolicyKey
+ */
+export function isValidPolicyKey(key: string): key is PolicyKey {
+  return VALID_KEYS.has(key);
+}
+
+/**
+ * Error thrown when an invalid policy key is requested
+ */
+export class InvalidPolicyKeyError extends Error {
+  constructor(key: string) {
+    super(`Invalid policy key: "${key}". Valid keys are: ${Array.from(VALID_KEYS).join(", ")}`);
+    this.name = "InvalidPolicyKeyError";
+  }
+}
+
+/**
+ * Error thrown when orgId is missing
+ */
+export class MissingOrgIdError extends Error {
+  constructor() {
+    super("orgId is required for policy access (even if currently unused)");
+    this.name = "MissingOrgIdError";
+  }
+}
+
+// =============================================================================
+// Main API
+// =============================================================================
+
+/**
+ * Get a policy value for an organization.
+ *
+ * @param key - The policy key to retrieve
+ * @param options - Options including orgId
+ * @returns The policy value (currently always the default)
+ * @throws InvalidPolicyKeyError if key is not a valid PolicyKey
+ * @throws MissingOrgIdError if orgId is not provided
+ *
+ * @example
+ * ```typescript
+ * const newbieDays = getPolicy("membership.newbieDays", { orgId: "org_123" });
+ * // Returns: 90 (default)
+ *
+ * const timezone = getPolicy("scheduling.timezone", { orgId: "org_123" });
+ * // Returns: "America/Los_Angeles" (default)
+ * ```
+ */
+export function getPolicy<K extends PolicyKey>(
+  key: K,
+  options: GetPolicyOptions
+): PolicyValue<K> {
+  // Validate orgId is provided (future: use for lookup)
+  if (!options?.orgId) {
+    throw new MissingOrgIdError();
+  }
+
+  // Validate key at runtime (TypeScript only catches compile-time)
+  if (!isValidPolicyKey(key)) {
+    throw new InvalidPolicyKeyError(key);
+  }
+
+  // TODO: Future implementation will:
+  // 1. Check cache for org-specific value
+  // 2. Query database if not cached
+  // 3. Fall back to default if not configured
+  //
+  // For now, always return the default
+  return POLICY_DEFAULTS[key] as PolicyValue<K>;
+}
+
+/**
+ * Get multiple policy values at once.
+ *
+ * @param keys - Array of policy keys to retrieve
+ * @param options - Options including orgId
+ * @returns Object mapping keys to their values
+ *
+ * @example
+ * ```typescript
+ * const policies = getPolicies(
+ *   ["membership.newbieDays", "membership.extendedDays"],
+ *   { orgId: "org_123" }
+ * );
+ * // Returns: { "membership.newbieDays": 90, "membership.extendedDays": 730 }
+ * ```
+ */
+export function getPolicies<K extends PolicyKey>(
+  keys: K[],
+  options: GetPolicyOptions
+): { [key in K]: PolicyValue<key> } {
+  const result = {} as { [key in K]: PolicyValue<key> };
+
+  for (const key of keys) {
+    result[key] = getPolicy(key, options);
+  }
+
+  return result;
+}
+
+/**
+ * Get all policy values for an organization.
+ *
+ * @param options - Options including orgId
+ * @returns Complete policy value map
+ */
+export function getAllPolicies(options: GetPolicyOptions): PolicyValueMap {
+  // Validate orgId
+  if (!options?.orgId) {
+    throw new MissingOrgIdError();
+  }
+
+  // TODO: Future implementation will merge org-specific values with defaults
+  return { ...POLICY_DEFAULTS };
+}
+
+/**
+ * Get the default value for a policy key.
+ * Use this when you specifically want the platform default, not the org value.
+ *
+ * @param key - The policy key
+ * @returns The default value
+ */
+export function getPolicyDefault<K extends PolicyKey>(key: K): PolicyValue<K> {
+  if (!isValidPolicyKey(key)) {
+    throw new InvalidPolicyKeyError(key);
+  }
+
+  return POLICY_DEFAULTS[key] as PolicyValue<K>;
+}
+
+// =============================================================================
+// Exports
+// =============================================================================
+
+export { POLICY_DEFAULTS };
+export type { PolicyKey, PolicyValue, PolicyValueMap, GetPolicyOptions } from "./types";

--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Policy Access Layer
+ *
+ * This module provides type-safe access to organization-configurable policies.
+ *
+ * Usage:
+ * ```typescript
+ * import { getPolicy, getPolicies } from '@/lib/policy';
+ *
+ * const newbieDays = getPolicy("membership.newbieDays", { orgId });
+ * ```
+ *
+ * See: docs/ARCH/PLATFORM_VS_POLICY.md
+ * Related: Issue #263 (Policy Configuration Layer)
+ */
+
+export {
+  getPolicy,
+  getPolicies,
+  getAllPolicies,
+  getPolicyDefault,
+  isValidPolicyKey,
+  InvalidPolicyKeyError,
+  MissingOrgIdError,
+  POLICY_DEFAULTS,
+} from "./getPolicy";
+
+export type {
+  PolicyKey,
+  PolicyValue,
+  PolicyValueMap,
+  GetPolicyOptions,
+  MembershipPolicyKey,
+  SchedulingPolicyKey,
+  GovernancePolicyKey,
+  KpiPolicyKey,
+  DisplayPolicyKey,
+  OrganizationId,
+} from "./types";

--- a/src/lib/policy/types.ts
+++ b/src/lib/policy/types.ts
@@ -1,0 +1,135 @@
+/**
+ * Policy Access Layer - Types
+ *
+ * This module defines the type-safe keys for organization-configurable policies.
+ * All policy access MUST go through getPolicy() to ensure:
+ * 1. Type safety for policy keys
+ * 2. Default value resolution
+ * 3. Future database/config integration
+ *
+ * See: docs/ARCH/PLATFORM_VS_POLICY.md
+ * Related: Issue #263 (Policy Configuration Layer)
+ */
+
+// =============================================================================
+// Policy Key Definitions
+// =============================================================================
+
+/**
+ * Membership lifecycle policy keys
+ */
+export type MembershipPolicyKey =
+  | "membership.newbieDays" // Days before newbie status expires
+  | "membership.extendedDays" // Days to qualify as extended member
+  | "membership.gracePeriodDays" // Days before lapsed status
+  | "membership.renewalReminderDays"; // Days before expiration to remind
+
+/**
+ * Event scheduling policy keys
+ */
+export type SchedulingPolicyKey =
+  | "scheduling.timezone" // Organization timezone (IANA format)
+  | "scheduling.registrationOpenDay" // Day of week registration opens (0-6)
+  | "scheduling.registrationOpenHour" // Hour registration opens (0-23)
+  | "scheduling.eventArchiveDays" // Days after event to archive
+  | "scheduling.announcementDay" // Day of week for announcements (0-6)
+  | "scheduling.announcementHour"; // Hour for announcements (0-23)
+
+/**
+ * Governance workflow policy keys
+ */
+export type GovernancePolicyKey =
+  | "governance.minutesReviewDays" // Days to review minutes
+  | "governance.boardEligibilityDays" // Days of membership for board eligibility
+  | "governance.quorumPercentage"; // Percentage for quorum
+
+/**
+ * KPI and dashboard policy keys
+ */
+export type KpiPolicyKey =
+  | "kpi.membershipWarningThreshold" // Membership count warning level
+  | "kpi.membershipDangerThreshold" // Membership count danger level
+  | "kpi.eventAttendanceWarningPercent" // Event attendance warning percentage
+  | "kpi.eventAttendanceDangerPercent"; // Event attendance danger percentage
+
+/**
+ * Display and terminology policy keys
+ */
+export type DisplayPolicyKey =
+  | "display.organizationName" // Organization display name
+  | "display.memberTermSingular" // What to call a member (e.g., "member", "participant")
+  | "display.memberTermPlural"; // Plural form
+
+/**
+ * Union of all valid policy keys
+ */
+export type PolicyKey =
+  | MembershipPolicyKey
+  | SchedulingPolicyKey
+  | GovernancePolicyKey
+  | KpiPolicyKey
+  | DisplayPolicyKey;
+
+// =============================================================================
+// Policy Value Types
+// =============================================================================
+
+/**
+ * Maps each policy key to its value type
+ */
+export interface PolicyValueMap {
+  // Membership
+  "membership.newbieDays": number;
+  "membership.extendedDays": number;
+  "membership.gracePeriodDays": number;
+  "membership.renewalReminderDays": number;
+
+  // Scheduling
+  "scheduling.timezone": string;
+  "scheduling.registrationOpenDay": number;
+  "scheduling.registrationOpenHour": number;
+  "scheduling.eventArchiveDays": number;
+  "scheduling.announcementDay": number;
+  "scheduling.announcementHour": number;
+
+  // Governance
+  "governance.minutesReviewDays": number;
+  "governance.boardEligibilityDays": number;
+  "governance.quorumPercentage": number;
+
+  // KPI
+  "kpi.membershipWarningThreshold": number;
+  "kpi.membershipDangerThreshold": number;
+  "kpi.eventAttendanceWarningPercent": number;
+  "kpi.eventAttendanceDangerPercent": number;
+
+  // Display
+  "display.organizationName": string;
+  "display.memberTermSingular": string;
+  "display.memberTermPlural": string;
+}
+
+// =============================================================================
+// Helper Types
+// =============================================================================
+
+/**
+ * Extract the value type for a given policy key
+ */
+export type PolicyValue<K extends PolicyKey> = PolicyValueMap[K];
+
+/**
+ * Organization ID type (opaque string for now)
+ */
+export type OrganizationId = string;
+
+/**
+ * Options for getPolicy
+ */
+export interface GetPolicyOptions {
+  /**
+   * Organization ID (required for future multi-tenant support)
+   * Currently unused but enforced for API stability
+   */
+  orgId: OrganizationId;
+}

--- a/tests/contracts/policy.contract.spec.ts
+++ b/tests/contracts/policy.contract.spec.ts
@@ -1,0 +1,372 @@
+/**
+ * Policy Access Layer Contract Tests
+ *
+ * Charter Principles:
+ * - P3: State machines over ad-hoc booleans (policies are typed, not magic strings)
+ * - P4: No hidden rules (defaults are explicit and documented)
+ * - P8: Schema and APIs are stable contracts (policy keys are typed)
+ *
+ * Tests the policy access layer contracts:
+ * 1. Unknown keys throw InvalidPolicyKeyError
+ * 2. Defaults resolve to documented SBNC values
+ * 3. orgId is required (throws MissingOrgIdError when missing)
+ * 4. Type safety for policy values
+ *
+ * These tests are deterministic and test pure functions.
+ *
+ * Related: Issue #263 (Policy Configuration Layer)
+ * See: docs/ARCH/PLATFORM_VS_POLICY.md
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  getPolicy,
+  getPolicies,
+  getAllPolicies,
+  getPolicyDefault,
+  isValidPolicyKey,
+  InvalidPolicyKeyError,
+  MissingOrgIdError,
+  POLICY_DEFAULTS,
+} from "../../src/lib/policy";
+
+// ============================================================================
+// A) UNKNOWN KEYS THROW
+// ============================================================================
+
+describe("Policy Contract: Invalid Keys", () => {
+  /**
+   * Contract: Unknown policy keys MUST throw InvalidPolicyKeyError
+   *
+   * This ensures callers can't pass arbitrary strings as policy keys.
+   * TypeScript catches this at compile time, but runtime validation
+   * protects against dynamic key construction.
+   */
+  describe("getPolicy throws for unknown keys", () => {
+    it("throws InvalidPolicyKeyError for completely unknown key", () => {
+      expect(() => {
+        // @ts-expect-error - Testing runtime validation
+        getPolicy("unknown.key", { orgId: "org_123" });
+      }).toThrow(InvalidPolicyKeyError);
+    });
+
+    it("throws InvalidPolicyKeyError for typo in valid key", () => {
+      expect(() => {
+        // @ts-expect-error - Testing runtime validation
+        getPolicy("membership.newbieDays_typo", { orgId: "org_123" });
+      }).toThrow(InvalidPolicyKeyError);
+    });
+
+    it("throws InvalidPolicyKeyError for empty string", () => {
+      expect(() => {
+        // @ts-expect-error - Testing runtime validation
+        getPolicy("", { orgId: "org_123" });
+      }).toThrow(InvalidPolicyKeyError);
+    });
+
+    it("error message includes the invalid key", () => {
+      try {
+        // @ts-expect-error - Testing runtime validation
+        getPolicy("bad.key", { orgId: "org_123" });
+        expect.fail("Should have thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(InvalidPolicyKeyError);
+        expect((e as Error).message).toContain("bad.key");
+      }
+    });
+
+    it("error message lists valid keys", () => {
+      try {
+        // @ts-expect-error - Testing runtime validation
+        getPolicy("bad.key", { orgId: "org_123" });
+        expect.fail("Should have thrown");
+      } catch (e) {
+        expect((e as Error).message).toContain("membership.newbieDays");
+      }
+    });
+  });
+
+  describe("getPolicyDefault throws for unknown keys", () => {
+    it("throws InvalidPolicyKeyError for unknown key", () => {
+      expect(() => {
+        // @ts-expect-error - Testing runtime validation
+        getPolicyDefault("unknown.key");
+      }).toThrow(InvalidPolicyKeyError);
+    });
+  });
+
+  describe("isValidPolicyKey validates keys", () => {
+    it("returns true for valid keys", () => {
+      expect(isValidPolicyKey("membership.newbieDays")).toBe(true);
+      expect(isValidPolicyKey("scheduling.timezone")).toBe(true);
+      expect(isValidPolicyKey("governance.quorumPercentage")).toBe(true);
+    });
+
+    it("returns false for invalid keys", () => {
+      expect(isValidPolicyKey("unknown.key")).toBe(false);
+      expect(isValidPolicyKey("")).toBe(false);
+      expect(isValidPolicyKey("membership")).toBe(false);
+    });
+  });
+});
+
+// ============================================================================
+// B) DEFAULTS RESOLVE CORRECTLY
+// ============================================================================
+
+describe("Policy Contract: Default Values", () => {
+  /**
+   * Contract: Defaults MUST match SBNC configuration values
+   *
+   * These are the documented defaults from PLATFORM_VS_POLICY.md.
+   * Changing these values requires updating both code and docs.
+   */
+  const TEST_ORG = { orgId: "org_test" };
+
+  describe("Membership defaults (SBNC values)", () => {
+    it("membership.newbieDays defaults to 90", () => {
+      expect(getPolicy("membership.newbieDays", TEST_ORG)).toBe(90);
+    });
+
+    it("membership.extendedDays defaults to 730 (2 years)", () => {
+      expect(getPolicy("membership.extendedDays", TEST_ORG)).toBe(730);
+    });
+
+    it("membership.gracePeriodDays defaults to 30", () => {
+      expect(getPolicy("membership.gracePeriodDays", TEST_ORG)).toBe(30);
+    });
+
+    it("membership.renewalReminderDays defaults to 30", () => {
+      expect(getPolicy("membership.renewalReminderDays", TEST_ORG)).toBe(30);
+    });
+  });
+
+  describe("Scheduling defaults (SBNC values)", () => {
+    it("scheduling.timezone defaults to America/Los_Angeles", () => {
+      expect(getPolicy("scheduling.timezone", TEST_ORG)).toBe("America/Los_Angeles");
+    });
+
+    it("scheduling.registrationOpenDay defaults to 2 (Tuesday)", () => {
+      expect(getPolicy("scheduling.registrationOpenDay", TEST_ORG)).toBe(2);
+    });
+
+    it("scheduling.registrationOpenHour defaults to 8 (8 AM)", () => {
+      expect(getPolicy("scheduling.registrationOpenHour", TEST_ORG)).toBe(8);
+    });
+
+    it("scheduling.announcementDay defaults to 0 (Sunday)", () => {
+      expect(getPolicy("scheduling.announcementDay", TEST_ORG)).toBe(0);
+    });
+  });
+
+  describe("Governance defaults", () => {
+    it("governance.boardEligibilityDays defaults to 730 (2 years)", () => {
+      expect(getPolicy("governance.boardEligibilityDays", TEST_ORG)).toBe(730);
+    });
+
+    it("governance.quorumPercentage defaults to 50", () => {
+      expect(getPolicy("governance.quorumPercentage", TEST_ORG)).toBe(50);
+    });
+  });
+
+  describe("Display defaults (neutral)", () => {
+    it("display.organizationName defaults to Organization", () => {
+      expect(getPolicy("display.organizationName", TEST_ORG)).toBe("Organization");
+    });
+
+    it("display.memberTermSingular defaults to member", () => {
+      expect(getPolicy("display.memberTermSingular", TEST_ORG)).toBe("member");
+    });
+
+    it("display.memberTermPlural defaults to members", () => {
+      expect(getPolicy("display.memberTermPlural", TEST_ORG)).toBe("members");
+    });
+  });
+
+  describe("getPolicyDefault returns defaults without orgId", () => {
+    it("returns default value for valid key", () => {
+      expect(getPolicyDefault("membership.newbieDays")).toBe(90);
+      expect(getPolicyDefault("scheduling.timezone")).toBe("America/Los_Angeles");
+    });
+  });
+
+  describe("POLICY_DEFAULTS export contains all keys", () => {
+    const expectedKeys = [
+      "membership.newbieDays",
+      "membership.extendedDays",
+      "membership.gracePeriodDays",
+      "membership.renewalReminderDays",
+      "scheduling.timezone",
+      "scheduling.registrationOpenDay",
+      "scheduling.registrationOpenHour",
+      "scheduling.eventArchiveDays",
+      "scheduling.announcementDay",
+      "scheduling.announcementHour",
+      "governance.minutesReviewDays",
+      "governance.boardEligibilityDays",
+      "governance.quorumPercentage",
+      "kpi.membershipWarningThreshold",
+      "kpi.membershipDangerThreshold",
+      "kpi.eventAttendanceWarningPercent",
+      "kpi.eventAttendanceDangerPercent",
+      "display.organizationName",
+      "display.memberTermSingular",
+      "display.memberTermPlural",
+    ];
+
+    it("has all expected policy keys", () => {
+      for (const key of expectedKeys) {
+        expect(POLICY_DEFAULTS).toHaveProperty(key);
+      }
+    });
+
+    it("has exactly the expected number of keys", () => {
+      expect(Object.keys(POLICY_DEFAULTS)).toHaveLength(expectedKeys.length);
+    });
+  });
+});
+
+// ============================================================================
+// C) ORGID IS REQUIRED
+// ============================================================================
+
+describe("Policy Contract: orgId Required", () => {
+  /**
+   * Contract: orgId MUST be provided to getPolicy/getPolicies/getAllPolicies
+   *
+   * Even though we currently ignore orgId (returning defaults), the API
+   * requires it for forward compatibility with multi-tenant lookup.
+   */
+  describe("getPolicy requires orgId", () => {
+    it("throws MissingOrgIdError when orgId is undefined", () => {
+      expect(() => {
+        // @ts-expect-error - Testing runtime validation
+        getPolicy("membership.newbieDays", {});
+      }).toThrow(MissingOrgIdError);
+    });
+
+    it("throws MissingOrgIdError when options is undefined", () => {
+      expect(() => {
+        // @ts-expect-error - Testing runtime validation
+        getPolicy("membership.newbieDays", undefined);
+      }).toThrow(MissingOrgIdError);
+    });
+
+    it("throws MissingOrgIdError when orgId is empty string", () => {
+      expect(() => {
+        getPolicy("membership.newbieDays", { orgId: "" });
+      }).toThrow(MissingOrgIdError);
+    });
+
+    it("succeeds when orgId is provided", () => {
+      expect(() => {
+        getPolicy("membership.newbieDays", { orgId: "org_123" });
+      }).not.toThrow();
+    });
+  });
+
+  describe("getPolicies requires orgId", () => {
+    it("throws MissingOrgIdError when orgId is missing", () => {
+      expect(() => {
+        // @ts-expect-error - Testing runtime validation
+        getPolicies(["membership.newbieDays"], {});
+      }).toThrow(MissingOrgIdError);
+    });
+  });
+
+  describe("getAllPolicies requires orgId", () => {
+    it("throws MissingOrgIdError when orgId is missing", () => {
+      expect(() => {
+        // @ts-expect-error - Testing runtime validation
+        getAllPolicies({});
+      }).toThrow(MissingOrgIdError);
+    });
+
+    it("returns all policies when orgId is provided", () => {
+      const policies = getAllPolicies({ orgId: "org_123" });
+      expect(policies["membership.newbieDays"]).toBe(90);
+      expect(policies["scheduling.timezone"]).toBe("America/Los_Angeles");
+    });
+  });
+});
+
+// ============================================================================
+// D) BATCH OPERATIONS
+// ============================================================================
+
+describe("Policy Contract: Batch Operations", () => {
+  const TEST_ORG = { orgId: "org_test" };
+
+  describe("getPolicies returns multiple values", () => {
+    it("returns correct values for multiple keys", () => {
+      const result = getPolicies(
+        ["membership.newbieDays", "membership.extendedDays"],
+        TEST_ORG
+      );
+
+      expect(result["membership.newbieDays"]).toBe(90);
+      expect(result["membership.extendedDays"]).toBe(730);
+    });
+
+    it("returns empty object for empty keys array", () => {
+      const result = getPolicies([], TEST_ORG);
+      expect(result).toEqual({});
+    });
+
+    it("throws for invalid key in batch", () => {
+      expect(() => {
+        // @ts-expect-error - Testing runtime validation
+        getPolicies(["membership.newbieDays", "invalid.key"], TEST_ORG);
+      }).toThrow(InvalidPolicyKeyError);
+    });
+  });
+
+  describe("getAllPolicies returns complete map", () => {
+    it("returns all policy values", () => {
+      const result = getAllPolicies(TEST_ORG);
+
+      // Spot check various categories
+      expect(result["membership.newbieDays"]).toBe(90);
+      expect(result["scheduling.timezone"]).toBe("America/Los_Angeles");
+      expect(result["governance.quorumPercentage"]).toBe(50);
+      expect(result["display.organizationName"]).toBe("Organization");
+    });
+  });
+});
+
+// ============================================================================
+// E) TYPE SAFETY (COMPILE-TIME CONTRACTS)
+// ============================================================================
+
+describe("Policy Contract: Type Safety", () => {
+  /**
+   * These tests verify that the type system correctly constrains values.
+   * The actual type checking happens at compile time, but we can verify
+   * the runtime behavior matches expectations.
+   */
+  const TEST_ORG = { orgId: "org_test" };
+
+  describe("Number policies return numbers", () => {
+    it("membership.newbieDays is a number", () => {
+      const value = getPolicy("membership.newbieDays", TEST_ORG);
+      expect(typeof value).toBe("number");
+    });
+
+    it("governance.quorumPercentage is a number", () => {
+      const value = getPolicy("governance.quorumPercentage", TEST_ORG);
+      expect(typeof value).toBe("number");
+    });
+  });
+
+  describe("String policies return strings", () => {
+    it("scheduling.timezone is a string", () => {
+      const value = getPolicy("scheduling.timezone", TEST_ORG);
+      expect(typeof value).toBe("string");
+    });
+
+    it("display.organizationName is a string", () => {
+      const value = getPolicy("display.organizationName", TEST_ORG);
+      expect(typeof value).toBe("string");
+    });
+  });
+});

--- a/tests/unit/policies/lifecycleThresholds.spec.ts
+++ b/tests/unit/policies/lifecycleThresholds.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * Lifecycle Thresholds Policy Integration Tests
+ *
+ * Proves that membership lifecycle thresholds come from the policy layer.
+ * This is a key invariant for platform vs policy separation.
+ *
+ * See: Issue #235 (Membership Lifecycle Thresholds Migration)
+ * See: Issue #263 (Policy Configuration Layer)
+ */
+
+import { describe, it, expect } from "vitest";
+import { getPolicyDefault, POLICY_DEFAULTS } from "@/lib/policy/getPolicy";
+import { inferLifecycleState, explainMemberLifecycle } from "@/lib/membership/lifecycle";
+
+describe("lifecycle thresholds from policy layer", () => {
+  describe("policy values", () => {
+    it("membership.newbieDays returns 90 (SBNC default)", () => {
+      const value = getPolicyDefault("membership.newbieDays");
+      expect(value).toBe(90);
+    });
+
+    it("membership.extendedDays returns 730 (SBNC default)", () => {
+      const value = getPolicyDefault("membership.extendedDays");
+      expect(value).toBe(730);
+    });
+
+    it("policy defaults include lifecycle thresholds", () => {
+      expect(POLICY_DEFAULTS).toHaveProperty("membership.newbieDays", 90);
+      expect(POLICY_DEFAULTS).toHaveProperty("membership.extendedDays", 730);
+    });
+  });
+
+  describe("lifecycle uses policy values", () => {
+    const baseInput = {
+      membershipStatusCode: "active",
+      membershipTierCode: "newbie_member",
+      waMembershipLevelRaw: null,
+    };
+
+    it("newbie period uses policy threshold (90 days)", () => {
+      const newbieDays = getPolicyDefault("membership.newbieDays");
+
+      // Day 89: still a newbie
+      const day89 = new Date();
+      day89.setDate(day89.getDate() - (newbieDays - 1));
+      const stateAt89 = inferLifecycleState({
+        ...baseInput,
+        joinedAt: day89,
+      });
+      expect(stateAt89).toBe("active_newbie");
+
+      // Day 90: no longer a newbie (transitions to active_member)
+      const day90 = new Date();
+      day90.setDate(day90.getDate() - newbieDays);
+      const stateAt90 = inferLifecycleState({
+        ...baseInput,
+        joinedAt: day90,
+      });
+      expect(stateAt90).toBe("active_member");
+    });
+
+    it("extended period uses policy threshold (730 days)", () => {
+      const extendedDays = getPolicyDefault("membership.extendedDays");
+
+      // Day 729: still a regular member
+      const day729 = new Date();
+      day729.setDate(day729.getDate() - (extendedDays - 1));
+      const stateAt729 = inferLifecycleState({
+        ...baseInput,
+        membershipTierCode: "member",
+        joinedAt: day729,
+      });
+      expect(stateAt729).toBe("active_member");
+
+      // Day 730: extended offer pending
+      const day730 = new Date();
+      day730.setDate(day730.getDate() - extendedDays);
+      const stateAt730 = inferLifecycleState({
+        ...baseInput,
+        membershipTierCode: "member",
+        joinedAt: day730,
+      });
+      expect(stateAt730).toBe("offer_extended");
+    });
+
+    it("explainMemberLifecycle milestones use policy values", () => {
+      const newbieDays = getPolicyDefault("membership.newbieDays");
+      const extendedDays = getPolicyDefault("membership.extendedDays");
+
+      const today = new Date();
+      const explanation = explainMemberLifecycle({
+        ...baseInput,
+        joinedAt: today,
+      });
+
+      // Verify milestones are calculated from today + policy threshold
+      const expectedNewbieEnd = new Date(today);
+      expectedNewbieEnd.setDate(expectedNewbieEnd.getDate() + newbieDays);
+
+      const expectedTwoYear = new Date(today);
+      expectedTwoYear.setDate(expectedTwoYear.getDate() + extendedDays);
+
+      // Compare dates (ignoring time component)
+      expect(explanation.milestones.newbieEndDate.toDateString()).toBe(
+        expectedNewbieEnd.toDateString()
+      );
+      expect(explanation.milestones.twoYearMark.toDateString()).toBe(
+        expectedTwoYear.toDateString()
+      );
+    });
+  });
+
+  describe("future policy customization", () => {
+    it("documents that thresholds are configurable per-org in future", () => {
+      // This test documents the intended future behavior.
+      // When Issue #263 is complete, organizations will be able to
+      // configure their own threshold values via getPolicy().
+      //
+      // For now, getPolicyDefault() returns SBNC defaults.
+      // The lifecycle module is already wired to the policy layer,
+      // so changing getPolicy() implementation will automatically
+      // update lifecycle behavior.
+
+      expect(getPolicyDefault("membership.newbieDays")).toBe(90);
+      expect(getPolicyDefault("membership.extendedDays")).toBe(730);
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,11 @@ export default defineConfig({
   },
   test: {
     environment: "node",
-    include: ["tests/unit/**/*.spec.ts", "tests/contracts/lifecycle.contract.spec.ts"],
+    include: [
+      "tests/unit/**/*.spec.ts",
+      "tests/contracts/lifecycle.contract.spec.ts",
+      "tests/contracts/policy.contract.spec.ts",
+    ],
     env: {
       // Set dummy DATABASE_URL for unit tests that import modules with Prisma
       DATABASE_URL: "postgresql://dummy:dummy@localhost:5432/dummy_test",


### PR DESCRIPTION
## Summary

- Implements the Policy Access Contract (Issue #263)
- Adds type-safe `getPolicy()` function with SBNC defaults as Tenant Zero values
- Includes 39 contract tests proving key validation, default resolution, and orgId requirements
- Integrates lifecycle module with policy layer for threshold values

## Changes

| File | Purpose |
|------|---------|
| `src/lib/policy/types.ts` | PolicyKey union types (membership, scheduling, governance, KPI, display) |
| `src/lib/policy/getPolicy.ts` | Main API: getPolicy(), getPolicies(), getAllPolicies(), getPolicyDefault() |
| `src/lib/policy/index.ts` | Barrel exports |
| `tests/contracts/policy.contract.spec.ts` | Contract tests (39 passing) |
| `tests/unit/policies/lifecycleThresholds.spec.ts` | Integration tests for lifecycle module |
| `vitest.config.ts` | Include policy contract tests |
| `src/lib/membership/lifecycle.ts` | Use policy layer for thresholds |

## Contract Tests Prove

1. **Unknown keys throw** - `InvalidPolicyKeyError` for invalid policy keys
2. **Defaults resolve** - SBNC values (90-day newbie, 730-day extended, etc.)
3. **orgId required** - `MissingOrgIdError` when orgId is missing

## Test Plan

- [x] `npm run green` passes (1453 tests)
- [x] Contract tests validate all invariants
- [x] Lifecycle module correctly uses policy thresholds

## Related

- Closes partial work on #263 (Policy Configuration Layer)
- See: `docs/ARCH/PLATFORM_VS_POLICY.md` for design context

🤖 Generated with [Claude Code](https://claude.com/claude-code)