### PR TITLE
ci: invariant-to-test traceability map

### DIFF
--- a/docs/CI/INVARIANT_TEST_MAP.md
+++ b/docs/CI/INVARIANT_TEST_MAP.md
@@ -1,0 +1,233 @@
+# Invariant-to-Test Traceability Map
+
+This document maps security and behavioral invariants to their verification tests.
+
+**Related Issues:** #258 (Traceability), #201 (Auth/RBAC Wave)
+
+---
+
+## Quick Reference
+
+| Category | Invariants | Contract Tests | CI Gate |
+|----------|------------|----------------|---------|
+| RBAC | Default deny, capability-based | `tests/contracts/rbac.contract.spec.ts` | `npm run green` |
+| Impersonation | Blocked capabilities | `tests/contracts/impersonation.contract.spec.ts` | `npm run green` |
+| Lifecycle | State machine boundaries | `tests/contracts/lifecycle.contract.spec.ts` | `npm run green` |
+| Policy | Typed keys, defaults | `tests/contracts/policy.contract.spec.ts` | `npm run green` |
+| Tenant Isolation | Member-scoped access | `tests/unit/tenant-isolation.spec.ts` | `npm run green` |
+
+---
+
+## 1. RBAC Invariants
+
+### INV-RBAC-001: Default Deny
+
+**Charter:** P2 (Default deny, least privilege)
+
+| Invariant | Test File | Test | Command |
+|-----------|-----------|------|---------|
+| Unauthenticated requests return 401 | `tests/contracts/rbac.contract.spec.ts` | "unauthenticated requests return 401" | `npm run test-contracts` |
+| Invalid tokens return 401 | `tests/contracts/rbac.contract.spec.ts` | "invalid token returns 401" | `npm run test-contracts` |
+| Member cannot access admin endpoints | `tests/contracts/rbac.contract.spec.ts` | "member token cannot access admin endpoints" | `npm run test-contracts` |
+
+### INV-RBAC-002: Capability-Based Access
+
+**Charter:** P1 (Authorization provable), P2 (Object scope)
+
+| Invariant | Test File | Test | Command |
+|-----------|-----------|------|---------|
+| Admin has admin:full capability | `tests/unit/tenant-isolation.spec.ts` | "admin:full capability is the only bypass" | `npm run test:unit` |
+| Capabilities are role-scoped | `tests/contracts/rbac.contract.spec.ts` | "capability system invariants are documented" | `npm run test-contracts` |
+| Admin can access admin endpoints | `tests/contracts/rbac.contract.spec.ts` | "admin token can access admin endpoints" | `npm run test-contracts` |
+
+### INV-RBAC-003: Admin Route Auth Guards
+
+**Charter:** P2 (Default deny), P9 (Fail closed)
+
+| Invariant | Test File | CI Script | Command |
+|-----------|-----------|-----------|---------|
+| All admin routes have auth | `scripts/ci/check-auth-guardrails.ts` | Check 2: Admin Auth Guards | `npm run test:guardrails` |
+
+---
+
+## 2. Impersonation Invariants
+
+### INV-IMP-001: Impersonation Requires Admin
+
+**Charter:** P1 (Identity provable), P2 (Least privilege)
+
+| Invariant | Test File | Test | Command |
+|-----------|-----------|------|---------|
+| Unauthenticated start returns 401 | `tests/contracts/impersonation.contract.spec.ts` | "unauthenticated request to start returns 401" | `npm run test-contracts` |
+| Member cannot start impersonation | `tests/contracts/impersonation.contract.spec.ts` | "member token cannot start impersonation" | `npm run test-contracts` |
+| Admin can start impersonation | `tests/contracts/impersonation.contract.spec.ts` | "admin can attempt impersonation start" | `npm run test-contracts` |
+
+### INV-IMP-002: Blocked Capabilities During Impersonation
+
+**Charter:** P2 (Least privilege), P9 (Fail closed)
+
+| Capability | Reason | Test File | Command |
+|------------|--------|-----------|---------|
+| `finance:manage` | No money movement | `tests/contracts/impersonation.contract.spec.ts` | `npm run test-contracts` |
+| `comms:send` | No email sending | `tests/contracts/impersonation.contract.spec.ts` | `npm run test-contracts` |
+| `users:manage` | No role changes | `tests/contracts/impersonation.contract.spec.ts` | `npm run test-contracts` |
+| `events:delete` | No destructive actions | `tests/contracts/impersonation.contract.spec.ts` | `npm run test-contracts` |
+| `admin:full` | Downgraded to read-only | `tests/contracts/impersonation.contract.spec.ts` | `npm run test-contracts` |
+
+**CI Enforcement:** `scripts/ci/check-auth-guardrails.ts` (Check 1: Impersonation Safety)
+
+### INV-IMP-003: Blocked Capabilities Sync
+
+**Charter:** P4 (No hidden rules)
+
+| Invariant | CI Script | Command |
+|-----------|-----------|---------|
+| Script matches `src/lib/auth.ts` | `scripts/ci/check-auth-guardrails.ts` (Check 3) | `npm run test:guardrails` |
+
+### INV-IMP-004: No Nesting
+
+**Charter:** P9 (Fail closed)
+
+| Invariant | Test File | Test | Command |
+|-----------|-----------|------|---------|
+| Cannot impersonate while impersonating | `tests/contracts/impersonation.contract.spec.ts` | "nesting prevention is a documented invariant" | `npm run test-contracts` |
+
+### INV-IMP-005: Audit Trail
+
+**Charter:** P1 (Provable), P7 (Observability)
+
+| Action | Audit Event | Test File | Command |
+|--------|-------------|-----------|---------|
+| Start impersonation | `IMPERSONATION_START` | `tests/contracts/impersonation.contract.spec.ts` | `npm run test-contracts` |
+| End impersonation | `IMPERSONATION_END` | `tests/contracts/impersonation.contract.spec.ts` | `npm run test-contracts` |
+| Blocked action | `IMPERSONATION_BLOCKED_ACTION` | `tests/contracts/impersonation.contract.spec.ts` | `npm run test-contracts` |
+
+---
+
+## 3. Membership Lifecycle Invariants
+
+### INV-LIFE-001: State Machine Transitions
+
+**Charter:** P3 (State machines over booleans)
+
+| Invariant | Test File | Test | Command |
+|-----------|-----------|------|---------|
+| Valid transitions are defined | `tests/contracts/lifecycle.contract.spec.ts` | "transition table has all expected entries" | `npm run test:unit` |
+| Lapsed has no outgoing transitions | `tests/contracts/lifecycle.contract.spec.ts` | "lapsed has no outgoing transitions" | `npm run test:unit` |
+| Cannot skip newbie period | `tests/contracts/lifecycle.contract.spec.ts` | "disallows pending_new -> active_member" | `npm run test:unit` |
+| Cannot go backwards | `tests/contracts/lifecycle.contract.spec.ts` | "disallows active_member -> active_newbie" | `npm run test:unit` |
+
+### INV-LIFE-002: Boundary Conditions
+
+**Charter:** P4 (No hidden rules)
+
+| Boundary | Days | Test File | Command |
+|----------|------|-----------|---------|
+| Newbie period ends | 90 | `tests/contracts/lifecycle.contract.spec.ts` | `npm run test:unit` |
+| Extended offer begins | 730 | `tests/contracts/lifecycle.contract.spec.ts` | `npm run test:unit` |
+
+### INV-LIFE-003: State Labels
+
+**Charter:** P6 (Human-first language)
+
+| Invariant | Test File | Test | Command |
+|-----------|-----------|------|---------|
+| All states have human labels | `tests/contracts/lifecycle.contract.spec.ts` | "state {x} has label {y}" | `npm run test:unit` |
+| Narratives are non-empty | `tests/contracts/lifecycle.contract.spec.ts` | "narratives are non-empty for all states" | `npm run test:unit` |
+
+---
+
+## 4. Policy Configuration Invariants
+
+### INV-POL-001: Typed Policy Keys
+
+**Charter:** P4 (No hidden rules), P8 (Stable contracts)
+
+| Invariant | Test File | Test | Command |
+|-----------|-----------|------|---------|
+| Unknown keys throw | `tests/contracts/policy.contract.spec.ts` | "throws InvalidPolicyKeyError for unknown key" | `npm run test:unit` |
+| Valid keys are recognized | `tests/contracts/policy.contract.spec.ts` | "returns true for valid keys" | `npm run test:unit` |
+
+### INV-POL-002: SBNC Defaults
+
+**Charter:** P4 (No hidden rules)
+
+| Policy | Default | Test File | Command |
+|--------|---------|-----------|---------|
+| `membership.newbieDays` | 90 | `tests/contracts/policy.contract.spec.ts` | `npm run test:unit` |
+| `membership.extendedDays` | 730 | `tests/contracts/policy.contract.spec.ts` | `npm run test:unit` |
+| `scheduling.timezone` | America/Los_Angeles | `tests/contracts/policy.contract.spec.ts` | `npm run test:unit` |
+| `governance.quorumPercentage` | 50 | `tests/contracts/policy.contract.spec.ts` | `npm run test:unit` |
+
+### INV-POL-003: orgId Required
+
+**Charter:** P1 (Identity provable)
+
+| Invariant | Test File | Test | Command |
+|-----------|-----------|------|---------|
+| getPolicy requires orgId | `tests/contracts/policy.contract.spec.ts` | "throws MissingOrgIdError when orgId is undefined" | `npm run test:unit` |
+| Empty orgId throws | `tests/contracts/policy.contract.spec.ts` | "throws MissingOrgIdError when orgId is empty string" | `npm run test:unit` |
+
+---
+
+## 5. Tenant Isolation Invariants
+
+### INV-TENANT-001: Self-Access Allowed
+
+**Charter:** P2 (Object scope)
+
+| Invariant | Test File | Test | Command |
+|-----------|-----------|------|---------|
+| Member can access own data | `tests/unit/tenant-isolation.spec.ts` | "{role} can access own data" | `npm run test:unit` |
+
+### INV-TENANT-002: Cross-Access Denied
+
+**Charter:** P2 (Default deny), P9 (Fail closed)
+
+| Invariant | Test File | Test | Command |
+|-----------|-----------|------|---------|
+| Non-admin cannot access other members | `tests/unit/tenant-isolation.spec.ts` | "{role} CANNOT access other member data" | `npm run test:unit` |
+| Only admin has admin:full | `tests/unit/tenant-isolation.spec.ts` | "admin:full capability is the only bypass" | `npm run test:unit` |
+
+### INV-TENANT-003: Admin Bypass
+
+**Charter:** P1 (Provable), P2 (Object scope)
+
+| Invariant | Test File | Test | Command |
+|-----------|-----------|------|---------|
+| Admin can access any member | `tests/unit/tenant-isolation.spec.ts` | "admin can access any member data" | `npm run test:unit` |
+
+---
+
+## CI Commands Summary
+
+| Command | What It Checks | Duration |
+|---------|----------------|----------|
+| `npm run test:unit` | Unit tests including contracts | ~5s |
+| `npm run test-contracts` | Playwright contract tests | ~10s |
+| `npm run test:guardrails` | Auth guardrail checks | ~5s |
+| `npm run green` | All PR gate checks | ~30-60s |
+
+---
+
+## Adding New Invariants
+
+When adding a new invariant:
+
+1. **Identify the charter principle(s)** it supports (P1-P10, N1-N8)
+2. **Write a contract test** in `tests/contracts/` or `tests/unit/`
+3. **Add to this map** with:
+   - Invariant ID (e.g., `INV-RBAC-004`)
+   - Charter reference
+   - Test file and test name
+   - Run command
+4. **If static analysis is needed**, add to `scripts/ci/check-auth-guardrails.ts`
+5. **Update `npm run green`** if a new CI step is required
+
+---
+
+## See Also
+
+- `docs/CI/INVARIANTS.md` - Security invariants and guardrails
+- `docs/ARCHITECTURAL_CHARTER.md` - Non-negotiable principles
+- `scripts/ci/check-auth-guardrails.ts` - CI guardrail implementation

