### PR TITLE
feat(migration): add CLI entry point for WA migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
     "green:flaky": "playwright test --grep @flaky --workers=1",
     "test:flaky-backlog": "npx tsx scripts/ci/check-flaky-backlog.ts",
     "explain:green": "node -e \"console.log('\\n=== npm run green ===\\n\\nFast, deterministic gate (~30-60s):\\n  1. typecheck  - TypeScript compilation\\n  2. lint       - ESLint checks\\n  3. guardrails - Auth/impersonation safety\\n  4. test:unit  - Vitest unit tests (including contracts)\\n\\nDoes NOT run (use green:e2e or green:full):\\n  - Playwright browser tests (slow, need db:seed)\\n  - Database seeding\\n\\nDocs: docs/CI/GREEN_GATE.md\\n')\"",
-    "reviewer:quickcheck": "echo '\n=== Reviewer Quickcheck ===\n\nWhat to verify in the PR:\n  1. Risk level selected (Low/Medium/High)\n  2. For Medium/High: Invariants section completed\n  3. For Medium/High: Proof of safety section completed\n  4. Hotspot plan if hotspots touched\n\nKey docs:\n  - docs/CI/REVIEWER_QUICKSTART.md (2-min guide)\n  - docs/CI/SAFETY_NET.md (defense layers)\n  - docs/CI/PR_REVIEW_CHECKLIST.md (full checklist)\n  - docs/CI/INVARIANTS.md (security invariants)\n\nCommands to run:\n  npm run green           # Full verification\n  npm run test:guardrails # Security checks only\n  npm run test-contracts  # Contract tests only\n  npm run typecheck       # Type check only\n'"
+    "reviewer:quickcheck": "echo '\n=== Reviewer Quickcheck ===\n\nWhat to verify in the PR:\n  1. Risk level selected (Low/Medium/High)\n  2. For Medium/High: Invariants section completed\n  3. For Medium/High: Proof of safety section completed\n  4. Hotspot plan if hotspots touched\n\nKey docs:\n  - docs/CI/REVIEWER_QUICKSTART.md (2-min guide)\n  - docs/CI/SAFETY_NET.md (defense layers)\n  - docs/CI/PR_REVIEW_CHECKLIST.md (full checklist)\n  - docs/CI/INVARIANTS.md (security invariants)\n\nCommands to run:\n  npm run green           # Full verification\n  npm run test:guardrails # Security checks only\n  npm run test-contracts  # Contract tests only\n  npm run typecheck       # Type check only\n'",
+    "migrate:dry-run": "npx tsx scripts/migration/migrate.ts --verbose",
+    "migrate:live": "npx tsx scripts/migration/migrate.ts --live --verbose",
+    "migrate:reset": "npx tsx scripts/migration/reset-sandbox.ts"
   },
   "prisma": {
     "seed": "npx tsx prisma/seed.ts"

--- a/scripts/migration/migrate.ts
+++ b/scripts/migration/migrate.ts
@@ -1,0 +1,496 @@
+#!/usr/bin/env npx tsx
+/**
+ * ClubOS Migration CLI Entry Point
+ *
+ * Invokes the migration engine to import data from Wild Apricot to ClubOS.
+ *
+ * Usage:
+ *   npx tsx scripts/migration/migrate.ts [options]
+ *
+ * Options:
+ *   --source-org <name>     Source organization identifier (default: "wild-apricot")
+ *   --target-org <name>     Target organization identifier (default: "clubos")
+ *   --dry-run               Run without making changes (default: true)
+ *   --live                  Run with actual database writes (sets dry-run=false)
+ *   --output-report <path>  Output directory for reports (default: scripts/migration/reports)
+ *   --verbose               Enable verbose logging
+ *   --config <path>         Path to migration config YAML
+ *   --data-dir <path>       Directory containing CSV export files
+ *   --members <file>        Members CSV filename (relative to data-dir)
+ *   --events <file>         Events CSV filename (relative to data-dir)
+ *   --registrations <file>  Registrations CSV filename (relative to data-dir)
+ *   --yes                   Skip confirmation prompt for live runs
+ *   --help                  Show this help message
+ *
+ * Examples:
+ *   # Dry run with sample data
+ *   npx tsx scripts/migration/migrate.ts
+ *
+ *   # Dry run with custom data directory
+ *   npx tsx scripts/migration/migrate.ts --data-dir ./wa-export
+ *
+ *   # Live run (requires --yes for confirmation)
+ *   npx tsx scripts/migration/migrate.ts --live --yes --data-dir ./wa-export
+ *
+ * Related: Issue #272 (A7: Migration CLI Entry Point)
+ */
+
+import * as path from "path";
+import * as fs from "fs";
+import * as readline from "readline";
+import { MigrationEngine } from "./lib/migration-engine";
+import { loadConfig, getDefaultConfigPath } from "./lib/config";
+import type { MigrationRunOptions } from "./lib/types";
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const VALID_SOURCES = ["wild-apricot", "wa", "wildapricot"];
+const VALID_TARGETS = ["clubos"];
+const DEFAULT_SOURCE = "wild-apricot";
+const DEFAULT_TARGET = "clubos";
+const DEFAULT_REPORTS_DIR = path.join(__dirname, "reports");
+const DEFAULT_DATA_DIR = path.join(__dirname, "sample-pack");
+const DEFAULT_MEMBERS_FILE = "members/wa-members-export.csv";
+const DEFAULT_EVENTS_FILE = "events/wa-events-export.csv";
+const DEFAULT_REGISTRATIONS_FILE = "events/wa-registrations-export.csv";
+
+// =============================================================================
+// CLI Argument Parsing
+// =============================================================================
+
+export interface CLIArgs {
+  sourceOrg: string;
+  targetOrg: string;
+  dryRun: boolean;
+  outputReport: string;
+  verbose: boolean;
+  configPath: string;
+  dataDir: string;
+  membersFile?: string;
+  eventsFile?: string;
+  registrationsFile?: string;
+  yes: boolean;
+  help: boolean;
+}
+
+export function parseArgs(argv: string[]): CLIArgs {
+  const args: CLIArgs = {
+    sourceOrg: DEFAULT_SOURCE,
+    targetOrg: DEFAULT_TARGET,
+    dryRun: true,
+    outputReport: DEFAULT_REPORTS_DIR,
+    verbose: false,
+    configPath: getDefaultConfigPath(),
+    dataDir: DEFAULT_DATA_DIR,
+    membersFile: undefined,
+    eventsFile: undefined,
+    registrationsFile: undefined,
+    yes: false,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const nextArg = argv[i + 1];
+
+    switch (arg) {
+      case "--source-org":
+        if (!nextArg || nextArg.startsWith("-")) {
+          throw new Error("--source-org requires a value");
+        }
+        args.sourceOrg = nextArg;
+        i++;
+        break;
+
+      case "--target-org":
+        if (!nextArg || nextArg.startsWith("-")) {
+          throw new Error("--target-org requires a value");
+        }
+        args.targetOrg = nextArg;
+        i++;
+        break;
+
+      case "--dry-run":
+        args.dryRun = true;
+        break;
+
+      case "--live":
+        args.dryRun = false;
+        break;
+
+      case "--output-report":
+        if (!nextArg || nextArg.startsWith("-")) {
+          throw new Error("--output-report requires a path");
+        }
+        args.outputReport = nextArg;
+        i++;
+        break;
+
+      case "--verbose":
+      case "-v":
+        args.verbose = true;
+        break;
+
+      case "--config":
+        if (!nextArg || nextArg.startsWith("-")) {
+          throw new Error("--config requires a path");
+        }
+        args.configPath = nextArg;
+        i++;
+        break;
+
+      case "--data-dir":
+        if (!nextArg || nextArg.startsWith("-")) {
+          throw new Error("--data-dir requires a path");
+        }
+        args.dataDir = nextArg;
+        i++;
+        break;
+
+      case "--members":
+        if (!nextArg || nextArg.startsWith("-")) {
+          throw new Error("--members requires a filename");
+        }
+        args.membersFile = nextArg;
+        i++;
+        break;
+
+      case "--events":
+        if (!nextArg || nextArg.startsWith("-")) {
+          throw new Error("--events requires a filename");
+        }
+        args.eventsFile = nextArg;
+        i++;
+        break;
+
+      case "--registrations":
+        if (!nextArg || nextArg.startsWith("-")) {
+          throw new Error("--registrations requires a filename");
+        }
+        args.registrationsFile = nextArg;
+        i++;
+        break;
+
+      case "--yes":
+      case "-y":
+        args.yes = true;
+        break;
+
+      case "--help":
+      case "-h":
+        args.help = true;
+        break;
+
+      default:
+        if (arg.startsWith("-")) {
+          throw new Error(`Unknown option: ${arg}`);
+        }
+    }
+  }
+
+  return args;
+}
+
+// =============================================================================
+// Validation
+// =============================================================================
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+export function validateArgs(args: CLIArgs): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // Validate source org
+  const normalizedSource = args.sourceOrg.toLowerCase().replace(/[^a-z]/g, "");
+  if (!VALID_SOURCES.some((s) => s.replace(/[^a-z]/g, "") === normalizedSource)) {
+    errors.push(
+      `Invalid --source-org: "${args.sourceOrg}". Valid options: ${VALID_SOURCES.join(", ")}`
+    );
+  }
+
+  // Validate target org
+  if (!VALID_TARGETS.includes(args.targetOrg.toLowerCase())) {
+    errors.push(
+      `Invalid --target-org: "${args.targetOrg}". Valid options: ${VALID_TARGETS.join(", ")}`
+    );
+  }
+
+  // Validate config file exists
+  const configPath = path.resolve(args.configPath);
+  if (!fs.existsSync(configPath)) {
+    errors.push(`Config file not found: ${configPath}`);
+  }
+
+  // Validate data directory exists
+  const dataDir = path.resolve(args.dataDir);
+  if (!fs.existsSync(dataDir)) {
+    errors.push(`Data directory not found: ${dataDir}`);
+  }
+
+  // Validate output directory is writable (or can be created)
+  const outputDir = path.resolve(args.outputReport);
+  const outputParent = path.dirname(outputDir);
+  if (!fs.existsSync(outputParent)) {
+    warnings.push(`Output parent directory does not exist: ${outputParent} (will be created)`);
+  }
+
+  // Validate CSV files if specified
+  if (args.membersFile) {
+    const membersPath = path.resolve(args.dataDir, args.membersFile);
+    if (!fs.existsSync(membersPath)) {
+      errors.push(`Members file not found: ${membersPath}`);
+    }
+  }
+
+  if (args.eventsFile) {
+    const eventsPath = path.resolve(args.dataDir, args.eventsFile);
+    if (!fs.existsSync(eventsPath)) {
+      errors.push(`Events file not found: ${eventsPath}`);
+    }
+  }
+
+  if (args.registrationsFile) {
+    const registrationsPath = path.resolve(args.dataDir, args.registrationsFile);
+    if (!fs.existsSync(registrationsPath)) {
+      errors.push(`Registrations file not found: ${registrationsPath}`);
+    }
+  }
+
+  // Check for default sample files if no files specified
+  if (!args.membersFile && !args.eventsFile && !args.registrationsFile) {
+    const defaultMembers = path.resolve(args.dataDir, DEFAULT_MEMBERS_FILE);
+    const defaultEvents = path.resolve(args.dataDir, DEFAULT_EVENTS_FILE);
+    const defaultRegistrations = path.resolve(args.dataDir, DEFAULT_REGISTRATIONS_FILE);
+
+    if (!fs.existsSync(defaultMembers) && !fs.existsSync(defaultEvents)) {
+      warnings.push(
+        `No CSV files specified and default sample files not found. ` +
+          `Use --members, --events, or --registrations to specify files.`
+      );
+    }
+  }
+
+  // Live run without --yes requires confirmation
+  if (!args.dryRun && !args.yes) {
+    warnings.push("Live run requires --yes flag or interactive confirmation");
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  };
+}
+
+// =============================================================================
+// Execution Plan Display
+// =============================================================================
+
+export function printExecutionPlan(args: CLIArgs): void {
+  const divider = "=".repeat(60);
+
+  console.log(`\n${divider}`);
+  console.log("ClubOS Migration - Execution Plan");
+  console.log(divider);
+
+  console.log(`\nMode:        ${args.dryRun ? "DRY RUN (no database changes)" : "LIVE (will modify database)"}`);
+  console.log(`Source:      ${args.sourceOrg}`);
+  console.log(`Target:      ${args.targetOrg}`);
+  console.log(`Config:      ${path.resolve(args.configPath)}`);
+  console.log(`Data Dir:    ${path.resolve(args.dataDir)}`);
+  console.log(`Reports Dir: ${path.resolve(args.outputReport)}`);
+  console.log(`Verbose:     ${args.verbose ? "yes" : "no"}`);
+
+  console.log("\nFiles to process:");
+  const membersFile = args.membersFile || DEFAULT_MEMBERS_FILE;
+  const eventsFile = args.eventsFile || DEFAULT_EVENTS_FILE;
+  const registrationsFile = args.registrationsFile || DEFAULT_REGISTRATIONS_FILE;
+
+  const membersPath = path.resolve(args.dataDir, membersFile);
+  const eventsPath = path.resolve(args.dataDir, eventsFile);
+  const registrationsPath = path.resolve(args.dataDir, registrationsFile);
+
+  console.log(`  Members:       ${fs.existsSync(membersPath) ? membersFile : "(not found)"}`);
+  console.log(`  Events:        ${fs.existsSync(eventsPath) ? eventsFile : "(not found)"}`);
+  console.log(`  Registrations: ${fs.existsSync(registrationsPath) ? registrationsFile : "(not found)"}`);
+
+  console.log(`\n${divider}\n`);
+}
+
+// =============================================================================
+// Help Output
+// =============================================================================
+
+export function printHelp(): void {
+  console.log(`
+ClubOS Migration CLI
+
+Imports data from Wild Apricot to ClubOS.
+
+USAGE
+  npx tsx scripts/migration/migrate.ts [options]
+
+OPTIONS
+  --source-org <name>     Source organization (default: "wild-apricot")
+  --target-org <name>     Target organization (default: "clubos")
+  --dry-run               Run without making changes (default)
+  --live                  Run with actual database writes
+  --output-report <path>  Output directory for reports
+  --verbose, -v           Enable verbose logging
+  --config <path>         Path to migration config YAML
+  --data-dir <path>       Directory containing CSV export files
+  --members <file>        Members CSV filename
+  --events <file>         Events CSV filename
+  --registrations <file>  Registrations CSV filename
+  --yes, -y               Skip confirmation prompt for live runs
+  --help, -h              Show this help message
+
+EXAMPLES
+  # Dry run with sample data
+  npx tsx scripts/migration/migrate.ts
+
+  # Dry run with custom data directory
+  npx tsx scripts/migration/migrate.ts --data-dir ./wa-export
+
+  # Live run (requires --yes)
+  npx tsx scripts/migration/migrate.ts --live --yes --data-dir ./wa-export
+
+  # Verbose dry run
+  npx tsx scripts/migration/migrate.ts --verbose --data-dir ./wa-export
+
+NOTES
+  - Default mode is dry-run (safe to test without changes)
+  - Live runs require --yes flag or interactive confirmation
+  - Reports are written to scripts/migration/reports/ by default
+  - See scripts/migration/README.md for more details
+`);
+}
+
+// =============================================================================
+// Confirmation Prompt
+// =============================================================================
+
+async function confirmLiveRun(): Promise<boolean> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  return new Promise((resolve) => {
+    rl.question(
+      "\n⚠️  You are about to run a LIVE migration that will modify the database.\n" +
+        '   Type "yes" to continue, or anything else to abort: ',
+      (answer) => {
+        rl.close();
+        resolve(answer.toLowerCase() === "yes");
+      }
+    );
+  });
+}
+
+// =============================================================================
+// Main Entry Point
+// =============================================================================
+
+export async function main(argv: string[] = process.argv.slice(2)): Promise<number> {
+  try {
+    // Parse arguments
+    const args = parseArgs(argv);
+
+    // Show help if requested
+    if (args.help) {
+      printHelp();
+      return 0;
+    }
+
+    // Validate arguments
+    const validation = validateArgs(args);
+
+    // Print warnings
+    for (const warning of validation.warnings) {
+      console.warn(`⚠️  Warning: ${warning}`);
+    }
+
+    // Exit on validation errors
+    if (!validation.valid) {
+      console.error("\n❌ Validation errors:");
+      for (const error of validation.errors) {
+        console.error(`   - ${error}`);
+      }
+      console.error("\nRun with --help for usage information.\n");
+      return 1;
+    }
+
+    // Print execution plan
+    printExecutionPlan(args);
+
+    // Confirm live runs
+    if (!args.dryRun && !args.yes) {
+      const confirmed = await confirmLiveRun();
+      if (!confirmed) {
+        console.log("\nMigration aborted.\n");
+        return 1;
+      }
+    }
+
+    // Determine which files to process
+    const membersFile = args.membersFile || DEFAULT_MEMBERS_FILE;
+    const eventsFile = args.eventsFile || DEFAULT_EVENTS_FILE;
+    const registrationsFile = args.registrationsFile || DEFAULT_REGISTRATIONS_FILE;
+
+    const membersPath = path.resolve(args.dataDir, membersFile);
+    const eventsPath = path.resolve(args.dataDir, eventsFile);
+    const registrationsPath = path.resolve(args.dataDir, registrationsFile);
+
+    // Build engine options
+    const engineOptions: MigrationRunOptions = {
+      dryRun: args.dryRun,
+      configPath: args.configPath,
+      dataDir: args.dataDir,
+      membersFile: fs.existsSync(membersPath) ? membersFile : undefined,
+      eventsFile: fs.existsSync(eventsPath) ? eventsFile : undefined,
+      registrationsFile: fs.existsSync(registrationsPath) ? registrationsFile : undefined,
+      outputDir: args.outputReport,
+      verbose: args.verbose,
+    };
+
+    // Check if any files to process
+    if (!engineOptions.membersFile && !engineOptions.eventsFile && !engineOptions.registrationsFile) {
+      console.error("\n❌ No CSV files found to process.");
+      console.error(`   Data directory: ${args.dataDir}`);
+      console.error("   Use --members, --events, or --registrations to specify files.\n");
+      return 1;
+    }
+
+    // Run migration engine exactly once
+    const engine = new MigrationEngine(engineOptions);
+    const report = await engine.run();
+
+    // Exit with error code if there were errors
+    if (report.summary.errors > 0) {
+      console.log(`\n⚠️  Migration completed with ${report.summary.errors} error(s).\n`);
+      return report.summary.errors > 10 ? 2 : 0; // Exit 2 for many errors
+    }
+
+    console.log("\n✅ Migration completed successfully.\n");
+    return 0;
+  } catch (error) {
+    console.error(`\n❌ Fatal error: ${(error as Error).message}\n`);
+    if (process.env.DEBUG) {
+      console.error((error as Error).stack);
+    }
+    return 1;
+  }
+}
+
+// Run if executed directly
+if (require.main === module) {
+  main().then((code) => process.exit(code));
+}

