### PR TITLE
docs(importing): clarify migration boundaries and exclusions

### DIFF
--- a/docs/IMPORTING/IMPORTER_RUNBOOK.md
+++ b/docs/IMPORTING/IMPORTER_RUNBOOK.md
@@ -19,6 +19,59 @@ The production runbook covers:
 
 ---
 
+## What Migration Includes — and What It Does Not
+
+### Migration Scope
+
+The Wild Apricot migration preserves your organization's **operational data**:
+
+| Included | Description |
+|----------|-------------|
+| Members | Contact records, membership status, join dates, custom fields |
+| Events | Event details, dates, locations, capacity limits |
+| Registrations | Attendee lists, registration status, cancellations |
+| Membership tiers | Level definitions and member-to-tier assignments |
+| Policies and configuration | Membership rules, eligibility settings, org-specific policies |
+
+### Explicitly Excluded
+
+The following are **intentionally not part of migration**:
+
+| Excluded | Reason |
+|----------|--------|
+| Automatic HTML scraping | WA pages are semi-structured and inconsistent |
+| Website/page cloning | Layout depends on WA's proprietary theme engine |
+| Theme or style migration | Visual presentation is platform-specific |
+| CMS content reconstruction | Automatic extraction would produce unreliable results |
+
+### Why Content Scraping Is Not Included
+
+Wild Apricot websites use a mix of structured widgets, embedded HTML, and theme-specific layouts. Attempting to automatically scrape and reconstruct this content would:
+
+- Produce fragmented, inconsistent output
+- Require constant maintenance as WA's markup changes
+- Create false confidence in content that needs human review anyway
+- Risk importing outdated or incorrect information
+
+This is a deliberate boundary, not a limitation.
+
+### The Intended Alternative
+
+Content migration is best handled through an **assisted, human-reviewed process**:
+
+- **Content inventory**: Identify which pages contain valuable content
+- **Template preparation**: Set up ClubOS page structures before copying
+- **Manual editorial review**: Verify accuracy and relevance during transfer
+- **Optional import tools**: Copy/paste or markdown import for text content
+
+This approach produces higher-quality results and ensures content is reviewed during the transition rather than blindly copied.
+
+> **Operator Expectation**
+>
+> This migration preserves *truth*, not *presentation*. You will receive accurate member data, event history, and registration records. Website appearance and page content require separate, human-guided work.
+
+---
+
 ## 1. Prerequisites
 
 ### 1.1 Environment Variables


### PR DESCRIPTION
## Summary

- Add "What Migration Includes — and What It Does Not" section to runbook
- Define migration scope: members, events, registrations, tiers, policies
- Explicitly exclude: HTML scraping, page cloning, theme migration, CMS
- Explain why content scraping is intentionally excluded (fragile, inconsistent source markup)
- Describe intended alternative: assisted, human-reviewed content migration
- Add operator expectation callout

## Purpose

This establishes clear, board-readable boundaries for migration scope. It explains *why* certain things are excluded without making promises about future features.

## Test plan

- [x] Document renders correctly in GitHub markdown preview
- [x] Tables display properly
- [x] Callout box renders as blockquote
- [x] No code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Release Classification
- **Scope:** Docs-only
- **Risk:** Low
- **Hotspots:** None
- **Test/Verification:** npm run green (merge captain)
- **Split Plan:** Docs changes; splitting may reduce coherence.