--- a/scripts/ci/invariant-map.json
+++ b/scripts/ci/invariant-map.json
@@ -1,0 +1,274 @@
+{
+  "version": "1.0.0",
+  "description": "Invariant-to-test traceability data",
+  "lastUpdated": "2024-12-24",
+  "relatedIssues": ["#258", "#201"],
+  "categories": {
+    "RBAC": {
+      "description": "Role-Based Access Control",
+      "invariants": [
+        {
+          "id": "INV-RBAC-001",
+          "name": "Default Deny",
+          "charter": ["P2"],
+          "tests": [
+            {
+              "file": "tests/contracts/rbac.contract.spec.ts",
+              "pattern": "unauthenticated requests return 401"
+            },
+            {
+              "file": "tests/contracts/rbac.contract.spec.ts",
+              "pattern": "invalid token returns 401"
+            },
+            {
+              "file": "tests/contracts/rbac.contract.spec.ts",
+              "pattern": "member token cannot access admin endpoints"
+            }
+          ],
+          "command": "npm run test-contracts"
+        },
+        {
+          "id": "INV-RBAC-002",
+          "name": "Capability-Based Access",
+          "charter": ["P1", "P2"],
+          "tests": [
+            {
+              "file": "tests/unit/tenant-isolation.spec.ts",
+              "pattern": "admin:full capability is the only bypass"
+            },
+            {
+              "file": "tests/contracts/rbac.contract.spec.ts",
+              "pattern": "capability system invariants are documented"
+            }
+          ],
+          "command": "npm run test:unit"
+        },
+        {
+          "id": "INV-RBAC-003",
+          "name": "Admin Route Auth Guards",
+          "charter": ["P2", "P9"],
+          "ciScript": "scripts/ci/check-auth-guardrails.ts",
+          "command": "npm run test:guardrails"
+        }
+      ]
+    },
+    "Impersonation": {
+      "description": "Impersonation Safety",
+      "invariants": [
+        {
+          "id": "INV-IMP-001",
+          "name": "Impersonation Requires Admin",
+          "charter": ["P1", "P2"],
+          "tests": [
+            {
+              "file": "tests/contracts/impersonation.contract.spec.ts",
+              "pattern": "unauthenticated request to start returns 401"
+            },
+            {
+              "file": "tests/contracts/impersonation.contract.spec.ts",
+              "pattern": "member token cannot start impersonation"
+            }
+          ],
+          "command": "npm run test-contracts"
+        },
+        {
+          "id": "INV-IMP-002",
+          "name": "Blocked Capabilities During Impersonation",
+          "charter": ["P2", "P9"],
+          "blockedCapabilities": [
+            "finance:manage",
+            "comms:send",
+            "users:manage",
+            "events:delete",
+            "admin:full"
+          ],
+          "tests": [
+            {
+              "file": "tests/contracts/impersonation.contract.spec.ts",
+              "pattern": "blocked capabilities include critical dangerous operations"
+            }
+          ],
+          "ciScript": "scripts/ci/check-auth-guardrails.ts",
+          "command": "npm run test:guardrails"
+        },
+        {
+          "id": "INV-IMP-003",
+          "name": "Blocked Capabilities Sync",
+          "charter": ["P4"],
+          "ciScript": "scripts/ci/check-auth-guardrails.ts",
+          "command": "npm run test:guardrails"
+        },
+        {
+          "id": "INV-IMP-004",
+          "name": "No Nesting",
+          "charter": ["P9"],
+          "tests": [
+            {
+              "file": "tests/contracts/impersonation.contract.spec.ts",
+              "pattern": "nesting prevention is a documented invariant"
+            }
+          ],
+          "command": "npm run test-contracts"
+        },
+        {
+          "id": "INV-IMP-005",
+          "name": "Audit Trail",
+          "charter": ["P1", "P7"],
+          "auditEvents": [
+            "IMPERSONATION_START",
+            "IMPERSONATION_END",
+            "IMPERSONATION_BLOCKED_ACTION"
+          ],
+          "tests": [
+            {
+              "file": "tests/contracts/impersonation.contract.spec.ts",
+              "pattern": "audit action names are standardized"
+            }
+          ],
+          "command": "npm run test-contracts"
+        }
+      ]
+    },
+    "Lifecycle": {
+      "description": "Membership Lifecycle State Machine",
+      "invariants": [
+        {
+          "id": "INV-LIFE-001",
+          "name": "State Machine Transitions",
+          "charter": ["P3"],
+          "tests": [
+            {
+              "file": "tests/contracts/lifecycle.contract.spec.ts",
+              "pattern": "transition table has all expected entries"
+            },
+            {
+              "file": "tests/contracts/lifecycle.contract.spec.ts",
+              "pattern": "lapsed has no outgoing transitions"
+            }
+          ],
+          "command": "npm run test:unit"
+        },
+        {
+          "id": "INV-LIFE-002",
+          "name": "Boundary Conditions",
+          "charter": ["P4"],
+          "boundaries": {
+            "newbiePeriodDays": 90,
+            "extendedOfferDays": 730
+          },
+          "tests": [
+            {
+              "file": "tests/contracts/lifecycle.contract.spec.ts",
+              "pattern": "90-day newbie boundary"
+            },
+            {
+              "file": "tests/contracts/lifecycle.contract.spec.ts",
+              "pattern": "730-day two-year boundary"
+            }
+          ],
+          "command": "npm run test:unit"
+        },
+        {
+          "id": "INV-LIFE-003",
+          "name": "State Labels",
+          "charter": ["P6"],
+          "tests": [
+            {
+              "file": "tests/contracts/lifecycle.contract.spec.ts",
+              "pattern": "state .* has label"
+            }
+          ],
+          "command": "npm run test:unit"
+        }
+      ]
+    },
+    "Policy": {
+      "description": "Policy Configuration Layer",
+      "invariants": [
+        {
+          "id": "INV-POL-001",
+          "name": "Typed Policy Keys",
+          "charter": ["P4", "P8"],
+          "tests": [
+            {
+              "file": "tests/contracts/policy.contract.spec.ts",
+              "pattern": "throws InvalidPolicyKeyError"
+            }
+          ],
+          "command": "npm run test:unit"
+        },
+        {
+          "id": "INV-POL-002",
+          "name": "SBNC Defaults",
+          "charter": ["P4"],
+          "defaults": {
+            "membership.newbieDays": 90,
+            "membership.extendedDays": 730,
+            "scheduling.timezone": "America/Los_Angeles",
+            "governance.quorumPercentage": 50
+          },
+          "tests": [
+            {
+              "file": "tests/contracts/policy.contract.spec.ts",
+              "pattern": "defaults to"
+            }
+          ],
+          "command": "npm run test:unit"
+        },
+        {
+          "id": "INV-POL-003",
+          "name": "orgId Required",
+          "charter": ["P1"],
+          "tests": [
+            {
+              "file": "tests/contracts/policy.contract.spec.ts",
+              "pattern": "throws MissingOrgIdError"
+            }
+          ],
+          "command": "npm run test:unit"
+        }
+      ]
+    },
+    "TenantIsolation": {
+      "description": "Member-Scoped Data Isolation",
+      "invariants": [
+        {
+          "id": "INV-TENANT-001",
+          "name": "Self-Access Allowed",
+          "charter": ["P2"],
+          "tests": [
+            {
+              "file": "tests/unit/tenant-isolation.spec.ts",
+              "pattern": "can access own data"
+            }
+          ],
+          "command": "npm run test:unit"
+        },
+        {
+          "id": "INV-TENANT-002",
+          "name": "Cross-Access Denied",
+          "charter": ["P2", "P9"],
+          "tests": [
+            {
+              "file": "tests/unit/tenant-isolation.spec.ts",
+              "pattern": "CANNOT access other member data"
+            }
+          ],
+          "command": "npm run test:unit"
+        },
+        {
+          "id": "INV-TENANT-003",
+          "name": "Admin Bypass",
+          "charter": ["P1", "P2"],
+          "tests": [
+            {
+              "file": "tests/unit/tenant-isolation.spec.ts",
+              "pattern": "admin can access any member data"
+            }
+          ],
+          "command": "npm run test:unit"
+        }
+      ]
+    }
+  }
+}

