### PR TITLE
refactor: migrate ROLE_CAPABILITIES to policy-backed lookup (#262)

### DIFF
--- a/src/lib/policies/index.ts
+++ b/src/lib/policies/index.ts
@@ -6,3 +6,4 @@
 
 export * from "./loader";
 export * from "./enforcement";
+export * from "./roleCapabilities";

--- a/src/lib/policies/roleCapabilities.ts
+++ b/src/lib/policies/roleCapabilities.ts
@@ -1,0 +1,224 @@
+/**
+ * Role Capabilities Policy Layer
+ *
+ * This module provides policy-backed lookup for role capabilities,
+ * enabling future tenant customization while maintaining behavioral
+ * compatibility with the static ROLE_CAPABILITIES map.
+ *
+ * SBNC Policy Coupling Audit Reference:
+ * - Issue #262, RD-002: ROLE_CAPABILITIES at src/lib/auth.ts:136-319
+ * - This module extracts SBNC-specific role-to-capability mapping
+ *   into a policy layer for future configurability.
+ *
+ * Copyright (c) Santa Barbara Newcomers Club
+ */
+
+import type { GlobalRole, Capability } from "@/lib/auth";
+
+/**
+ * Result of a policy-backed capability lookup.
+ */
+export interface RoleCapabilityPolicyResult {
+  /** The role that was looked up */
+  role: GlobalRole;
+  /** The capabilities granted to this role */
+  capabilities: readonly Capability[];
+  /** Source of the capability configuration */
+  source: "default" | "tenant_override";
+}
+
+/**
+ * SBNC default role capabilities.
+ *
+ * This is the baseline configuration extracted from the original
+ * ROLE_CAPABILITIES constant. It represents SBNC-specific role
+ * definitions that could be customized per-tenant in the future.
+ *
+ * IMPORTANT: This map must be kept in sync with auth.ts ROLE_CAPABILITIES
+ * until direct usage is fully deprecated.
+ */
+const SBNC_DEFAULT_ROLE_CAPABILITIES: Record<GlobalRole, readonly Capability[]> = {
+  admin: [
+    "admin:full",
+    "publishing:manage",
+    "comms:manage",
+    "comms:send",
+    "members:view",
+    "members:history",
+    "registrations:view",
+    "events:view",
+    "events:edit",
+    "events:delete",
+    "events:approve",
+    "events:submit",
+    "events:schedule:view",
+    "events:enews:edit",
+    "exports:access",
+    "finance:view",
+    "finance:manage",
+    "transitions:view",
+    "transitions:approve",
+    "users:manage",
+    "roles:assign",
+    "roles:view",
+    "files:upload",
+    "files:manage",
+    "files:view_all",
+  ],
+  president: [
+    "members:view",
+    "members:history",
+    "registrations:view",
+    "events:view",
+    "events:edit",
+    "exports:access",
+    "finance:view",
+    "transitions:view",
+    "transitions:approve",
+    "roles:assign",
+    "roles:view",
+    "governance:flags:read",
+    "governance:flags:resolve",
+    "governance:annotations:read",
+  ],
+  "past-president": [
+    "members:view",
+    "members:history",
+    "registrations:view",
+    "events:view",
+    "transitions:view",
+  ],
+  "vp-activities": [
+    "members:view",
+    "members:history",
+    "registrations:view",
+    "events:view",
+    "events:edit",
+    "events:approve",
+    "events:submit",
+    "events:schedule:view",
+    "transitions:view",
+    "transitions:approve",
+    "roles:assign",
+    "roles:view",
+  ],
+  "vp-communications": [
+    "events:view",
+    "events:schedule:view",
+    "events:enews:edit",
+    "comms:manage",
+    "comms:send",
+    "roles:assign",
+    "roles:view",
+  ],
+  "event-chair": [
+    "members:view",
+    "registrations:view",
+    "events:view",
+    "events:submit",
+  ],
+  webmaster: [
+    "publishing:manage",
+    "comms:manage",
+  ],
+  secretary: [
+    "meetings:read",
+    "meetings:minutes:draft:create",
+    "meetings:minutes:draft:edit",
+    "meetings:minutes:draft:submit",
+    "meetings:minutes:read_all",
+    "governance:docs:read",
+    "governance:annotations:read",
+    "governance:annotations:write",
+    "governance:flags:read",
+    "governance:flags:write",
+    "governance:flags:create",
+    "files:upload",
+  ],
+  parliamentarian: [
+    "meetings:read",
+    "meetings:motions:read",
+    "meetings:motions:annotate",
+    "governance:rules:manage",
+    "governance:flags:read",
+    "governance:flags:write",
+    "governance:flags:create",
+    "governance:flags:resolve",
+    "governance:annotations:read",
+    "governance:annotations:write",
+    "governance:annotations:publish",
+    "governance:interpretations:create",
+    "governance:interpretations:edit",
+    "governance:interpretations:publish",
+    "governance:policies:annotate",
+    "governance:policies:propose_change",
+    "governance:docs:read",
+    "governance:docs:write",
+    "files:upload",
+  ],
+  member: [],
+} as const;
+
+/**
+ * Get role capabilities from policy.
+ *
+ * This function provides an indirection layer for capability lookups,
+ * enabling future tenant-specific customization. Currently returns
+ * SBNC defaults, but the interface supports policy overrides.
+ *
+ * @param role - The GlobalRole to look up capabilities for
+ * @returns Policy result with capabilities and source
+ */
+export function getRoleCapabilitiesFromPolicy(
+  role: GlobalRole
+): RoleCapabilityPolicyResult {
+  // Future: Look up tenant-specific policy overrides here
+  // const tenantOverride = await getTenantPolicyOverride(tenantId, role);
+  // if (tenantOverride) return { role, capabilities: tenantOverride, source: "tenant_override" };
+
+  const capabilities = SBNC_DEFAULT_ROLE_CAPABILITIES[role];
+  return {
+    role,
+    capabilities,
+    source: "default",
+  };
+}
+
+/**
+ * Validate that a role capability policy matches expected defaults.
+ *
+ * This is used in contract tests to ensure the policy layer
+ * maintains behavioral compatibility with the original ROLE_CAPABILITIES.
+ *
+ * @param role - The role to validate
+ * @param expectedCapabilities - Expected capabilities from auth.ts
+ * @returns true if capabilities match, false otherwise
+ */
+export function validateRoleCapabilityPolicy(
+  role: GlobalRole,
+  expectedCapabilities: readonly Capability[]
+): boolean {
+  const policyResult = getRoleCapabilitiesFromPolicy(role);
+  const policySet = new Set(policyResult.capabilities);
+  const expectedSet = new Set(expectedCapabilities);
+
+  if (policySet.size !== expectedSet.size) {
+    return false;
+  }
+
+  for (const cap of expectedSet) {
+    if (!policySet.has(cap)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Get the default SBNC role capabilities.
+ * Exposed for testing and validation purposes only.
+ */
+export function getSBNCDefaultCapabilities(): Record<GlobalRole, readonly Capability[]> {
+  return SBNC_DEFAULT_ROLE_CAPABILITIES;
+}

--- a/tests/unit/role-capabilities-policy.spec.ts
+++ b/tests/unit/role-capabilities-policy.spec.ts
@@ -1,0 +1,304 @@
+/**
+ * Role Capabilities Policy Indirection Contract Tests
+ *
+ * Charter Principles:
+ * - P2: Default deny, least privilege, object scope
+ * - P4: No hidden rules (behavior explainable in plain English)
+ *
+ * SBNC Policy Coupling Audit Reference:
+ * - Issue #262, RD-002: Role capabilities policy indirection
+ *
+ * Tests the policy indirection invariants:
+ * 1. Policy lookup returns identical capabilities to original ROLE_CAPABILITIES
+ * 2. All GlobalRoles are covered by the policy layer
+ * 3. Webmaster debug mode is preserved through policy layer
+ * 4. Impersonation-blocked capabilities remain invariant
+ *
+ * These tests are deterministic and ensure behavioral compatibility
+ * when migrating from direct ROLE_CAPABILITIES access to policy-backed lookup.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  getRoleCapabilitiesFromPolicy,
+  validateRoleCapabilityPolicy,
+  getSBNCDefaultCapabilities,
+} from "@/lib/policies/roleCapabilities";
+import {
+  getRoleCapabilities,
+  GlobalRole,
+  BLOCKED_WHILE_IMPERSONATING,
+} from "@/lib/auth";
+
+// ============================================================================
+// A) POLICY LAYER BEHAVIORAL COMPATIBILITY
+// ============================================================================
+
+describe("Role Capabilities Policy Contract: Behavioral Compatibility", () => {
+  const ALL_ROLES: GlobalRole[] = [
+    "admin",
+    "president",
+    "past-president",
+    "vp-activities",
+    "vp-communications",
+    "event-chair",
+    "webmaster",
+    "secretary",
+    "parliamentarian",
+    "member",
+  ];
+
+  describe("policy lookup returns capabilities for all roles", () => {
+    for (const role of ALL_ROLES) {
+      it(`getRoleCapabilitiesFromPolicy returns result for ${role}`, () => {
+        const result = getRoleCapabilitiesFromPolicy(role);
+
+        expect(result).toHaveProperty("role", role);
+        expect(result).toHaveProperty("capabilities");
+        expect(result).toHaveProperty("source");
+        expect(Array.isArray(result.capabilities)).toBe(true);
+      });
+    }
+  });
+
+  describe("policy returns 'default' source for all roles", () => {
+    for (const role of ALL_ROLES) {
+      it(`${role} returns source: 'default'`, () => {
+        const result = getRoleCapabilitiesFromPolicy(role);
+        expect(result.source).toBe("default");
+      });
+    }
+  });
+
+  describe("policy capabilities match auth.ts behavior", () => {
+    for (const role of ALL_ROLES) {
+      it(`${role} policy capabilities produce identical hasCapability results`, () => {
+        const policyResult = getRoleCapabilitiesFromPolicy(role);
+        const authCapabilities = getRoleCapabilities(role);
+
+        // Compare capability sets
+        const policySet = new Set(policyResult.capabilities);
+        const authSet = new Set(authCapabilities);
+
+        // Policy should return the base capabilities
+        // Auth may add debug capabilities for webmaster
+        for (const cap of policyResult.capabilities) {
+          expect(authSet.has(cap)).toBe(true);
+        }
+      });
+    }
+  });
+});
+
+// ============================================================================
+// B) VALIDATION HELPER CONTRACT
+// ============================================================================
+
+describe("Role Capabilities Policy Contract: Validation Helper", () => {
+  it("validateRoleCapabilityPolicy returns true for matching capabilities", () => {
+    const adminCaps = getRoleCapabilitiesFromPolicy("admin").capabilities;
+    const isValid = validateRoleCapabilityPolicy("admin", adminCaps);
+    expect(isValid).toBe(true);
+  });
+
+  it("validateRoleCapabilityPolicy returns false for mismatched capabilities", () => {
+    // Provide wrong capabilities for admin
+    const isValid = validateRoleCapabilityPolicy("admin", []);
+    expect(isValid).toBe(false);
+  });
+
+  it("validateRoleCapabilityPolicy returns false for partial capabilities", () => {
+    const adminCaps = getRoleCapabilitiesFromPolicy("admin").capabilities;
+    // Remove one capability
+    const partialCaps = adminCaps.slice(1);
+    const isValid = validateRoleCapabilityPolicy("admin", partialCaps);
+    expect(isValid).toBe(false);
+  });
+});
+
+// ============================================================================
+// C) SBNC DEFAULT CAPABILITIES COVERAGE
+// ============================================================================
+
+describe("Role Capabilities Policy Contract: SBNC Default Coverage", () => {
+  const ALL_ROLES: GlobalRole[] = [
+    "admin",
+    "president",
+    "past-president",
+    "vp-activities",
+    "vp-communications",
+    "event-chair",
+    "webmaster",
+    "secretary",
+    "parliamentarian",
+    "member",
+  ];
+
+  it("getSBNCDefaultCapabilities returns capabilities for all roles", () => {
+    const defaults = getSBNCDefaultCapabilities();
+
+    for (const role of ALL_ROLES) {
+      expect(defaults).toHaveProperty(role);
+      expect(Array.isArray(defaults[role])).toBe(true);
+    }
+  });
+
+  it("admin has admin:full capability", () => {
+    const defaults = getSBNCDefaultCapabilities();
+    expect(defaults.admin).toContain("admin:full");
+  });
+
+  it("member has empty capabilities", () => {
+    const defaults = getSBNCDefaultCapabilities();
+    expect(defaults.member).toHaveLength(0);
+  });
+
+  it("webmaster has publishing:manage but not admin:full", () => {
+    const defaults = getSBNCDefaultCapabilities();
+    expect(defaults.webmaster).toContain("publishing:manage");
+    expect(defaults.webmaster).not.toContain("admin:full");
+  });
+});
+
+// ============================================================================
+// D) IMPERSONATION SAFETY INVARIANT
+// ============================================================================
+
+describe("Role Capabilities Policy Contract: Impersonation Safety", () => {
+  /**
+   * These capabilities MUST remain blocked during impersonation.
+   * This invariant must hold regardless of policy layer changes.
+   */
+  const EXPECTED_BLOCKED_CAPABILITIES = [
+    "finance:manage",
+    "comms:send",
+    "users:manage",
+    "events:delete",
+    "admin:full",
+  ];
+
+  it("BLOCKED_WHILE_IMPERSONATING contains all expected blocked capabilities", () => {
+    for (const cap of EXPECTED_BLOCKED_CAPABILITIES) {
+      expect(BLOCKED_WHILE_IMPERSONATING).toContain(cap);
+    }
+  });
+
+  it("BLOCKED_WHILE_IMPERSONATING has exactly 5 items", () => {
+    expect(BLOCKED_WHILE_IMPERSONATING).toHaveLength(5);
+  });
+
+  it("policy layer does not affect blocked capabilities", () => {
+    // Verify that using policy lookup doesn't change what's blocked
+    const adminCaps = getRoleCapabilitiesFromPolicy("admin").capabilities;
+
+    for (const blockedCap of EXPECTED_BLOCKED_CAPABILITIES) {
+      // Admin should have these capabilities from policy
+      if (blockedCap !== "comms:send" || adminCaps.includes("comms:send")) {
+        expect(adminCaps).toContain(blockedCap);
+      }
+    }
+
+    // But they should still be in the blocked list
+    expect(BLOCKED_WHILE_IMPERSONATING).toEqual(
+      expect.arrayContaining(EXPECTED_BLOCKED_CAPABILITIES)
+    );
+  });
+});
+
+// ============================================================================
+// E) WEBMASTER DEBUG MODE PRESERVATION
+// ============================================================================
+
+describe("Role Capabilities Policy Contract: Webmaster Debug Mode", () => {
+  const originalEnv = process.env.WEBMASTER_DEBUG_READONLY;
+
+  afterEach(() => {
+    // Restore original env
+    if (originalEnv === undefined) {
+      delete process.env.WEBMASTER_DEBUG_READONLY;
+    } else {
+      process.env.WEBMASTER_DEBUG_READONLY = originalEnv;
+    }
+  });
+
+  it("webmaster base policy does not include debug capabilities", () => {
+    const policyCaps = getRoleCapabilitiesFromPolicy("webmaster").capabilities;
+
+    // Policy layer should NOT include debug-mode capabilities
+    expect(policyCaps).not.toContain("members:view");
+    expect(policyCaps).not.toContain("registrations:view");
+    expect(policyCaps).not.toContain("events:view");
+    expect(policyCaps).not.toContain("debug:readonly");
+  });
+
+  it("auth layer adds debug capabilities when WEBMASTER_DEBUG_READONLY=true", () => {
+    process.env.WEBMASTER_DEBUG_READONLY = "true";
+
+    // getRoleCapabilities goes through the auth layer which adds debug caps
+    const authCaps = getRoleCapabilities("webmaster");
+
+    expect(authCaps).toContain("members:view");
+    expect(authCaps).toContain("registrations:view");
+    expect(authCaps).toContain("events:view");
+    expect(authCaps).toContain("debug:readonly");
+  });
+
+  it("auth layer preserves base capabilities when debug mode enabled", () => {
+    process.env.WEBMASTER_DEBUG_READONLY = "true";
+
+    const authCaps = getRoleCapabilities("webmaster");
+
+    // Should still have base webmaster capabilities
+    expect(authCaps).toContain("publishing:manage");
+    expect(authCaps).toContain("comms:manage");
+  });
+});
+
+// ============================================================================
+// F) CRITICAL CAPABILITY INVARIANTS
+// ============================================================================
+
+describe("Role Capabilities Policy Contract: Critical Invariants", () => {
+  it("only admin has admin:full capability", () => {
+    const ALL_ROLES: GlobalRole[] = [
+      "admin",
+      "president",
+      "past-president",
+      "vp-activities",
+      "vp-communications",
+      "event-chair",
+      "webmaster",
+      "secretary",
+      "parliamentarian",
+      "member",
+    ];
+
+    for (const role of ALL_ROLES) {
+      const caps = getRoleCapabilitiesFromPolicy(role).capabilities;
+      if (role === "admin") {
+        expect(caps).toContain("admin:full");
+      } else {
+        expect(caps).not.toContain("admin:full");
+      }
+    }
+  });
+
+  it("only admin has events:delete capability", () => {
+    const defaults = getSBNCDefaultCapabilities();
+
+    expect(defaults.admin).toContain("events:delete");
+    expect(defaults.president).not.toContain("events:delete");
+    expect(defaults["vp-activities"]).not.toContain("events:delete");
+  });
+
+  it("webmaster cannot manage users", () => {
+    const caps = getRoleCapabilitiesFromPolicy("webmaster").capabilities;
+    expect(caps).not.toContain("users:manage");
+  });
+
+  it("webmaster cannot view finance", () => {
+    const caps = getRoleCapabilitiesFromPolicy("webmaster").capabilities;
+    expect(caps).not.toContain("finance:view");
+    expect(caps).not.toContain("finance:manage");
+  });
+});


### PR DESCRIPTION
## Summary

Migrate ROLE_CAPABILITIES to policy-backed lookup (#262).

- Add policy indirection layer for role capabilities lookup
- Enable future tenant-specific customization while maintaining behavioral compatibility
- Add 47 contract tests validating policy invariants

## Changes

1. **New policy layer** (`src/lib/policies/roleCapabilities.ts`)
   - `getRoleCapabilitiesFromPolicy()` - policy-backed capability lookup
   - `validateRoleCapabilityPolicy()` - contract validation helper
   - `getSBNCDefaultCapabilities()` - exposes defaults for testing

2. **Auth integration** (`src/lib/auth.ts`)
   - Updated `getEffectiveCapabilities()` to use policy layer
   - Added deprecation notice to direct `ROLE_CAPABILITIES` access
   - Preserved webmaster debug mode runtime override

3. **Contract tests** (`tests/unit/role-capabilities-policy.spec.ts`)
   - Behavioral compatibility with auth.ts
   - Validation helper contract
   - SBNC default coverage

## Release classification

- [x] experimental

## Risk level

- [x] Medium - refactors auth capability lookup

## Invariants

- [x] No behavior changes - policy layer returns same values as hardcoded constants
- [x] Webmaster debug mode preserved
- [x] Impersonation safety maintained

## Test plan

- [x] 47 contract tests validating policy invariants
- [x] `npm run green` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)