--- a/tests/unit/migration/cli.spec.ts
+++ b/tests/unit/migration/cli.spec.ts
@@ -1,0 +1,373 @@
+/**
+ * Migration CLI Unit Tests
+ *
+ * Tests argument parsing and validation for the migration CLI.
+ *
+ * Related: Issue #272 (A7: Migration CLI Entry Point)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as path from "path";
+import * as fs from "fs";
+import { parseArgs, validateArgs, CLIArgs } from "../../../scripts/migration/migrate";
+
+// =============================================================================
+// parseArgs Tests
+// =============================================================================
+
+describe("parseArgs", () => {
+  describe("default values", () => {
+    it("returns defaults when no arguments provided", () => {
+      const args = parseArgs([]);
+
+      expect(args.sourceOrg).toBe("wild-apricot");
+      expect(args.targetOrg).toBe("clubos");
+      expect(args.dryRun).toBe(true);
+      expect(args.verbose).toBe(false);
+      expect(args.yes).toBe(false);
+      expect(args.help).toBe(false);
+    });
+
+    it("dryRun defaults to true", () => {
+      const args = parseArgs([]);
+      expect(args.dryRun).toBe(true);
+    });
+  });
+
+  describe("--source-org", () => {
+    it("parses --source-org value", () => {
+      const args = parseArgs(["--source-org", "my-source"]);
+      expect(args.sourceOrg).toBe("my-source");
+    });
+
+    it("throws if --source-org has no value", () => {
+      expect(() => parseArgs(["--source-org"])).toThrow("--source-org requires a value");
+    });
+
+    it("throws if --source-org value starts with dash", () => {
+      expect(() => parseArgs(["--source-org", "--other"])).toThrow(
+        "--source-org requires a value"
+      );
+    });
+  });
+
+  describe("--target-org", () => {
+    it("parses --target-org value", () => {
+      const args = parseArgs(["--target-org", "my-target"]);
+      expect(args.targetOrg).toBe("my-target");
+    });
+
+    it("throws if --target-org has no value", () => {
+      expect(() => parseArgs(["--target-org"])).toThrow("--target-org requires a value");
+    });
+  });
+
+  describe("--dry-run and --live", () => {
+    it("--dry-run sets dryRun to true", () => {
+      const args = parseArgs(["--dry-run"]);
+      expect(args.dryRun).toBe(true);
+    });
+
+    it("--live sets dryRun to false", () => {
+      const args = parseArgs(["--live"]);
+      expect(args.dryRun).toBe(false);
+    });
+
+    it("last flag wins: --dry-run after --live", () => {
+      const args = parseArgs(["--live", "--dry-run"]);
+      expect(args.dryRun).toBe(true);
+    });
+
+    it("last flag wins: --live after --dry-run", () => {
+      const args = parseArgs(["--dry-run", "--live"]);
+      expect(args.dryRun).toBe(false);
+    });
+  });
+
+  describe("--output-report", () => {
+    it("parses --output-report path", () => {
+      const args = parseArgs(["--output-report", "/tmp/reports"]);
+      expect(args.outputReport).toBe("/tmp/reports");
+    });
+
+    it("throws if --output-report has no value", () => {
+      expect(() => parseArgs(["--output-report"])).toThrow("--output-report requires a path");
+    });
+  });
+
+  describe("--verbose", () => {
+    it("--verbose sets verbose to true", () => {
+      const args = parseArgs(["--verbose"]);
+      expect(args.verbose).toBe(true);
+    });
+
+    it("-v sets verbose to true", () => {
+      const args = parseArgs(["-v"]);
+      expect(args.verbose).toBe(true);
+    });
+  });
+
+  describe("--config", () => {
+    it("parses --config path", () => {
+      const args = parseArgs(["--config", "/custom/config.yaml"]);
+      expect(args.configPath).toBe("/custom/config.yaml");
+    });
+
+    it("throws if --config has no value", () => {
+      expect(() => parseArgs(["--config"])).toThrow("--config requires a path");
+    });
+  });
+
+  describe("--data-dir", () => {
+    it("parses --data-dir path", () => {
+      const args = parseArgs(["--data-dir", "/data/exports"]);
+      expect(args.dataDir).toBe("/data/exports");
+    });
+
+    it("throws if --data-dir has no value", () => {
+      expect(() => parseArgs(["--data-dir"])).toThrow("--data-dir requires a path");
+    });
+  });
+
+  describe("file arguments", () => {
+    it("parses --members filename", () => {
+      const args = parseArgs(["--members", "members.csv"]);
+      expect(args.membersFile).toBe("members.csv");
+    });
+
+    it("parses --events filename", () => {
+      const args = parseArgs(["--events", "events.csv"]);
+      expect(args.eventsFile).toBe("events.csv");
+    });
+
+    it("parses --registrations filename", () => {
+      const args = parseArgs(["--registrations", "registrations.csv"]);
+      expect(args.registrationsFile).toBe("registrations.csv");
+    });
+
+    it("throws if file arguments have no value", () => {
+      expect(() => parseArgs(["--members"])).toThrow("--members requires a filename");
+      expect(() => parseArgs(["--events"])).toThrow("--events requires a filename");
+      expect(() => parseArgs(["--registrations"])).toThrow(
+        "--registrations requires a filename"
+      );
+    });
+  });
+
+  describe("--yes", () => {
+    it("--yes sets yes to true", () => {
+      const args = parseArgs(["--yes"]);
+      expect(args.yes).toBe(true);
+    });
+
+    it("-y sets yes to true", () => {
+      const args = parseArgs(["-y"]);
+      expect(args.yes).toBe(true);
+    });
+  });
+
+  describe("--help", () => {
+    it("--help sets help to true", () => {
+      const args = parseArgs(["--help"]);
+      expect(args.help).toBe(true);
+    });
+
+    it("-h sets help to true", () => {
+      const args = parseArgs(["-h"]);
+      expect(args.help).toBe(true);
+    });
+  });
+
+  describe("unknown options", () => {
+    it("throws for unknown options", () => {
+      expect(() => parseArgs(["--unknown"])).toThrow("Unknown option: --unknown");
+    });
+
+    it("ignores positional arguments that don't start with dash", () => {
+      // This is acceptable behavior - positional args are ignored
+      const args = parseArgs(["somefile.csv"]);
+      expect(args.sourceOrg).toBe("wild-apricot");
+    });
+  });
+
+  describe("combined arguments", () => {
+    it("parses multiple arguments correctly", () => {
+      const args = parseArgs([
+        "--source-org",
+        "wa",
+        "--target-org",
+        "clubos",
+        "--live",
+        "--verbose",
+        "--yes",
+        "--data-dir",
+        "/tmp/data",
+        "--members",
+        "m.csv",
+        "--events",
+        "e.csv",
+      ]);
+
+      expect(args.sourceOrg).toBe("wa");
+      expect(args.targetOrg).toBe("clubos");
+      expect(args.dryRun).toBe(false);
+      expect(args.verbose).toBe(true);
+      expect(args.yes).toBe(true);
+      expect(args.dataDir).toBe("/tmp/data");
+      expect(args.membersFile).toBe("m.csv");
+      expect(args.eventsFile).toBe("e.csv");
+    });
+  });
+});
+
+// =============================================================================
+// validateArgs Tests
+// =============================================================================
+
+describe("validateArgs", () => {
+  const defaultArgs: CLIArgs = {
+    sourceOrg: "wild-apricot",
+    targetOrg: "clubos",
+    dryRun: true,
+    outputReport: "/tmp/reports",
+    verbose: false,
+    configPath: path.join(__dirname, "../../../scripts/migration/config/migration-config.yaml"),
+    dataDir: path.join(__dirname, "../../../scripts/migration/sample-pack"),
+    membersFile: undefined,
+    eventsFile: undefined,
+    registrationsFile: undefined,
+    yes: false,
+    help: false,
+  };
+
+  describe("source-org validation", () => {
+    it("accepts valid source orgs", () => {
+      const validSources = ["wild-apricot", "wa", "wildapricot"];
+      for (const source of validSources) {
+        const result = validateArgs({ ...defaultArgs, sourceOrg: source });
+        expect(result.errors.filter((e) => e.includes("source-org"))).toHaveLength(0);
+      }
+    });
+
+    it("rejects invalid source org", () => {
+      const result = validateArgs({ ...defaultArgs, sourceOrg: "invalid-source" });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes("Invalid --source-org"))).toBe(true);
+    });
+
+    it("is case-insensitive for source org", () => {
+      const result = validateArgs({ ...defaultArgs, sourceOrg: "WILD-APRICOT" });
+      expect(result.errors.filter((e) => e.includes("source-org"))).toHaveLength(0);
+    });
+  });
+
+  describe("target-org validation", () => {
+    it("accepts valid target org", () => {
+      const result = validateArgs({ ...defaultArgs, targetOrg: "clubos" });
+      expect(result.errors.filter((e) => e.includes("target-org"))).toHaveLength(0);
+    });
+
+    it("rejects invalid target org", () => {
+      const result = validateArgs({ ...defaultArgs, targetOrg: "other-system" });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes("Invalid --target-org"))).toBe(true);
+    });
+  });
+
+  describe("config file validation", () => {
+    it("returns error if config file does not exist", () => {
+      const result = validateArgs({ ...defaultArgs, configPath: "/nonexistent/config.yaml" });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes("Config file not found"))).toBe(true);
+    });
+
+    it("accepts existing config file", () => {
+      // Uses the default config path which should exist
+      const result = validateArgs(defaultArgs);
+      expect(result.errors.filter((e) => e.includes("Config file not found"))).toHaveLength(
+        0
+      );
+    });
+  });
+
+  describe("data directory validation", () => {
+    it("returns error if data directory does not exist", () => {
+      const result = validateArgs({ ...defaultArgs, dataDir: "/nonexistent/data" });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes("Data directory not found"))).toBe(true);
+    });
+
+    it("accepts existing data directory", () => {
+      const result = validateArgs(defaultArgs);
+      expect(result.errors.filter((e) => e.includes("Data directory not found"))).toHaveLength(
+        0
+      );
+    });
+  });
+
+  describe("CSV file validation", () => {
+    it("returns error if specified members file does not exist", () => {
+      const result = validateArgs({
+        ...defaultArgs,
+        membersFile: "nonexistent.csv",
+      });
+      expect(result.errors.some((e) => e.includes("Members file not found"))).toBe(true);
+    });
+
+    it("returns error if specified events file does not exist", () => {
+      const result = validateArgs({
+        ...defaultArgs,
+        eventsFile: "nonexistent.csv",
+      });
+      expect(result.errors.some((e) => e.includes("Events file not found"))).toBe(true);
+    });
+
+    it("returns error if specified registrations file does not exist", () => {
+      const result = validateArgs({
+        ...defaultArgs,
+        registrationsFile: "nonexistent.csv",
+      });
+      expect(result.errors.some((e) => e.includes("Registrations file not found"))).toBe(
+        true
+      );
+    });
+  });
+
+  describe("live run warnings", () => {
+    it("warns about live run without --yes", () => {
+      const result = validateArgs({ ...defaultArgs, dryRun: false, yes: false });
+      expect(result.warnings.some((w) => w.includes("Live run requires"))).toBe(true);
+    });
+
+    it("no warning for live run with --yes", () => {
+      const result = validateArgs({ ...defaultArgs, dryRun: false, yes: true });
+      expect(result.warnings.filter((w) => w.includes("Live run requires"))).toHaveLength(0);
+    });
+
+    it("no warning for dry run", () => {
+      const result = validateArgs({ ...defaultArgs, dryRun: true, yes: false });
+      expect(result.warnings.filter((w) => w.includes("Live run requires"))).toHaveLength(0);
+    });
+  });
+
+  describe("validation result structure", () => {
+    it("returns valid=true when no errors", () => {
+      const result = validateArgs(defaultArgs);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("returns valid=false when errors exist", () => {
+      const result = validateArgs({ ...defaultArgs, sourceOrg: "invalid" });
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it("warnings do not affect validity", () => {
+      const result = validateArgs({ ...defaultArgs, dryRun: false, yes: false });
+      // May have warnings but validation errors determine validity
+      expect(result.warnings.length).toBeGreaterThan(0);
+      expect(typeof result.valid).toBe("boolean");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `scripts/migration/migrate.ts` CLI entry point for WA migration engine
- Implement argument parsing with validation and clear error messages  
- Add execution plan display showing what will be processed before running
- Include help output (`--help`) documenting all options
- Default to dry-run mode (safe by default, requires `--live` for actual writes)

## CLI Options

```
--source-org <name>     Source organization (default: "wild-apricot")
--target-org <name>     Target organization (default: "clubos")
--dry-run               Run without making changes (default)
--live                  Run with actual database writes
--verbose, -v           Enable verbose logging
--config <path>         Path to migration config YAML
--data-dir <path>       Directory containing CSV export files
--members <file>        Members CSV filename
--events <file>         Events CSV filename
--registrations <file>  Registrations CSV filename
--yes, -y               Skip confirmation prompt for live runs
--help, -h              Show help message
```

## Usage Examples

```bash
# Dry run with sample data
npm run migrate:dry-run

# Live run with confirmation
npm run migrate:live -- --yes --data-dir ./wa-export
```

## Test Plan

- [x] 48 unit tests for argument parsing and validation
- [x] Tests cover default values, all flags, validation errors, warnings
- [x] `npm run test:unit` passes (1501 tests)

## Notes

**No schema changes** - This PR only adds CLI tooling, no database migrations.

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)