--- a/scripts/ci/print-invariant-map.ts
+++ b/scripts/ci/print-invariant-map.ts
@@ -1,0 +1,185 @@
+#!/usr/bin/env npx tsx
+/**
+ * Print Invariant-to-Test Traceability Map
+ *
+ * Usage:
+ *   npx tsx scripts/ci/print-invariant-map.ts          # Print all
+ *   npx tsx scripts/ci/print-invariant-map.ts --json   # Output as JSON
+ *   npx tsx scripts/ci/print-invariant-map.ts RBAC     # Filter by category
+ *   npx tsx scripts/ci/print-invariant-map.ts INV-IMP  # Filter by invariant prefix
+ *
+ * Related: Issue #258 (Invariant-to-test traceability)
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+// ANSI colors
+const CYAN = "\x1b[36m";
+const GREEN = "\x1b[32m";
+const YELLOW = "\x1b[33m";
+const NC = "\x1b[0m";
+
+interface Test {
+  file: string;
+  pattern: string;
+}
+
+interface Invariant {
+  id: string;
+  name: string;
+  charter: string[];
+  tests?: Test[];
+  ciScript?: string;
+  command: string;
+  blockedCapabilities?: string[];
+  auditEvents?: string[];
+  boundaries?: Record<string, number>;
+  defaults?: Record<string, number | string>;
+}
+
+interface Category {
+  description: string;
+  invariants: Invariant[];
+}
+
+interface InvariantMap {
+  version: string;
+  description: string;
+  lastUpdated: string;
+  relatedIssues: string[];
+  categories: Record<string, Category>;
+}
+
+function loadMap(): InvariantMap {
+  const mapPath = path.join(__dirname, "invariant-map.json");
+  const content = fs.readFileSync(mapPath, "utf-8");
+  return JSON.parse(content) as InvariantMap;
+}
+
+function printTable(rows: string[][], headers: string[]): void {
+  // Calculate column widths
+  const widths = headers.map((h, i) =>
+    Math.max(h.length, ...rows.map((r) => (r[i] || "").length))
+  );
+
+  // Print header
+  const headerLine = headers.map((h, i) => h.padEnd(widths[i])).join(" | ");
+  console.log(headerLine);
+  console.log(widths.map((w) => "-".repeat(w)).join("-+-"));
+
+  // Print rows
+  for (const row of rows) {
+    console.log(row.map((c, i) => (c || "").padEnd(widths[i])).join(" | "));
+  }
+}
+
+function printInvariant(inv: Invariant): void {
+  console.log(`\n${CYAN}${inv.id}${NC}: ${inv.name}`);
+  console.log(`  Charter: ${inv.charter.map((c) => `P${c.replace("P", "")}`).join(", ")}`);
+  console.log(`  Command: ${GREEN}${inv.command}${NC}`);
+
+  if (inv.tests && inv.tests.length > 0) {
+    console.log("  Tests:");
+    for (const test of inv.tests) {
+      console.log(`    - ${test.file}`);
+      console.log(`      ${YELLOW}${test.pattern}${NC}`);
+    }
+  }
+
+  if (inv.ciScript) {
+    console.log(`  CI Script: ${inv.ciScript}`);
+  }
+
+  if (inv.blockedCapabilities) {
+    console.log(`  Blocked Capabilities: ${inv.blockedCapabilities.join(", ")}`);
+  }
+
+  if (inv.auditEvents) {
+    console.log(`  Audit Events: ${inv.auditEvents.join(", ")}`);
+  }
+
+  if (inv.boundaries) {
+    console.log("  Boundaries:");
+    for (const [key, val] of Object.entries(inv.boundaries)) {
+      console.log(`    - ${key}: ${val} days`);
+    }
+  }
+
+  if (inv.defaults) {
+    console.log("  Defaults:");
+    for (const [key, val] of Object.entries(inv.defaults)) {
+      console.log(`    - ${key}: ${val}`);
+    }
+  }
+}
+
+function main(): void {
+  const args = process.argv.slice(2);
+  const jsonOutput = args.includes("--json");
+  const filter = args.find((a) => !a.startsWith("--"));
+
+  const map = loadMap();
+
+  if (jsonOutput) {
+    console.log(JSON.stringify(map, null, 2));
+    return;
+  }
+
+  console.log("=".repeat(60));
+  console.log("Invariant-to-Test Traceability Map");
+  console.log(`Version: ${map.version} | Updated: ${map.lastUpdated}`);
+  console.log(`Issues: ${map.relatedIssues.join(", ")}`);
+  console.log("=".repeat(60));
+
+  // Summary table
+  const summaryRows: string[][] = [];
+  let totalInvariants = 0;
+  let totalTests = 0;
+
+  for (const [catName, cat] of Object.entries(map.categories)) {
+    const catTests = cat.invariants.reduce(
+      (sum, inv) => sum + (inv.tests?.length || 0),
+      0
+    );
+    summaryRows.push([catName, cat.invariants.length.toString(), catTests.toString()]);
+    totalInvariants += cat.invariants.length;
+    totalTests += catTests;
+  }
+
+  console.log("\n## Summary\n");
+  printTable(summaryRows, ["Category", "Invariants", "Tests"]);
+  console.log(`\nTotal: ${totalInvariants} invariants, ${totalTests} tests`);
+
+  // Detailed view (filtered if requested)
+  for (const [catName, cat] of Object.entries(map.categories)) {
+    // Filter by category name
+    if (filter && !catName.toLowerCase().includes(filter.toLowerCase())) {
+      // Check if any invariant matches the filter
+      const hasMatch = cat.invariants.some((inv) =>
+        inv.id.toLowerCase().includes(filter.toLowerCase())
+      );
+      if (!hasMatch) continue;
+    }
+
+    console.log(`\n${"=".repeat(60)}`);
+    console.log(`${catName}: ${cat.description}`);
+    console.log("=".repeat(60));
+
+    for (const inv of cat.invariants) {
+      // Filter by invariant ID
+      if (filter && !catName.toLowerCase().includes(filter.toLowerCase())) {
+        if (!inv.id.toLowerCase().includes(filter.toLowerCase())) {
+          continue;
+        }
+      }
+      printInvariant(inv);
+    }
+  }
+
+  console.log("\n" + "=".repeat(60));
+  console.log("Run `npm run green` to verify all invariants");
+  console.log("=".repeat(60) + "\n");
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds documentation and tooling to trace security invariants to their verification tests, making it easy to see: invariant -> where it's tested.

## Release Classification

- [x] experimental

## What Changed

### New Files

- `docs/CI/INVARIANT_TEST_MAP.md` - Maps each invariant to test files
- `scripts/ci/invariant-map.json` - Structured data for automation
- `scripts/ci/print-invariant-map.ts` - CLI to query invariants

### Categories Tracked

| Category | Invariants | Tests |
|----------|------------|-------|
| RBAC | 3 | 5 |
| Impersonation | 5 | 5 |
| Lifecycle | 3 | 5 |
| Policy | 3 | 3 |
| Tenant Isolation | 3 | 3 |
| **Total** | **17** | **21** |

### CLI Usage

```bash
npx tsx scripts/ci/print-invariant-map.ts          # Print all
npx tsx scripts/ci/print-invariant-map.ts RBAC     # Filter by category
npx tsx scripts/ci/print-invariant-map.ts INV-IMP  # Filter by invariant
npx tsx scripts/ci/print-invariant-map.ts --json   # JSON output
```

## No Hotspots

This is a docs-only + small script change. Does not touch hotspot files.

Closes #258
Related: #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)